### PR TITLE
docs: keep main linear — use rebase merges in the PR snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The PR-merge snippet in `docs/development.md` now uses
+  `merge_method: "rebase"` to keep `main` linear — a `"merge"` merge commit
+  adds a second commit per PR even when the branch is fast-forwardable.
 - **CI runs the real-composition integration suite.** The workflow builds
   the checkout before testing, prepares the `feishu-dev` profile with
   `dsh plugin ... add link:$GITHUB_WORKSPACE`, and runs tests with

--- a/docs/development.md
+++ b/docs/development.md
@@ -189,13 +189,15 @@ curl -s -H "Authorization: Bearer $TOKEN" \
   "https://api.github.com/repos/PGZXB/dsh-feishu/actions/runs?head_sha=$SHA"
 ```
 
-Merge once the PR's `mergeable_state` is `clean` (checks green):
+Merge once the PR's `mergeable_state` is `clean` (checks green). Use
+`merge_method: "rebase"` to keep `main` linear — "merge" always adds a merge
+commit even when a fast-forward is possible, leaving two commits per PR:
 
 ```sh
 curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
   -H 'Accept: application/vnd.github+json' -H 'Content-Type: application/json' \
   https://api.github.com/repos/PGZXB/dsh-feishu/pulls/<number>/merge \
-  --data '{"commit_title":"...","merge_method":"merge"}'
+  --data '{"commit_title":"...","merge_method":"rebase"}'
 ```
 
 Before opening the PR, rebase onto the latest `origin/main` and re-run the


### PR DESCRIPTION
The PR-merge snippet used `merge_method: "merge"`, which makes GitHub add a merge commit even when the PR head is fast-forwardable — leaving two commits per PR on main. Switch the snippet to `rebase` (linear history) and note the reason.