### PR TITLE
docs: record the worktree + PR + automation workflow for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,38 @@ PLAN.md               # the development plan (bilingual planning artifact)
    `pnpm run build` and confirm each returns 0 before committing with a
    Conventional Commit message.
 
+## Worktree + PR workflow
+
+The main working tree is shared: a human or another agent may be editing it at
+any moment. Never commit or run stateful work there. Do feature work in a git
+**worktree under `_dev/`** (git-ignored, so it never pollutes commits):
+
+```sh
+git worktree add -b <topic-branch> _dev/dsh-feishu-<topic> main
+```
+
+A fresh worktree has no `node_modules/`, `lib/`, or `_dev/` state. Before
+running the gates there: `pnpm install`, `pnpm run build`, and prepare the
+integration profile (`DSH_HOME="$(pwd)/_dev/dsh-home" dsh plugin --profile
+feishu-dev add "link:$(pwd)"`). pnpm is not on PATH in this environment — use
+the local install under `_dev/pnpm` and point store/cache at `_dev/` (env
+block in `docs/development.md` → "Local toolchain").
+
+Verify every gate exactly as CI does — including `FEISHU_INT_REQUIRED=1` so
+the integration suite must actually run, never silently skip — then:
+
+```sh
+git fetch origin && git rebase origin/main   # resolve conflicts, re-verify
+git push -u origin <topic-branch>            # open a PR; never push to main
+```
+
+Merge only through a PR with green CI. GitHub API access (PR creation, CI
+monitoring, merge) is automated with the repo-scoped PAT at `_dev/gh-token`
+(chmod 600); the concrete API calls live in `docs/development.md` →
+"Pull requests and CI". Keep the main tree untouched throughout: the
+integration suite writes `_dev/` state (dsh home, memory transport), so run it
+in the worktree, never in the main tree.
+
 ## Lessons learned (field-proven on real devices)
 
 These rules came from real bugs; each has a regression test and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Agent workflow documentation.** `AGENTS.md` gains a "Worktree + PR
+  workflow" section (work in a git worktree under `_dev/`, verify gates with
+  `FEISHU_INT_REQUIRED=1`, rebase onto latest `origin/main`, merge only via a
+  green PR); `docs/development.md` gains "Local toolchain" (the pnpm
+  PATH/store/cache env block for this machine) and "Pull requests and CI"
+  (the GitHub API calls for PR creation, CI monitoring, and merge using the
+  PAT at `_dev/gh-token`).
+
 - **Interactive approvals (Iteration 3).** `ctx.on('approval/request')`
   answers every approval with a Feishu card (tool + reason, ✅ Allow once /
   ❌ Reject) through the new shared `InteractionRegistry`

--- a/docs/development.md
+++ b/docs/development.md
@@ -27,6 +27,25 @@ pnpm install
 > # keep HOME exported for every pnpm invocation in this shell
 > ```
 
+### Local toolchain
+
+On this machine `pnpm` is not on `PATH`. Use the local install and point every
+pnpm invocation — including the profile's spawned `pnpm`, since `dsh plugin`
+forwards to it — at writable store/cache paths under `_dev/`:
+
+```sh
+export PATH="/home/zhangmm23/dsh-feishu/_dev/pnpm/node_modules/.bin:$PATH"
+export npm_config_store_dir="/home/zhangmm23/dsh-feishu/_dev/pnpm-store"
+export npm_config_cache_dir="/home/zhangmm23/dsh-feishu/_dev/pnpm-cache"
+export XDG_CACHE_HOME="/home/zhangmm23/dsh-feishu/_dev/xdg-cache"  # node-gyp builds
+```
+
+`npm_config_*` env vars override project config, so `dsh plugin`'s inner
+`pnpm add` uses the same store without editing the profile. `XDG_CACHE_HOME`
+redirects node-gyp's header cache (the default `~/.cache/node-gyp` sits on a
+read-only mount here) — without it native modules such as node-pty fail to
+build.
+
 ## Gates
 
 ```sh
@@ -139,6 +158,51 @@ timeout 30 dsh --profile feishu-dev       # boot; expect the "[feishu]" log line
    `ctx.get`).
 4. Update the relevant `docs/` page and `CHANGELOG.md`.
 5. Run all gates; commit with a Conventional Commit message.
+
+## Pull requests and CI
+
+Merge only through a PR with green CI — never push to main. GitHub API access
+uses the repo-scoped fine-grained PAT at `_dev/gh-token` (chmod 600, owned by
+the developer, never committed). Read it into a variable per call and never
+echo it:
+
+```sh
+TOKEN=$(cat _dev/gh-token)
+```
+
+Open a PR (head = your pushed branch, base = `main`):
+
+```sh
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  -H 'Accept: application/vnd.github+json' -H 'Content-Type: application/json' \
+  https://api.github.com/repos/PGZXB/dsh-feishu/pulls \
+  --data '{"title":"...","head":"<branch>","base":"main","body":"..."}'
+```
+
+Watch CI until it concludes — the workflow runs the full gate matrix,
+including the real-composition integration suite:
+
+```sh
+SHA=$(git rev-parse HEAD)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  -H 'Accept: application/vnd.github+json' \
+  "https://api.github.com/repos/PGZXB/dsh-feishu/actions/runs?head_sha=$SHA"
+```
+
+Merge once the PR's `mergeable_state` is `clean` (checks green):
+
+```sh
+curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
+  -H 'Accept: application/vnd.github+json' -H 'Content-Type: application/json' \
+  https://api.github.com/repos/PGZXB/dsh-feishu/pulls/<number>/merge \
+  --data '{"commit_title":"...","merge_method":"merge"}'
+```
+
+Before opening the PR, rebase onto the latest `origin/main` and re-run the
+gates: the main tree moves under concurrent work, and conflicts are cheapest
+to fix before the PR exists. If CI is red, fix in the worktree and re-push —
+GitHub re-runs checks on the new head. See AGENTS.md → "Worktree + PR
+workflow" for the end-to-end practice.
 
 ## Publishing (planned)
 


### PR DESCRIPTION
## What

Document the agent workflow that was proven in the CI-enablement change
(#1): work in a git worktree under `_dev/`, verify all gates locally
(integration suite with `FEISHU_INT_REQUIRED=1`), rebase onto the latest
`origin/main`, and merge only through a green PR.

## Changes

- **`AGENTS.md`** — new "Worktree + PR workflow" section: why worktrees under
  `_dev/` (shared main tree, git-ignored), how to set one up, and the
  commit/push/PR/merge loop.
- **`docs/development.md`** —
  - "Local toolchain": the pnpm PATH/store/cache env block for this machine
    (pnpm lives under `_dev/pnpm`; `npm_config_*` env vars propagate to the
    profile's spawned pnpm; `XDG_CACHE_HOME` redirects node-gyp so native
    builds work).
  - "Pull requests and CI": the GitHub API calls for PR creation, CI
    monitoring, and merge using the repo-scoped PAT at `_dev/gh-token`.
- **`CHANGELOG.md`** — entry under Added.

## Verification

Docs-only change; all four gates pass locally (299/299 tests, integration
suite runs).
