### PR TITLE
feat: Feishu quick setup — one-QR Open Platform automation (botmux-style)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,13 @@ docs, and lands on `main`.
 - **Write docs promptly after a feature.** Completing a feature updates the
   relevant `docs/` page(s) and the CHANGELOG in the same change. No feature
   lands without its documentation.
+- **Feishu permissions manifest, kept in sync in the same change.** Any
+  feature that needs a new Feishu scope, event, or card callback updates
+  `src/setup/feishu-manifest.json` — the single source of truth for the
+  quick-setup automation (`pnpm run setup:feishu`), its manual fallback, and
+  `docs/feishu-setup.md` — IN THE SAME change. The setup tool grants exactly
+  what that file lists; an unlisted scope is a bot that silently cannot do
+  the feature. Example: `/export` (file messages) added `im:resource`.
 - **Registrations are effects.** Every contribution goes through `ctx.on()` /
   `ctx.effect()`; a registry's `register()` returns a disposer, and tests
   verify disposal where a registry is involved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`session-<id>.md`) built from `ctx.sessionQuery.readSession` via
   `im.v1.file.create` → `msg_type: 'file'`. `FeishuTransport` gains
   `sendFile`; the memory transport records `kind: 'file'` outbox entries.
-  No truncation — the file is not bound by the card cap.
+  No truncation — the file is not bound by the card cap. (New scope
+  `im:resource` — see the permissions manifest below.)
 - **`ask_user_question` tool mounted (web parity).** The web surface
   exposes the standard `@deepseek-ai/dsh-tool-ask-user` tool through its
   standard/code agent presets; this bundle now inserts the same tool row
@@ -27,6 +28,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ask_user_question` posts a question card and an option tap feeds the
   answer back into the turn. Tests: 308 (was 299).
 
+- **Feishu quick setup (botmux-style Open Platform automation).** One QR scan
+  now creates/configures the app end to end: `pnpm run setup:feishu` drives
+  the console over a reusable Web session (`src/setup/*`, entry
+  `scripts/setup-feishu.mjs` + `dsh-feishu-setup` bin) — creates a
+  企业自建应用, enables the bot, subscribes `im.message.receive_v1` +
+  `card.action.trigger` in long-connection mode (read-back verified,
+  fail-closed), grants the scopes listed in
+  `src/setup/feishu-manifest.json` (currently `im:message`,
+  `im:message:send_as_bot`, `im:chat`, `im:resource` — the single source of
+  truth for the automation, the manual fallback, and the setup docs),
+  publishes a "visible to me only" version (instant approval), and writes
+  `appId`/`appSecret` into the profile's `cordis.patch.yml` (backed up).
+  `--no-open-platform-auto` keeps the manual paste-credentials path; the
+  credentials are validated against the Feishu API first. 34 unit tests cover
+  the cookie jar, session file, QR helpers, payload builders, response
+  extractors, the fail-closed verification, the profile writer, and the
+  configure flow driven through a fake fetcher.
 
 - **Agent workflow documentation.** `AGENTS.md` gains a "Worktree + PR
   workflow" section (work in a git worktree under `_dev/`, verify gates with

--- a/docs/development.md
+++ b/docs/development.md
@@ -129,6 +129,10 @@ inject a fake message by writing a JSON file into
 The bundle must mount into a real dsh profile. Use an isolated `DSH_HOME` so
 the verification never touches a production profile:
 
+> For creating/configuring the Feishu app itself — one QR scan, no
+> web-console work — see `docs/feishu-setup.md` → "Quick setup"
+> (`pnpm run setup:feishu`).
+
 ```sh
 # From the checkout root:
 export DSH_HOME="$(pwd)/_dev/dsh-home"   # git-ignored

--- a/docs/feishu-setup.md
+++ b/docs/feishu-setup.md
@@ -1,21 +1,77 @@
 # Feishu App Setup
 
 How to create the Feishu (Lark) custom app the surface connects as, and how
-to configure its credentials.
+to configure its credentials. Two paths: the **quick setup** (one QR scan,
+the Open Platform is configured automatically — recommended) and the
+**manual path** (paste credentials, follow a short checklist).
 
-## 1. Create the app and bot
+## Quick setup (recommended)
+
+`pnpm run setup:feishu` drives the Feishu Open Platform console automatically
+over a reusable Web session (mirroring botmux's `setup` wizard). One QR scan
+is the only human step:
+
+```sh
+pnpm run build                       # the setup CLI lives in lib/setup
+pnpm run setup:feishu -- --new       # create a new app + configure it
+```
+
+The wizard then, with no further web-console work:
+
+1. Creates a **企业自建应用** (default name "DSH Agent (dsh-feishu)",
+   `--app-name` to change) and reads back its `app_id` / `app_secret`.
+2. Enables the **bot** capability.
+3. Switches **events and card callbacks to the long connection** and
+   subscribes `im.message.receive_v1` (event) + `card.action.trigger`
+   (card callback) — both required, verified by read-back (fail-closed).
+4. Grants the scopes `im:message`, `im:message:send_as_bot`, `im:chat`.
+5. Publishes an app version with **"visible to me only"** visibility —
+   auto-approved, no administrator wait.
+6. Writes `appId` / `appSecret` into the profile's `cordis.patch.yml`
+   (a `.bak` backup is kept), or prints export lines with `--print-env`.
+
+Reconfigure an existing app instead of creating one:
+
+```sh
+pnpm run setup:feishu -- --app-id cli_xxx
+```
+
+Other options: `--list` (list apps the session can see), `--force-login`
+(fresh QR even with a cached session), `--lark` (Lark international console),
+`--verify-boot` (boots `dsh --profile <name>` afterwards and waits for
+`[feishu] bridge ready`), `--help` (full usage). The session file lives at
+`~/.dsh-feishu/feishu-session.json` (`DSH_FEISHU_SESSION` to override) and is
+reused across runs — only the first run needs a QR scan.
+
+### What stays manual
+
+Creating the app, granting scopes, subscribing events, and publishing
+versions are console-only actions — there is no public API for them. The
+automation reduces the console work to **scanning one QR code**; when it
+cannot run (no terminal QR, corporate login policies), use the manual path.
+
+## Manual path (`--no-open-platform-auto`)
+
+Paste the credentials and get the config written plus a short checklist:
+
+```sh
+pnpm run setup:feishu -- --no-open-platform-auto
+```
+
+The tool validates the credentials against the Feishu API, writes them into
+the profile (or `--print-env`), and prints the remaining console steps.
+Manual steps, for reference:
+
+### 1. Create the app and bot
 
 1. Open the [Feishu Open Platform](https://open.feishu.cn/app) (Lark:
    [larksuite.com](https://open.larksuite.com/app)) and create a **custom
    app** (企业自建应用).
 2. In **App Features → Bot** (应用功能 → 机器人), enable the bot.
-3. Publish the app **version** (创建版本并发布) and let an administrator
-   approve it — events and API access only work after the version is
-   released.
-4. In **Credentials & Basic Info** (凭证与基础信息), note the **App ID**
+3. In **Credentials & Basic Info** (凭证与基础信息), note the **App ID**
    (`cli_...`) and **App Secret** (`...`).
 
-## 2. Enable the long connection
+### 2. Enable the long connection
 
 The surface receives events over the Feishu **WebSocket long connection** —
 no callback URL, no public endpoint, no public IP on the host (all traffic is
@@ -29,19 +85,25 @@ outbound). In **Events & Callbacks** (事件与回调):
   button presses fail with "该应用尚未配置卡片回调" (the app has no card
   callback configured).
 
-## 3. Grant permissions
+### 3. Grant permissions
 
-Add the following **scopes** (权限) to the app version:
+The canonical list lives in `src/setup/feishu-manifest.json` (the setup
+automation grants exactly that list — keep it in sync when adding features).
+Current scopes (权限):
 
 | Scope | Purpose |
 |---|---|
 | `im:message` | Receive messages (`im.message.receive_v1`) |
 | `im:message:send_as_bot` | Send messages and cards as the bot |
-| `im:chat` | Read chat metadata (later iterations) |
+| `im:chat` | Read chat metadata |
+| `im:resource` | Upload file messages (`/export`) |
 
-Publish a new version after adding scopes.
+### 4. Publish
 
-## 4. Configure the surface
+Create a version and publish it. Choose **"visible to me only"** (仅自己可见)
+so the version is approved instantly — no administrator wait.
+
+## Configure the surface
 
 Credentials are read from the `appId` / `appSecret` config keys or the
 `FEISHU_APP_ID` / `FEISHU_APP_SECRET` environment variables:
@@ -62,7 +124,7 @@ or in the profile's `cordis.patch.yml`:
     appSecret: yyy
 ```
 
-## 5. Verify
+## Verify
 
 With credentials configured, the boot log prints:
 
@@ -73,7 +135,7 @@ feishu long connection ready
 ```
 
 Then direct-message the bot from a test account; the reply streams back as a
-live card.
+live card. `--verify-boot` automates this check after setup.
 
 ## Network requirements
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "./cordis.patch.yml": "./cordis.patch.yml",
     "./package.json": "./package.json"
   },
+  "bin": {
+    "dsh-feishu-setup": "lib/setup/cli.js"
+  },
   "files": [
     "lib",
     "cordis.patch.yml",
@@ -31,13 +34,16 @@
     "format": "biome format --write src tests",
     "test": "vitest run",
     "test:watch": "vitest",
+    "setup:feishu": "node scripts/setup-feishu.mjs",
     "prepublishOnly": "pnpm run lint && pnpm run typecheck && pnpm run test && pnpm run build"
   },
   "dependencies": {
     "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
     "@deepseek-ai/schemastery": "^3.18.1",
     "@larksuiteoapi/node-sdk": "^1.73.0",
-    "markdown-it": "^15.0.0"
+    "js-yaml": "^5.2.3",
+    "markdown-it": "^15.0.0",
+    "qrcode-terminal": "^0.12.0"
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
@@ -59,8 +65,10 @@
     "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.6",
+    "@types/js-yaml": "^4.0.9",
     "@types/markdown-it": "^14.1.2",
     "@types/node": "^22.15.0",
+    "@types/qrcode-terminal": "^0.12.2",
     "typescript": "^5.9.3",
     "vitest": "^3.2.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,15 @@ importers:
       '@larksuiteoapi/node-sdk':
         specifier: ^1.73.0
         version: 1.73.0
+      js-yaml:
+        specifier: ^5.2.3
+        version: 5.2.3
       markdown-it:
         specifier: ^15.0.0
         version: 15.0.0
+      qrcode-terminal:
+        specifier: ^0.12.0
+        version: 0.12.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.7
@@ -48,12 +54,18 @@ importers:
       '@deepseek-ai/dsh-user-questions':
         specifier: ^0.1.0-rc.6
         version: 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.6(b0514d7a320728b6d8f5a31eb3960e10))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/markdown-it':
         specifier: ^14.1.2
         version: 14.1.2
       '@types/node':
         specifier: ^22.15.0
         version: 22.20.1
+      '@types/qrcode-terminal':
+        specifier: ^0.12.2
+        version: 0.12.2
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -3004,6 +3016,9 @@ packages:
   '@types/hast@3.0.5':
     resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
   '@types/katex@0.16.8':
     resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
 
@@ -3024,6 +3039,9 @@ packages:
 
   '@types/node@22.20.1':
     resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
+
+  '@types/qrcode-terminal@0.12.2':
+    resolution: {integrity: sha512-v+RcIEJ+Uhd6ygSQ0u5YYY7ZM+la7GgPbs0V/7l/kFs2uO4S8BcIUEMoP7za4DNIqNnUD5npf0A/7kBhrCKG5Q==}
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
@@ -3564,6 +3582,10 @@ packages:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
+  js-yaml@5.2.3:
+    resolution: {integrity: sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==}
+    hasBin: true
+
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
@@ -3952,6 +3974,10 @@ packages:
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
+
+  qrcode-terminal@0.12.0:
+    resolution: {integrity: sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==}
+    hasBin: true
 
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
@@ -7725,6 +7751,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/js-yaml@4.0.9': {}
+
   '@types/katex@0.16.8': {}
 
   '@types/linkify-it@5.0.0': {}
@@ -7745,6 +7773,8 @@ snapshots:
   '@types/node@22.20.1':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/qrcode-terminal@0.12.2': {}
 
   '@types/retry@0.12.0': {}
 
@@ -8315,6 +8345,10 @@ snapshots:
   js-tokens@9.0.1: {}
 
   js-yaml@4.3.1:
+    dependencies:
+      argparse: 2.0.1
+
+  js-yaml@5.2.3:
     dependencies:
       argparse: 2.0.1
 
@@ -8893,6 +8927,8 @@ snapshots:
   proxy-from-env@2.1.0: {}
 
   punycode.js@2.3.1: {}
+
+  qrcode-terminal@0.12.0: {}
 
   qs@6.15.3:
     dependencies:

--- a/scripts/setup-feishu.mjs
+++ b/scripts/setup-feishu.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+/**
+ * Thin launcher for the dsh-feishu quick-setup CLI. The implementation lives
+ * in the TypeScript build (lib/setup/cli.js); this launcher only checks that
+ * the build exists and forwards argv. Run `pnpm run build` first.
+ */
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const libCli = fileURLToPath(new URL('../lib/setup/cli.js', import.meta.url));
+if (!existsSync(libCli)) {
+  process.stderr.write('lib/ is not built. Run `pnpm run build` first, then re-run this command.\n');
+  process.exit(1);
+}
+const { main } = await import(libCli);
+await main(process.argv.slice(2));

--- a/src/setup/cli.ts
+++ b/src/setup/cli.ts
@@ -1,0 +1,426 @@
+#!/usr/bin/env node
+/**
+ * dsh-feishu quick-setup CLI. Primary path: one Feishu QR scan → the Open
+ * Platform automation creates (or reconfigures) the app, subscribes events
+ * and card callbacks over the long connection, grants scopes, publishes a
+ * version, and writes the credentials into a dsh profile. `--no-open-platform-auto`
+ * keeps a manual fallback (paste credentials → config written → checklist).
+ *
+ * Mirrors botmux's `botmux setup` wizard
+ * (`_tmp/botmux/src/setup/*`); the console automation uses the same internal
+ * `/developers/v1/*` endpoints with a reusable cookie session.
+ */
+
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { createInterface } from 'node:readline/promises';
+import { pathToFileURL } from 'node:url';
+import { createOpenPlatformApiClient } from './client.js';
+import { configureFeishuApp } from './configure.js';
+import type { StoredCookie } from './cookies.js';
+import { createFeishuOpenPlatformApp } from './create-app.js';
+import {
+  APP_EVENTS,
+  CARD_CALLBACKS,
+  DEFAULT_APP_NAME,
+  FEISHU_MANIFEST,
+  SCOPES,
+} from './manifest.js';
+import { fetchOpenPlatformAppSecret, listOpenPlatformApps } from './payloads.js';
+import { dshHome, profilePatchPath, writeProfileCredentials } from './profile-writer.js';
+import { classifyFeishuLoginError, loginFeishuWebSession } from './qr-login.js';
+import {
+  feishuSessionFilePath,
+  readStoredCookiesFromSessionFile,
+  writeStoredCookiesToSessionFile,
+} from './session.js';
+
+interface CliOptions {
+  newApp: boolean;
+  appId?: string;
+  list: boolean;
+  appName: string;
+  profile: string;
+  dshHomeDir: string;
+  noAuto: boolean;
+  lark: boolean;
+  forceLogin: boolean;
+  printEnv: boolean;
+  verifyBoot: boolean;
+  appSecret?: string;
+  help: boolean;
+}
+
+function parseArgs(argv: readonly string[]): CliOptions {
+  const opts: CliOptions = {
+    newApp: false,
+    list: false,
+    appName: DEFAULT_APP_NAME,
+    profile: 'feishu-dev',
+    dshHomeDir: dshHome(),
+    noAuto: false,
+    lark: false,
+    forceLogin: false,
+    printEnv: false,
+    verifyBoot: false,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const value = (): string => {
+      const next = argv[i + 1];
+      if (next === undefined) throw new Error(`missing value for ${arg}`);
+      i += 1;
+      return next;
+    };
+    if (arg === '--new') opts.newApp = true;
+    else if (arg === '--app-id') opts.appId = value();
+    else if (arg === '--app-secret') opts.appSecret = value();
+    else if (arg === '--list') opts.list = true;
+    else if (arg === '--app-name') opts.appName = value();
+    else if (arg === '--profile') opts.profile = value();
+    else if (arg === '--dsh-home') opts.dshHomeDir = value();
+    else if (arg === '--no-open-platform-auto') opts.noAuto = true;
+    else if (arg === '--lark') opts.lark = true;
+    else if (arg === '--force-login') opts.forceLogin = true;
+    else if (arg === '--print-env') opts.printEnv = true;
+    else if (arg === '--verify-boot') opts.verifyBoot = true;
+    else if (arg === '--help' || arg === '-h') opts.help = true;
+    else throw new Error(`unknown option: ${arg}`);
+  }
+  return opts;
+}
+
+const USAGE = `dsh-feishu quick setup — minimize Feishu Open Platform web-console work.
+
+Usage:
+  node scripts/setup-feishu.mjs [options]
+
+Options:
+  --new                     create a new app (default when --app-id is absent)
+  --app-id <id>             configure an existing app (cli_...)
+  --app-secret <secret>     app secret (manual path only)
+  --list                    list apps visible to the session, then exit
+  --app-name <name>         name for a new app (default "${DEFAULT_APP_NAME}")
+  --profile <name>          dsh profile to write credentials into (default feishu-dev)
+  --dsh-home <dir>          dsh home (default $DSH_HOME or ~/.dsh)
+  --no-open-platform-auto   manual path: paste credentials, write config, print steps
+  --lark                    Lark international console origin
+  --force-login             ignore a cached session and scan a fresh QR
+  --print-env               print export lines instead of writing the profile
+  --verify-boot             after configuring, boot dsh and wait for the bridge
+  --help                    show this help
+
+The automatic path needs one Feishu QR scan (displayed in the terminal). It
+creates/reconfigures the app, subscribes im.message.receive_v1 and
+card.action.trigger over the long connection, grants the scopes
+(${SCOPES.join(', ')}), publishes a version, and writes appId/appSecret into
+the profile's cordis.patch.yml (backed up first).
+`;
+
+function log(message: string): void {
+  process.stderr.write(`[setup] ${message}\n`);
+}
+
+function logError(message: string): void {
+  process.stderr.write(`[setup] error: ${message}\n`);
+}
+
+async function prompt(question: string): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    return (await rl.question(question)).trim();
+  } finally {
+    rl.close();
+  }
+}
+
+/** Resolve the dsh CLI binary: $DSH_BIN, then `dsh` on PATH. */
+function resolveDshBin(): string | undefined {
+  if (process.env.DSH_BIN !== undefined && process.env.DSH_BIN !== '') return process.env.DSH_BIN;
+  const probe = spawnSync('sh', ['-c', 'command -v dsh'], { encoding: 'utf8' });
+  if (probe.status === 0 && probe.stdout.trim() !== '') return probe.stdout.trim();
+  return undefined;
+}
+
+/**
+ * Boot `dsh --profile <name>` with the credentials and wait for the bridge.
+ * @returns true when the surface reported ready within the deadline.
+ */
+async function verifyBoot(
+  dshHomeDir: string,
+  profileName: string,
+  credentials: { appId: string; appSecret: string },
+  timeoutMs = 60_000,
+): Promise<boolean> {
+  const bin = resolveDshBin();
+  if (!bin) {
+    logError('dsh CLI not found ($DSH_BIN or dsh on PATH); skipping boot verification');
+    return false;
+  }
+  return await new Promise<boolean>((resolvePromise) => {
+    const child = spawn(bin, ['--profile', profileName], {
+      env: {
+        ...process.env,
+        DSH_HOME: dshHomeDir,
+        FEISHU_APP_ID: credentials.appId,
+        FEISHU_APP_SECRET: credentials.appSecret,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let output = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      resolvePromise(false);
+    }, timeoutMs);
+    const onData = (chunk: Buffer): void => {
+      output += chunk.toString();
+      if (output.includes('[feishu] bridge ready')) {
+        clearTimeout(timer);
+        child.kill('SIGTERM');
+        resolvePromise(true);
+      }
+    };
+    child.stdout?.on('data', onData);
+    child.stderr?.on('data', onData);
+    child.on('error', () => {
+      clearTimeout(timer);
+      resolvePromise(false);
+    });
+  });
+}
+
+/** Validate app credentials via the public tenant-token endpoint. */
+async function validateCredentials(
+  appId: string,
+  appSecret: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ ok: boolean; message?: string }> {
+  try {
+    const response = await fetchImpl(
+      'https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ app_id: appId, app_secret: appSecret }),
+      },
+    );
+    const data = (await response.json()) as { code?: number; msg?: string };
+    if (data.code === 0) return { ok: true };
+    return {
+      ok: false,
+      message: `tenant token rejected: ${data.msg ?? `code ${String(data.code)}`}`,
+    };
+  } catch (error) {
+    return { ok: false, message: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/** Write credentials to the profile or print export lines. */
+function deliverCredentials(
+  options: CliOptions,
+  credentials: { appId: string; appSecret: string },
+): void {
+  if (options.printEnv) {
+    process.stdout.write(`export FEISHU_APP_ID=${credentials.appId}\n`);
+    process.stdout.write(`export FEISHU_APP_SECRET=${credentials.appSecret}\n`);
+    return;
+  }
+  const result = writeProfileCredentials(options.dshHomeDir, options.profile, credentials);
+  if (result.changed) {
+    log(
+      `wrote appId/appSecret into ${result.path}${result.backupPath ? ` (backup: ${result.backupPath})` : ''}`,
+    );
+  } else {
+    log(`credentials already present in ${result.path}`);
+  }
+}
+
+/** Print the manual web-console checklist (used by the fallback path). */
+function printManualChecklist(appId: string): void {
+  process.stderr.write(`\nRemaining steps in the Feishu Open Platform console for ${appId}:\n`);
+  process.stderr.write(`  1. App Features → Bot: enable the bot.\n`);
+  process.stderr.write(
+    `  2. Events & Callbacks → Events: choose "Long connection" and subscribe:\n`,
+  );
+  process.stderr.write(`     ${APP_EVENTS.join(', ')}\n`);
+  process.stderr.write(
+    `  3. Events & Callbacks → Card callbacks: choose "Long connection" and subscribe:\n`,
+  );
+  process.stderr.write(`     ${CARD_CALLBACKS.join(', ')}\n`);
+  process.stderr.write(
+    `  4. Permissions: add ${SCOPES.join(', ')} (the manifest JSON below lists them).\n`,
+  );
+  process.stderr.write(`  5. Create a version and publish it — choose "visible to me only" for\n`);
+  process.stderr.write(`     instant approval (no administrator wait).\n`);
+}
+
+/** The manual fallback: no browser session, paste credentials, write config. */
+async function runManualSetup(options: CliOptions): Promise<void> {
+  let appId = options.appId;
+  let appSecret = options.appSecret;
+  if (!appId) appId = await prompt('Feishu app id (cli_...): ');
+  if (!appId) throw new Error('app id is required');
+  if (!appSecret) appSecret = await prompt('Feishu app secret: ');
+  if (!appSecret) throw new Error('app secret is required');
+
+  log('validating credentials against the Feishu API…');
+  const validation = await validateCredentials(appId, appSecret);
+  if (!validation.ok) {
+    throw new Error(`credentials look invalid: ${validation.message ?? 'unknown error'}`);
+  }
+  deliverCredentials(options, { appId, appSecret });
+  printManualChecklist(appId);
+
+  const manifestPath = join(process.cwd(), 'feishu-manifest.json');
+  writeFileSync(manifestPath, JSON.stringify(FEISHU_MANIFEST, null, 2), 'utf8');
+  log(`manifest written to ${manifestPath}`);
+
+  if (options.verifyBoot) {
+    log('verifying the boot…');
+    const ready = await verifyBoot(options.dshHomeDir, options.profile, { appId, appSecret });
+    if (!ready) logError('boot verification timed out (check the long connection / network)');
+    else log('bridge ready — the surface is live');
+  }
+  process.stdout.write(
+    `\nDone. Configured manually; start with \`dsh --profile ${options.profile}\`.\n`,
+  );
+}
+
+/** The automatic path: QR session → create/configure → publish → credentials. */
+async function runAutoSetup(options: CliOptions): Promise<void> {
+  const sessionFile = feishuSessionFilePath();
+
+  // Reuse a cached session when it still works; otherwise scan a fresh QR.
+  let cookies: StoredCookie[] | null = null;
+  if (!options.forceLogin) {
+    const cached = readStoredCookiesFromSessionFile(sessionFile);
+    if (cached && cached.length > 0) {
+      const probe = await createOpenPlatformApiClient(cached);
+      if (probe.ok) {
+        cookies = cached;
+        log('reusing the cached Feishu Web session');
+      } else if (probe.reason === 'network') {
+        throw new Error(`cannot reach the Open Platform: ${probe.message}`);
+      } else {
+        log(`cached session expired (${probe.message}); scanning a fresh QR`);
+      }
+    }
+  }
+  if (!cookies) {
+    log('scan the QR below with the Feishu app to continue');
+    try {
+      cookies = await loginFeishuWebSession({ maxWaitMs: 180_000 });
+      writeStoredCookiesToSessionFile(sessionFile, cookies);
+      log('session saved for reuse');
+    } catch (error) {
+      throw new Error(
+        `QR login failed (${classifyFeishuLoginError(error)}): ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  const clientResult = await createOpenPlatformApiClient(cookies);
+  if (!clientResult.ok) {
+    throw new Error(clientResult.message);
+  }
+  const { client } = clientResult;
+  if (clientResult.identity) {
+    log(`logged in as ${clientResult.identity.userName} · ${clientResult.identity.tenantName}`);
+  }
+
+  if (options.list) {
+    const apps = await listOpenPlatformApps(client);
+    for (const app of apps) {
+      process.stdout.write(`${app.clientId}\t${app.name}\n`);
+    }
+    return;
+  }
+
+  // Target: create a new app, or reconfigure an existing one.
+  let appId: string;
+  let appSecret: string;
+  if (options.newApp || options.appId === undefined) {
+    if (!clientResult.identity) {
+      throw new Error(
+        'cannot create an app without the session identity; re-run with --force-login',
+      );
+    }
+    log(`creating a new app "${options.appName}"…`);
+    const created = await createFeishuOpenPlatformApp(client, {
+      name: options.appName,
+      creatorUserId: clientResult.identity.userId,
+    });
+    if (!created.ok || !created.appId || !created.appSecret) {
+      throw new Error(created.message ?? 'app creation failed');
+    }
+    appId = created.appId;
+    appSecret = created.appSecret;
+    log(`app created and enabled: ${appId}`);
+  } else {
+    appId = options.appId;
+    log(`configuring existing app ${appId}…`);
+    const configured = await configureFeishuApp(client, appId, { publish: true });
+    if (!configured.ok) {
+      throw new Error(configured.message ?? 'configuration failed');
+    }
+    if (configured.warning) log(`warning: ${configured.warning}`);
+    log(
+      `scopes granted: ${configured.scopeCount ?? 0}; subscriptions confirmed: ${configured.subscribedEventCount ?? 0}`,
+    );
+    if (configured.versionId) log(`version published: ${configured.versionId}`);
+    appSecret = await fetchOpenPlatformAppSecret(client, appId);
+  }
+
+  deliverCredentials(options, { appId, appSecret });
+
+  if (options.verifyBoot) {
+    log('verifying the boot…');
+    const ready = await verifyBoot(options.dshHomeDir, options.profile, { appId, appSecret });
+    if (!ready) logError('boot verification timed out (check the long connection / network)');
+    else log('bridge ready — the surface is live');
+  }
+  process.stdout.write(`\nDone. App ${appId} configured for profile '${options.profile}'.\n`);
+  process.stdout.write(`Start with: dsh --profile ${options.profile}\n`);
+}
+
+/** CLI entry point. */
+export async function main(argv: readonly string[]): Promise<void> {
+  let options: CliOptions;
+  try {
+    options = parseArgs(argv);
+  } catch (error) {
+    logError(error instanceof Error ? error.message : String(error));
+    process.stderr.write(USAGE);
+    process.exitCode = 2;
+    return;
+  }
+  if (options.help) {
+    process.stdout.write(USAGE);
+    return;
+  }
+  if (!options.printEnv && !existsSync(profilePatchPath(options.dshHomeDir, options.profile))) {
+    const parent = resolve(profilePatchPath(options.dshHomeDir, options.profile), '..');
+    logError(
+      `profile '${options.profile}' not found under ${parent}. Create it first, e.g. with: dsh plugin --profile ${options.profile} add link:<checkout>`,
+    );
+    process.exitCode = 2;
+    return;
+  }
+  try {
+    if (options.noAuto) {
+      await runManualSetup(options);
+    } else {
+      await runAutoSetup(options);
+    }
+  } catch (error) {
+    logError(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}
+
+// Direct execution (bin entry): run main; imported launchers call main() themselves.
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  void main(process.argv.slice(2));
+}

--- a/src/setup/client.ts
+++ b/src/setup/client.ts
@@ -1,0 +1,153 @@
+/**
+ * Feishu Open Platform console API client: loads a console page with the
+ * session cookies, extracts `window.csrfToken` and the final origin (some
+ * tenants redirect the console to open.larkoffice.com), then issues
+ * `POST /developers/v1/*` calls the same way the console frontend does.
+ * Mirrors botmux's `createOpenPlatformApiClient`
+ * (`_tmp/botmux/src/setup/open-platform-automation.ts`).
+ */
+
+import { MutableCookieJar, type StoredCookie } from './cookies.js';
+import {
+  extractOpenPlatformCsrfToken,
+  extractOpenPlatformSessionIdentity,
+  type FeishuWebSessionIdentity,
+} from './session.js';
+
+/** Error carrying the console API payload for diagnostics. */
+export class OpenPlatformApiError extends Error {
+  constructor(
+    message: string,
+    readonly payload: unknown,
+    readonly status: number,
+  ) {
+    super(message);
+  }
+}
+
+function summarizeOpenPlatformPayload(payload: unknown): string {
+  if (!payload || typeof payload !== 'object') return String(payload);
+  const record = payload as Record<string, unknown>;
+  const summary: Record<string, unknown> = {};
+  for (const key of ['code', 'msg', 'message', 'error', 'error_msg']) {
+    if (record[key] !== undefined) summary[key] = record[key];
+  }
+  return JSON.stringify(summary).slice(0, 500);
+}
+
+/** Console client surface used by the automation flows. */
+export interface OpenPlatformApiClient {
+  readonly apiOrigin: string;
+  postJson(path: string, body?: unknown): Promise<unknown>;
+  postForm(path: string, body: FormData): Promise<unknown>;
+}
+
+export type OpenPlatformClientResult =
+  | { ok: true; client: OpenPlatformApiClient; identity?: FeishuWebSessionIdentity }
+  | { ok: false; reason: 'missing_csrf' | 'network'; message: string };
+
+/** Create a console client for the given session cookies. */
+export async function createOpenPlatformApiClient(
+  cookies: readonly StoredCookie[],
+  options: { fetchImpl?: typeof fetch } = {},
+): Promise<OpenPlatformClientResult> {
+  const fetcher = options.fetchImpl ?? fetch;
+  const session = new MutableCookieJar(cookies);
+  let csrfToken: string | null = null;
+  let apiOrigin = 'https://open.feishu.cn';
+  let referer = `${apiOrigin}/app`;
+  let identity: FeishuWebSessionIdentity | undefined;
+  try {
+    const page = await session.fetchTextWithUrl(fetcher, `${apiOrigin}/app`);
+    apiOrigin = new URL(page.finalUrl).origin;
+    referer = page.finalUrl;
+    csrfToken = extractOpenPlatformCsrfToken(page.text);
+    identity = extractOpenPlatformSessionIdentity(page.text) ?? undefined;
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'network',
+      message: `Failed to load the Open Platform page: ${safeErrorMessage(error)}`,
+    };
+  }
+  if (!csrfToken) {
+    return {
+      ok: false,
+      reason: 'missing_csrf',
+      message:
+        'The Open Platform page did not return window.csrfToken; the Web session may be ' +
+        'expired or not fully logged in',
+    };
+  }
+
+  const request = async (
+    path: string,
+    body?: RequestInit['body'],
+    contentType?: string,
+  ): Promise<unknown> => {
+    const url = `${apiOrigin}${path}`;
+    const { response } = await session.fetchRaw(fetcher, url, {
+      method: 'POST',
+      headers: {
+        accept: 'application/json, text/plain, */*',
+        origin: apiOrigin,
+        referer,
+        'x-csrf-token': csrfToken,
+        ...(contentType ? { 'content-type': contentType } : {}),
+      },
+      ...(body !== undefined ? { body } : {}),
+    });
+    let data: unknown = null;
+    try {
+      data = (await response.json()) as unknown;
+    } catch {
+      data = null;
+    }
+    if (!response.ok) {
+      throw new OpenPlatformApiError(
+        `HTTP ${response.status} ${path}: ${summarizeOpenPlatformPayload(data)}`,
+        data,
+        response.status,
+      );
+    }
+    if (
+      data &&
+      typeof data === 'object' &&
+      typeof (data as { code?: unknown }).code === 'number' &&
+      (data as { code: number }).code !== 0
+    ) {
+      throw new OpenPlatformApiError(
+        `code=${(data as { code: number }).code} msg=${(data as { msg?: string; message?: string }).msg ?? (data as { message?: string }).message ?? ''}`,
+        data,
+        response.status,
+      );
+    }
+    return data;
+  };
+
+  const postJson = async (path: string, body?: unknown): Promise<unknown> =>
+    request(
+      path,
+      body === undefined ? undefined : JSON.stringify(body),
+      body === undefined ? undefined : 'application/json',
+    );
+  const postForm = async (path: string, body: FormData): Promise<unknown> => request(path, body);
+
+  return {
+    ok: true,
+    client: { apiOrigin, postJson, postForm },
+    ...(identity !== undefined ? { identity } : {}),
+  };
+}
+
+/** True when the console denied access to the app (not an automation bug). */
+export function openPlatformOwnerAccessDenied(error: unknown): boolean {
+  if (!(error instanceof OpenPlatformApiError)) return false;
+  const payload = error.payload as { code?: unknown } | null;
+  return error.status === 403 && payload?.code === 10003;
+}
+
+function safeErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.replace(/[A-Za-z0-9_=-]{24,}/g, '***');
+}

--- a/src/setup/configure.ts
+++ b/src/setup/configure.ts
@@ -1,0 +1,305 @@
+/**
+ * The Open Platform configuration flow for a Feishu app: bot capability,
+ * long-connection event + card-callback subscriptions, scopes, safe settings,
+ * and a version publish. Read-back verification is fail-closed on the two
+ * critical subscriptions (`im.message.receive_v1` event and
+ * `card.action.trigger` callback, both in long-connection mode) — a bot that
+ * cannot receive messages or card clicks must never be reported as
+ * configured. Mirrors botmux's `automateOpenPlatformSetup`
+ * (`_tmp/botmux/src/setup/open-platform-automation.ts`).
+ */
+
+import { type OpenPlatformApiClient, openPlatformOwnerAccessDenied } from './client.js';
+import { SCOPES } from './manifest.js';
+import {
+  buildAppVersionCreatePayload,
+  buildCallbackSubscriptionPayload,
+  buildEventSubscriptionPayload,
+  buildSafeSettingPayload,
+  buildScopeUpdatePayload,
+  extractOpenPlatformCallbackState,
+  extractOpenPlatformEventState,
+  extractOpenPlatformScopeEntries,
+  extractVersionId,
+  LONG_CONNECTION_EVENT_MODE,
+  mapManifestScopesToOpenPlatformIds,
+  nextAppVersion,
+  type OnlineVisibility,
+  type OpenPlatformCallbackState,
+  type OpenPlatformEventState,
+  parseOnlineVisibility,
+  REQUIRED_CALLBACKS,
+  REQUIRED_EVENTS,
+} from './payloads.js';
+
+/** Outcome of the configure flow. */
+export interface ConfigureResult {
+  readonly ok: boolean;
+  /** When `ok`, number of scopes granted (may be 0 when already granted). */
+  readonly scopeCount?: number;
+  /** When `ok`, number of event+callback subscriptions confirmed. */
+  readonly subscribedEventCount?: number;
+  /** Non-fatal issues (skipped scopes, partial event failures). */
+  readonly warning?: string;
+  /** Published version id, when the version was created. */
+  readonly versionId?: string;
+  /** Failure reason for diagnostics. */
+  readonly reason?:
+    | 'api_error'
+    | 'event_verification_failed'
+    | 'visibility_unreadable'
+    | 'owner_session_mismatch';
+  readonly message?: string;
+}
+
+function safeErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.replace(/[A-Za-z0-9_=-]{24,}/g, '***');
+}
+
+/**
+ * Configure an existing Feishu app end to end.
+ * @param client - authenticated console client.
+ * @param appId - `cli_...` app id.
+ * @param options - when `publish` is false the version steps are skipped.
+ */
+export async function configureFeishuApp(
+  client: OpenPlatformApiClient,
+  appId: string,
+  options: { publish?: boolean; fetchImpl?: typeof fetch } = {},
+): Promise<ConfigureResult> {
+  const postJson = client.postJson;
+  const warnings: string[] = [];
+
+  // ── Scopes (non-fatal: some tenants cannot grant individual scopes). ──
+  let scopeCount = 0;
+  try {
+    const catalogPayload = await postJson(`/developers/v1/scope/all/${appId}`);
+    const catalog = extractOpenPlatformScopeEntries(catalogPayload);
+    const mapped = mapManifestScopesToOpenPlatformIds(SCOPES, catalog);
+    if (mapped.missing.length > 0) {
+      warnings.push(`scopes not in the catalog (skipped): ${mapped.missing.join(', ')}`);
+    }
+    if (mapped.tenantScopeIds.length + mapped.userScopeIds.length > 0) {
+      try {
+        await postJson(
+          `/developers/v1/scope/update/${appId}`,
+          buildScopeUpdatePayload(appId, mapped),
+        );
+        scopeCount = mapped.tenantScopeIds.length + mapped.userScopeIds.length;
+      } catch (error) {
+        warnings.push(`granting scopes failed: ${safeErrorMessage(error)}`);
+      }
+    }
+  } catch (error) {
+    if (openPlatformOwnerAccessDenied(error)) {
+      return {
+        ok: false,
+        reason: 'owner_session_mismatch',
+        message: `The session cannot manage app ${appId} (not the owner?)`,
+      };
+    }
+    warnings.push(`reading the scope catalog failed: ${safeErrorMessage(error)}`);
+  }
+
+  // ── Bot + long-connection event mode (fatal: without them no messages). ──
+  try {
+    await postJson(`/developers/v1/robot/switch/${appId}`, { clientId: appId, enable: true });
+    await postJson(`/developers/v1/event/switch/${appId}`, {
+      clientId: appId,
+      eventMode: LONG_CONNECTION_EVENT_MODE,
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'api_error',
+      message: `Enabling the bot or long-connection events failed: ${safeErrorMessage(error)}`,
+      ...(warnings.length > 0 ? { warning: warnings.join('; ') } : {}),
+    };
+  }
+
+  // ── Events: read → add missing → re-read → verify (fail-closed). ──
+  let eventState: OpenPlatformEventState | undefined;
+  try {
+    eventState = extractOpenPlatformEventState(
+      await postJson(`/developers/v1/event/${appId}`, { needEventDetail: true }),
+    );
+  } catch (error) {
+    warnings.push(`reading event subscriptions failed: ${safeErrorMessage(error)}`);
+  }
+  const hasEvent = (name: string): boolean => Boolean(eventState?.events.includes(name));
+  const missingAppEvents = REQUIRED_EVENTS.filter((name) => !hasEvent(name));
+  if (missingAppEvents.length > 0) {
+    const eventMode = eventState?.eventMode ?? LONG_CONNECTION_EVENT_MODE;
+    try {
+      await postJson(
+        `/developers/v1/event/update/${appId}`,
+        buildEventSubscriptionPayload(appId, eventMode, missingAppEvents),
+      );
+    } catch {
+      for (const name of missingAppEvents) {
+        try {
+          await postJson(
+            `/developers/v1/event/update/${appId}`,
+            buildEventSubscriptionPayload(appId, eventMode, [name]),
+          );
+        } catch (inner) {
+          warnings.push(`subscribing event ${name} failed: ${safeErrorMessage(inner)}`);
+        }
+      }
+    }
+    try {
+      eventState = extractOpenPlatformEventState(
+        await postJson(`/developers/v1/event/${appId}`, { needEventDetail: true }),
+      );
+    } catch (error) {
+      warnings.push(`re-reading event subscriptions failed: ${safeErrorMessage(error)}`);
+    }
+  }
+  const missingBaselineEvents = REQUIRED_EVENTS.filter((name) => !hasEvent(name));
+  if (missingBaselineEvents.length > 0) {
+    warnings.push(`events not confirmed: ${missingBaselineEvents.join(', ')}`);
+  }
+
+  // ── Card callbacks: separate channel; switch + add + verify (fail-closed). ──
+  let callbackState: OpenPlatformCallbackState | undefined;
+  try {
+    callbackState = extractOpenPlatformCallbackState(
+      await postJson(`/developers/v1/callback/${appId}`, {}),
+    );
+  } catch (error) {
+    warnings.push(`reading callback subscriptions failed: ${safeErrorMessage(error)}`);
+  }
+  if (callbackState && callbackState.callbackMode !== LONG_CONNECTION_EVENT_MODE) {
+    try {
+      await postJson(`/developers/v1/callback/switch/${appId}`, {
+        clientId: appId,
+        callbackMode: LONG_CONNECTION_EVENT_MODE,
+      });
+      callbackState = extractOpenPlatformCallbackState(
+        await postJson(`/developers/v1/callback/${appId}`, {}),
+      );
+    } catch (error) {
+      warnings.push(`switching callbacks to long connection failed: ${safeErrorMessage(error)}`);
+    }
+  }
+  let missingCallbacks = REQUIRED_CALLBACKS.filter(
+    (name) => !callbackState?.callbacks.includes(name),
+  );
+  if (missingCallbacks.length > 0) {
+    try {
+      await postJson(
+        `/developers/v1/callback/update/${appId}`,
+        buildCallbackSubscriptionPayload(
+          appId,
+          callbackState?.callbackMode ?? LONG_CONNECTION_EVENT_MODE,
+          missingCallbacks,
+        ),
+      );
+    } catch (error) {
+      warnings.push(`subscribing card callbacks failed: ${safeErrorMessage(error)}`);
+    }
+    try {
+      callbackState = extractOpenPlatformCallbackState(
+        await postJson(`/developers/v1/callback/${appId}`, {}),
+      );
+    } catch (error) {
+      warnings.push(`re-reading callback subscriptions failed: ${safeErrorMessage(error)}`);
+    }
+    missingCallbacks = REQUIRED_CALLBACKS.filter(
+      (name) => !callbackState?.callbacks.includes(name),
+    );
+  }
+
+  const subscribedEventCount =
+    REQUIRED_EVENTS.filter((name) => hasEvent(name)).length +
+    REQUIRED_CALLBACKS.filter((name) => callbackState?.callbacks.includes(name)).length;
+  const warning = warnings.length > 0 ? warnings.join('; ') : undefined;
+
+  // Fail-closed: the two critical subscriptions and the long-connection modes.
+  const criticalIssues: string[] = [...missingBaselineEvents, ...missingCallbacks];
+  if (eventState?.eventMode !== LONG_CONNECTION_EVENT_MODE) {
+    criticalIssues.push(
+      `event mode=${eventState?.eventMode ?? 'unknown'} (need ${LONG_CONNECTION_EVENT_MODE})`,
+    );
+  }
+  if (callbackState?.callbackMode !== LONG_CONNECTION_EVENT_MODE) {
+    criticalIssues.push(
+      `callback mode=${callbackState?.callbackMode ?? 'unknown'} (need ${LONG_CONNECTION_EVENT_MODE})`,
+    );
+  }
+  if (criticalIssues.length > 0) {
+    return {
+      ok: false,
+      reason: 'event_verification_failed',
+      message:
+        `Critical subscriptions did not take effect (${criticalIssues.join('; ')}); ` +
+        'the bot would receive neither messages nor card clicks. Fix in the Open Platform ' +
+        'console (Events & Callbacks → Long connection) and re-run.',
+      ...(warning !== undefined ? { warning } : {}),
+      ...(subscribedEventCount !== undefined ? { subscribedEventCount } : {}),
+    };
+  }
+
+  if (options.publish === false) {
+    return {
+      ok: true,
+      scopeCount,
+      ...(warning !== undefined ? { warning } : {}),
+      ...(subscribedEventCount !== undefined ? { subscribedEventCount } : {}),
+    };
+  }
+
+  // ── Version publish (visibility full-overwrite protection). ──
+  try {
+    await postJson(`/developers/v1/safe_setting/update/${appId}`, buildSafeSettingPayload(appId));
+    let visibility: OnlineVisibility;
+    try {
+      visibility = parseOnlineVisibility(
+        await postJson(`/developers/v1/visible/online/${appId}`, {}),
+      );
+    } catch (error) {
+      return {
+        ok: false,
+        reason: 'visibility_unreadable',
+        message:
+          `Cannot read the app's current visibility (${safeErrorMessage(error)}); aborted the publish ` +
+          'rather than reset it. Publish the version manually in the console.',
+        ...(warning !== undefined ? { warning } : {}),
+        ...(subscribedEventCount !== undefined ? { subscribedEventCount } : {}),
+      };
+    }
+    const versionList = await postJson(`/developers/v1/app_version/list/${appId}`, {});
+    const appVersion = nextAppVersion(versionList);
+    const versionPayload = buildAppVersionCreatePayload(appVersion, visibility.visibleSuggest);
+    versionPayload.blackVisibleSuggest = visibility.blackVisibleSuggest;
+    const created = await postJson(`/developers/v1/app_version/create/${appId}`, versionPayload);
+    const versionId = extractVersionId(created);
+    if (!versionId) {
+      return {
+        ok: false,
+        reason: 'api_error',
+        message:
+          'The Open Platform created a version draft but returned no version id; publish manually.',
+        ...(warning !== undefined ? { warning } : {}),
+        ...(subscribedEventCount !== undefined ? { subscribedEventCount } : {}),
+      };
+    }
+    await postJson(`/developers/v1/publish/commit/${appId}/${versionId}`, { clientId: appId });
+    return {
+      ok: true,
+      scopeCount,
+      versionId,
+      ...(warning !== undefined ? { warning } : {}),
+      ...(subscribedEventCount !== undefined ? { subscribedEventCount } : {}),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'api_error',
+      message: `Open Platform configuration failed: ${safeErrorMessage(error)}`,
+      ...(warning !== undefined ? { warning } : {}),
+      ...(subscribedEventCount !== undefined ? { subscribedEventCount } : {}),
+    };
+  }
+}

--- a/src/setup/cookies.ts
+++ b/src/setup/cookies.ts
@@ -1,0 +1,225 @@
+/**
+ * RFC 6265 cookie jar for the Feishu Open Platform Web session. The console
+ * automation authenticates by QR login and then drives the console's internal
+ * `/developers/v1/*` APIs with the resulting cookies, so the jar must follow
+ * redirects manually (Node `fetch` `redirect: 'manual'`) and persist the
+ * `Set-Cookie` responses along the way.
+ *
+ * The flow mirrors botmux's open-platform automation
+ * (`_tmp/botmux/src/setup/open-platform-automation.ts`); the cookie semantics
+ * here are standard RFC 6265 behavior, reimplemented compactly.
+ */
+
+/** A stored cookie, as serialized to the session file. */
+export interface StoredCookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  secure: boolean;
+  httpOnly: boolean;
+  /** Host-only cookies match exactly one host; domain cookies match subdomains. */
+  hostOnly: boolean;
+  /** Milliseconds epoch; session cookies have none. */
+  expiresAt?: number;
+  sameSite?: string;
+}
+
+/** Split a raw `Set-Cookie` header into individual cookie headers. */
+export function splitSetCookieHeader(header: string | null): string[] {
+  if (!header) return [];
+  const parts: string[] = [];
+  let start = 0;
+  let inExpires = false;
+  for (let i = 0; i < header.length; i += 1) {
+    const slice = header.slice(Math.max(0, i - 8), i + 1).toLowerCase();
+    if (slice.endsWith('expires=')) inExpires = true;
+    if (inExpires && header[i] === ';') inExpires = false;
+    if (!inExpires && header[i] === ',') {
+      parts.push(header.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+  parts.push(header.slice(start).trim());
+  return parts.filter(Boolean);
+}
+
+/** Parse one `Set-Cookie` header value into a stored cookie. */
+export function parseSetCookie(responseUrl: string, header: string): StoredCookie | null {
+  const url = new URL(responseUrl);
+  const parts = header
+    .split(';')
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const first = parts.shift();
+  if (!first) return null;
+  const eq = first.indexOf('=');
+  if (eq <= 0) return null;
+  const cookie: StoredCookie = {
+    name: first.slice(0, eq),
+    value: first.slice(eq + 1),
+    domain: url.hostname,
+    path: '/',
+    secure: false,
+    httpOnly: false,
+    hostOnly: true,
+  };
+  for (const part of parts) {
+    const partEq = part.indexOf('=');
+    const key = (partEq >= 0 ? part.slice(0, partEq) : part).trim().toLowerCase();
+    const value = partEq >= 0 ? part.slice(partEq + 1).trim() : '';
+    if (key === 'domain' && value) {
+      cookie.domain = value.toLowerCase();
+      cookie.hostOnly = false;
+    } else if (key === 'path' && value) {
+      cookie.path = value;
+    } else if (key === 'secure') {
+      cookie.secure = true;
+    } else if (key === 'httponly') {
+      cookie.httpOnly = true;
+    } else if (key === 'expires' && value) {
+      const parsed = Date.parse(value);
+      if (Number.isFinite(parsed)) cookie.expiresAt = parsed;
+    } else if (key === 'max-age' && value) {
+      const seconds = Number(value);
+      if (Number.isFinite(seconds)) cookie.expiresAt = Date.now() + seconds * 1000;
+    } else if (key === 'samesite' && value) {
+      cookie.sameSite = value;
+    }
+  }
+  return cookie;
+}
+
+/** Drop expired cookies; session cookies (no expiry) survive. */
+export function pruneExpiredCookies(cookies: readonly StoredCookie[]): StoredCookie[] {
+  const now = Date.now();
+  return cookies.filter((cookie) => cookie.expiresAt === undefined || cookie.expiresAt > now);
+}
+
+function domainMatches(hostname: string, cookie: StoredCookie): boolean {
+  const host = hostname.toLowerCase();
+  const domain = cookie.domain.replace(/^\./, '').toLowerCase();
+  if (cookie.hostOnly) return host === domain;
+  return host === domain || host.endsWith(`.${domain}`);
+}
+
+function pathMatches(requestPath: string, cookiePath: string): boolean {
+  if (requestPath === cookiePath) return true;
+  if (!requestPath.startsWith(cookiePath)) return false;
+  return cookiePath.endsWith('/') || requestPath[cookiePath.length] === '/';
+}
+
+/** Build the `Cookie` header for a request URL from the jar. */
+export function getCookieHeader(cookies: readonly StoredCookie[], requestUrl: string): string {
+  const url = new URL(requestUrl);
+  return pruneExpiredCookies(cookies)
+    .filter((cookie) => {
+      if (cookie.secure && url.protocol !== 'https:') return false;
+      if (!domainMatches(url.hostname, cookie)) return false;
+      return pathMatches(url.pathname || '/', cookie.path || '/');
+    })
+    .sort((a, b) => b.path.length - a.path.length)
+    .map((cookie) => `${cookie.name}=${cookie.value}`)
+    .join('; ');
+}
+
+/** Result of a jar-managed fetch: the final response and its URL. */
+export interface JarFetchResult {
+  readonly response: Response;
+  readonly finalUrl: string;
+}
+
+const DEFAULT_BROWSER_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+  '(KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36';
+
+/**
+ * A cookie jar that follows redirects manually so every `Set-Cookie` on the
+ * way is captured, and sends the accumulated cookies on each hop.
+ */
+export class MutableCookieJar {
+  private cookies: StoredCookie[];
+
+  constructor(cookies: readonly StoredCookie[] = []) {
+    this.cookies = pruneExpiredCookies(cookies);
+  }
+
+  /** Snapshot of the jar for persistence. */
+  toJSON(): StoredCookie[] {
+    this.cookies = pruneExpiredCookies(this.cookies);
+    return this.cookies.map((cookie) => ({ ...cookie }));
+  }
+
+  /** GET a URL and return its final text. */
+  async fetchText(fetcher: typeof fetch, url: string): Promise<string> {
+    const result = await this.fetchRaw(fetcher, url, { method: 'GET' });
+    return await result.response.text();
+  }
+
+  /** GET a URL and return its final text plus the final URL (post-redirects). */
+  async fetchTextWithUrl(
+    fetcher: typeof fetch,
+    url: string,
+  ): Promise<{ text: string; finalUrl: string }> {
+    const result = await this.fetchRaw(fetcher, url, { method: 'GET' });
+    return { text: await result.response.text(), finalUrl: result.finalUrl };
+  }
+
+  /**
+   * Fetch one URL, following redirects manually while accumulating cookies.
+   * @param fetcher - injectable fetch (defaults are passed by the caller).
+   * @param url - request URL.
+   * @param init - request options; `redirect` is forced to `manual`.
+   * @param maxHops - redirect cap (default 10).
+   */
+  async fetchRaw(
+    fetcher: typeof fetch,
+    url: string,
+    init: RequestInit = {},
+    maxHops = 10,
+  ): Promise<JarFetchResult> {
+    let current = url;
+    let referer: string | undefined;
+    for (let hop = 0; hop <= maxHops; hop += 1) {
+      const headers = new Headers(init.headers);
+      const cookieHeader = getCookieHeader(this.cookies, current);
+      if (cookieHeader) headers.set('cookie', cookieHeader);
+      headers.set('user-agent', headers.get('user-agent') ?? DEFAULT_BROWSER_USER_AGENT);
+      if (referer && !headers.has('referer')) headers.set('referer', referer);
+
+      const response = await fetcher(current, { ...init, headers, redirect: 'manual' });
+      this.loadFromResponse(current, response.headers);
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get('location');
+        if (!location) return { response, finalUrl: current };
+        referer = current;
+        current = new URL(location, current).toString();
+        continue;
+      }
+      return { response, finalUrl: current };
+    }
+    throw new Error('Too many redirects while accessing the Feishu Open Platform');
+  }
+
+  private loadFromResponse(responseUrl: string, headers: Headers): void {
+    const rawSetCookies =
+      typeof headers.getSetCookie === 'function'
+        ? headers.getSetCookie()
+        : splitSetCookieHeader(headers.get('set-cookie'));
+    for (const raw of rawSetCookies) {
+      const cookie = parseSetCookie(responseUrl, raw);
+      if (!cookie) continue;
+      const idx = this.cookies.findIndex(
+        (item) =>
+          item.name === cookie.name && item.domain === cookie.domain && item.path === cookie.path,
+      );
+      if (cookie.expiresAt !== undefined && cookie.expiresAt <= Date.now()) {
+        if (idx >= 0) this.cookies.splice(idx, 1);
+        continue;
+      }
+      if (idx >= 0) this.cookies[idx] = cookie;
+      else this.cookies.push(cookie);
+    }
+    this.cookies = pruneExpiredCookies(this.cookies);
+  }
+}

--- a/src/setup/create-app.ts
+++ b/src/setup/create-app.ts
@@ -1,0 +1,272 @@
+/**
+ * Create a Feishu self-built app from the console session and return its
+ * credentials. The preferred path uses the console launcher's manifest
+ * template (the app is born with bot capability, long connection, and base
+ * event subscriptions); a definite rejection falls back to the bare
+ * `app/create` endpoint. Configuration (scopes, events, callbacks) runs
+ * through the shared configure flow, then a single version is published with
+ * the creator's visibility so the app auto-enables. Mirrors botmux's
+ * `createOpenPlatformAppWithClient`
+ * (`_tmp/botmux/src/setup/open-platform-automation.ts`).
+ */
+
+import { deflateSync } from 'node:zlib';
+import { type OpenPlatformApiClient, OpenPlatformApiError } from './client.js';
+import { configureFeishuApp } from './configure.js';
+import { LONG_CONNECTION_EVENT_MODE } from './manifest.js';
+import {
+  buildAppVersionCreatePayload,
+  buildManifestTemplateCreatePayload,
+  extractVersionId,
+  fetchOpenPlatformAppSecret,
+  ONECLICK_APP_MANIFEST_TEMPLATE_ID,
+} from './payloads.js';
+
+/** Result of app creation. */
+export interface CreateAppResult {
+  readonly ok: boolean;
+  readonly appId?: string;
+  readonly appSecret?: string;
+  readonly reason?: 'api_error' | 'missing_avatar' | 'event_verification_failed';
+  readonly message?: string;
+}
+
+function safeErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.replace(/[A-Za-z0-9_=-]{24,}/g, '***');
+}
+
+// ── Minimal PNG encoder (solid-color icon, no image dependency). ────────────
+
+function crc32(buffer: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of buffer) {
+    crc ^= byte;
+    for (let i = 0; i < 8; i += 1) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type: string, data: Buffer): Buffer {
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length, 0);
+  const typeAndData = Buffer.concat([Buffer.from(type, 'ascii'), data]);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(typeAndData), 0);
+  return Buffer.concat([length, typeAndData, crc]);
+}
+
+/** Build a solid-color RGBA PNG of the given size (used as the app icon). */
+export function makePlaceholderIconPng(
+  size = 64,
+  rgb: readonly [number, number, number] = [22, 119, 255],
+): Buffer {
+  const signature = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(size, 0);
+  ihdr.writeUInt32BE(size, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 6; // color type RGBA
+  const row = Buffer.alloc(1 + size * 4);
+  for (let x = 0; x < size; x += 1) {
+    row[1 + x * 4] = rgb[0];
+    row[2 + x * 4] = rgb[1];
+    row[3 + x * 4] = rgb[2];
+    row[4 + x * 4] = 255;
+  }
+  const scanlines = Buffer.concat(Array.from({ length: size }, () => row));
+  const idat = deflateSync(scanlines, { level: 9 });
+  return Buffer.concat([
+    signature,
+    pngChunk('IHDR', ihdr),
+    pngChunk('IDAT', idat),
+    pngChunk('IEND', Buffer.alloc(0)),
+  ]);
+}
+
+// ── App creation flow. ──────────────────────────────────────────────────────
+
+/** True when the template endpoint definitively rejected (safe to fall back). */
+function isDefiniteTemplateRejection(error: unknown): boolean {
+  if (!(error instanceof OpenPlatformApiError)) return false;
+  const payload = error.payload as { code?: unknown } | null;
+  if (typeof payload?.code === 'number' && payload.code !== 0) return true;
+  return /^HTTP 404\b/.test(error.message);
+}
+
+function pickPayloadString(payload: unknown, keys: readonly string[]): string | undefined {
+  const record =
+    payload && typeof payload === 'object' && !Array.isArray(payload)
+      ? (payload as Record<string, unknown>)
+      : {};
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value) return value;
+  }
+  const data = record.data;
+  if (data && typeof data === 'object' && !Array.isArray(data)) {
+    return pickPayloadString(data, keys);
+  }
+  return undefined;
+}
+
+/**
+ * Create an app end to end: upload an icon, create via the template (falling
+ * back to `app/create` on a definite rejection), configure through
+ * {@link configureFeishuApp}, publish the first version with the creator's
+ * visibility, and read back the secret.
+ *
+ * @param client - authenticated console client.
+ * @param options - name, description, and the creator's user id (the first
+ *   version must be visible to the creator or the app will not auto-enable).
+ */
+export async function createFeishuOpenPlatformApp(
+  client: OpenPlatformApiClient,
+  options: { name: string; description?: string; creatorUserId: string },
+): Promise<CreateAppResult> {
+  const name = options.name.trim();
+  if (!name) {
+    return { ok: false, reason: 'api_error', message: 'The app name must not be empty' };
+  }
+  if (!options.creatorUserId) {
+    return {
+      ok: false,
+      reason: 'api_error',
+      message: 'Missing creator user id; cannot enable the app on publish',
+    };
+  }
+  const description = options.description?.trim() || 'A dsh agent surface on Feishu.';
+
+  // Upload a placeholder icon (the create endpoints require an avatar url).
+  let avatar: string | undefined;
+  try {
+    const form = new FormData();
+    form.append(
+      'file',
+      new Blob([makePlaceholderIconPng()], { type: 'image/png' }),
+      'dsh-feishu.png',
+    );
+    form.append('uploadType', '4'); // console enum: Icon
+    form.append('isIsv', 'false'); // self-built app
+    form.append('scale', JSON.stringify({ width: 64, height: 64 }));
+    const uploaded = await client.postForm('/developers/v1/app/upload/image', form);
+    avatar = pickPayloadString(uploaded, ['url']);
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'api_error',
+      message: `Uploading the app icon failed: ${safeErrorMessage(error)}`,
+    };
+  }
+  if (!avatar) {
+    return {
+      ok: false,
+      reason: 'missing_avatar',
+      message: 'The Open Platform did not return an icon url',
+    };
+  }
+
+  // Create the app; fall back to the bare endpoint on a definite rejection.
+  let appId: string | undefined;
+  try {
+    const created = await client.postJson(
+      '/developers/v1/manifest/upsert_by_template',
+      buildManifestTemplateCreatePayload(name, description, avatar, crypto.randomUUID()),
+    );
+    const templateAppId = pickPayloadString(created, ['ClientID', 'clientID', 'clientId', 'appId']);
+    if (!templateAppId?.startsWith('cli_')) {
+      throw new Error('template creation returned success without a ClientID (result unknown)');
+    }
+    appId = templateAppId;
+  } catch (error) {
+    if (!isDefiniteTemplateRejection(error)) {
+      return {
+        ok: false,
+        reason: 'api_error',
+        message:
+          `Template app creation failed with an unknown result (${safeErrorMessage(error)}); ` +
+          'check the console for a duplicate app before retrying.',
+      };
+    }
+    try {
+      const created = await client.postJson('/developers/v1/app/create', {
+        appSceneType: 0,
+        name,
+        desc: description,
+        avatar,
+        i18n: { zh_cn: { name, description } },
+        primaryLang: 'zh_cn',
+      });
+      appId = pickPayloadString(created, ['ClientID', 'clientID', 'clientId', 'appId']);
+    } catch (fallbackError) {
+      return {
+        ok: false,
+        reason: 'api_error',
+        message: `Creating the app failed: ${safeErrorMessage(fallbackError)}`,
+      };
+    }
+  }
+  if (!appId?.startsWith('cli_')) {
+    return {
+      ok: false,
+      reason: 'api_error',
+      message: 'The Open Platform did not return a ClientID',
+    };
+  }
+
+  // Configure (scopes, events, callbacks, safe settings) without publishing,
+  // then publish ONE version with the creator visible (auto-enables the app).
+  try {
+    await client.postJson(`/developers/v1/robot/switch/${appId}`, {
+      clientId: appId,
+      enable: true,
+    });
+    await client.postJson(`/developers/v1/event/switch/${appId}`, {
+      clientId: appId,
+      eventMode: LONG_CONNECTION_EVENT_MODE,
+    });
+    const configured = await configureFeishuApp(client, appId, { publish: false });
+    if (!configured.ok) {
+      const reason: 'api_error' | 'event_verification_failed' =
+        configured.reason === 'event_verification_failed'
+          ? 'event_verification_failed'
+          : 'api_error';
+      return { ok: false, reason, message: configured.message ?? 'Configuration failed', appId };
+    }
+    const versionCreated = await client.postJson(
+      `/developers/v1/app_version/create/${appId}`,
+      buildAppVersionCreatePayload('1.0.0', {
+        departments: [],
+        members: [options.creatorUserId],
+        groups: [],
+        isAll: 0,
+      }),
+    );
+    const versionId = extractVersionId(versionCreated);
+    if (!versionId) {
+      return {
+        ok: false,
+        reason: 'api_error',
+        message:
+          'The enable version was created without a version id (a draft may remain); check the console.',
+        appId,
+      };
+    }
+    await client.postJson(`/developers/v1/publish/commit/${appId}/${versionId}`, {
+      clientId: appId,
+    });
+    const appSecret = await fetchOpenPlatformAppSecret(client, appId);
+    return { ok: true, appId, appSecret };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'api_error',
+      message: `Configuring the new app failed: ${safeErrorMessage(error)}`,
+      appId,
+    };
+  }
+}
+
+export { ONECLICK_APP_MANIFEST_TEMPLATE_ID };

--- a/src/setup/feishu-manifest.json
+++ b/src/setup/feishu-manifest.json
@@ -1,0 +1,7 @@
+{
+  "appEvents": ["im.message.receive_v1"],
+  "cardCallbacks": ["card.action.trigger"],
+  "longConnectionMode": 4,
+  "scopes": ["im:message", "im:message:send_as_bot", "im:chat", "im:resource"],
+  "defaultAppName": "DSH Agent (dsh-feishu)"
+}

--- a/src/setup/manifest.ts
+++ b/src/setup/manifest.ts
@@ -1,0 +1,36 @@
+/**
+ * The Feishu app surface manifest — the single source of truth for what the
+ * surface needs from the Open Platform. The quick-setup automation
+ * (`src/setup/*`), its manual fallback, and `docs/feishu-setup.md` all derive
+ * from `feishu-manifest.json`.
+ *
+ * ⚠️ KEEP IN SYNC: any feature that needs a new Feishu scope, event, or card
+ * callback must update `feishu-manifest.json` in the SAME change (see
+ * AGENTS.md → "Feishu permissions manifest"). The setup tool grants exactly
+ * what this file lists — an unlisted scope is a bot that cannot do the
+ * feature.
+ */
+
+import feishuManifest from './feishu-manifest.json' with { type: 'json' };
+
+/** Feishu console receive-mode value for the WebSocket long connection. */
+export const LONG_CONNECTION_EVENT_MODE = feishuManifest.longConnectionMode;
+
+/** Event (not callback) types the surface consumes via `im.message.receive_v1`. */
+export const APP_EVENTS = feishuManifest.appEvents as readonly string[];
+
+/**
+ * Card callback types the surface consumes. The Open Platform treats card
+ * button presses as callbacks configured separately from events; missing
+ * `card.action.trigger` makes every button dead ("该应用尚未配置卡片回调").
+ */
+export const CARD_CALLBACKS = feishuManifest.cardCallbacks as readonly string[];
+
+/** Permission scopes the surface needs (console: 权限管理). */
+export const SCOPES = feishuManifest.scopes as readonly string[];
+
+/** Default name for an app created by the setup tool. */
+export const DEFAULT_APP_NAME = feishuManifest.defaultAppName;
+
+/** The raw manifest object (as committed). */
+export const FEISHU_MANIFEST = feishuManifest;

--- a/src/setup/payloads.ts
+++ b/src/setup/payloads.ts
@@ -1,0 +1,439 @@
+/**
+ * Payload builders and response extractors for the Open Platform console's
+ * `/developers/v1/*` internal APIs, mirroring the console frontend and
+ * botmux's open-platform automation. Each builder/extractor is pure and unit
+ * tested; the automation flows in `configure.ts` / `create-app.ts` call them.
+ */
+
+import type { OpenPlatformApiClient } from './client.js';
+import { APP_EVENTS, CARD_CALLBACKS, LONG_CONNECTION_EVENT_MODE } from './manifest.js';
+
+/** Console app-catalog template id for the "one-click agent" launcher. */
+export const ONECLICK_APP_MANIFEST_TEMPLATE_ID = 'developer_console';
+
+/** Build the scope-update payload (console `updateScope`). */
+export function buildScopeUpdatePayload(
+  appId: string,
+  mapped: { tenantScopeIds: readonly string[]; userScopeIds: readonly string[] },
+): Record<string, unknown> {
+  return {
+    clientId: appId,
+    appScopeIDs: mapped.tenantScopeIds,
+    userScopeIDs: mapped.userScopeIds,
+    scopeIds: [],
+    operation: 'add',
+    isDeveloperPanel: true,
+  };
+}
+
+/** Build the safe-settings payload (empty redirect whitelist = unrestricted). */
+export function buildSafeSettingPayload(appId: string): Record<string, unknown> {
+  return { clientId: appId, redirectURL: [] };
+}
+
+/** Build the incremental event-subscription payload (console `updateEvent`). */
+export function buildEventSubscriptionPayload(
+  appId: string,
+  eventMode: number,
+  appEvents: readonly string[],
+  userEvents: readonly string[] = [],
+  events: readonly string[] = [],
+): Record<string, unknown> {
+  return {
+    clientId: appId,
+    operation: 'add',
+    events,
+    appEvents,
+    userEvents,
+    eventMode,
+  };
+}
+
+/** Build the incremental callback-subscription payload (console `updateCallback`). */
+export function buildCallbackSubscriptionPayload(
+  appId: string,
+  callbackMode: number,
+  callbacks: readonly string[],
+): Record<string, unknown> {
+  return {
+    clientId: appId,
+    operation: 'add',
+    callbacks,
+    callbackMode,
+  };
+}
+
+/** Build the manifest-template create payload (console "one-click" launcher). */
+export function buildManifestTemplateCreatePayload(
+  name: string,
+  description: string,
+  avatar: string,
+  cid: string,
+): Record<string, unknown> {
+  return {
+    appManifestTemplateID: ONECLICK_APP_MANIFEST_TEMPLATE_ID,
+    createAppUserCustomField: {
+      i18n: { zh_cn: { name, description } },
+      avatar,
+      primaryLang: 'zh_cn',
+    },
+    cid,
+    HTTPHead: {},
+  };
+}
+
+/**
+ * Build the app-version create payload. `visibleSuggest` is FULL-OVERWRITE:
+ * for an existing app the caller must read the online visibility
+ * (`/developers/v1/visible/online`) and pass it through; for a brand-new app
+ * pass the creator's member id so the version auto-enables on publish.
+ */
+export function buildAppVersionCreatePayload(
+  appVersion: string,
+  visibleSuggest: {
+    departments: readonly string[];
+    members: readonly string[];
+    groups: readonly string[];
+    isAll: number;
+  },
+): Record<string, unknown> {
+  return {
+    appVersion,
+    mobileDefaultAbility: 'bot',
+    pcDefaultAbility: 'bot',
+    changeLog: 'Initial bot release.',
+    visibleSuggest: {
+      departments: [...visibleSuggest.departments],
+      members: [...visibleSuggest.members],
+      groups: [...visibleSuggest.groups],
+      isAll: visibleSuggest.isAll,
+    },
+    blackVisibleSuggest: {
+      departments: [],
+      members: [],
+      groups: [],
+      isAll: 0,
+    },
+  };
+}
+
+/** Visibility structure as read back from `/developers/v1/visible/online`. */
+export interface OnlineVisibility {
+  readonly visibleSuggest: {
+    departments: readonly string[];
+    members: readonly string[];
+    groups: readonly string[];
+    isAll: number;
+  };
+  readonly blackVisibleSuggest: {
+    departments: readonly string[];
+    members: readonly string[];
+    groups: readonly string[];
+    isAll: number;
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function pickString(record: Record<string, unknown>, keys: readonly string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value) return value;
+    if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  }
+  return undefined;
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return [
+    ...new Set(
+      values.filter((value): value is string => typeof value === 'string' && value !== ''),
+    ),
+  ];
+}
+
+function asVisibilityGroup(value: unknown): {
+  departments: string[];
+  members: string[];
+  groups: string[];
+  isAll: number;
+} {
+  const record = asRecord(value);
+  const stringArray = (key: string): string[] => {
+    const raw = record[key];
+    return Array.isArray(raw) ? raw.filter((item): item is string => typeof item === 'string') : [];
+  };
+  const isAll = typeof record.isAll === 'number' ? record.isAll : 0;
+  return {
+    departments: stringArray('departments'),
+    members: stringArray('members'),
+    groups: stringArray('groups'),
+    isAll,
+  };
+}
+
+/**
+ * Parse the online-visibility payload. Fails loud (throws) when the shape is
+ * unexpected: the caller must never publish a version that silently resets
+ * the visibility of an existing app.
+ */
+export function parseOnlineVisibility(payload: unknown): OnlineVisibility {
+  const data = asRecord(asRecord(payload).data);
+  const visible = asVisibilityGroup(data.visibleSuggest ?? data.visible_suggest);
+  const black = asVisibilityGroup(data.blackVisibleSuggest ?? data.black_visible_suggest);
+  if (
+    visible.departments.length === 0 &&
+    visible.members.length === 0 &&
+    visible.groups.length === 0 &&
+    !Object.hasOwn(data, 'visibleSuggest') &&
+    !Object.hasOwn(data, 'visible_suggest')
+  ) {
+    throw new Error('visibility payload missing visibleSuggest');
+  }
+  return {
+    visibleSuggest: visible,
+    blackVisibleSuggest: black,
+  };
+}
+
+/** Event-subscription state as read back from `/developers/v1/event/:appId`. */
+export interface OpenPlatformEventState {
+  readonly eventMode?: number;
+  /** All subscribed events (generic + app/user buckets). */
+  readonly events: string[];
+  readonly appEvents: string[];
+  readonly userEvents: string[];
+}
+
+/** Callback-subscription state as read back from `/developers/v1/callback/:appId`. */
+export interface OpenPlatformCallbackState {
+  readonly callbackMode?: number;
+  readonly callbacks: string[];
+}
+
+function extractEventIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return uniqueStrings(
+    value
+      .map((item) => (typeof item === 'string' ? item : pickString(asRecord(item), ['id'])))
+      .filter((item): item is string => item !== undefined),
+  );
+}
+
+function extractEventIdsFromDetails(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return uniqueStrings(value.flatMap((group) => extractEventIds(asRecord(group).items)));
+}
+
+/** Parse the event-state payload (console `getEvent`). */
+export function extractOpenPlatformEventState(payload: unknown): OpenPlatformEventState {
+  const root = asRecord(payload);
+  const wrapped = asRecord(root.data);
+  const data = Object.keys(wrapped).length > 0 ? wrapped : root;
+  const appEvents = uniqueStrings([
+    ...extractEventIds(data.appEvents),
+    ...extractEventIdsFromDetails(data.appEventDetails),
+  ]);
+  const userEvents = uniqueStrings([
+    ...extractEventIds(data.userEvents),
+    ...extractEventIdsFromDetails(data.userEventDetails),
+  ]);
+  const genericEvents = uniqueStrings([
+    ...extractEventIds(data.events),
+    ...extractEventIdsFromDetails(data.eventDetails),
+  ]);
+  const eventMode =
+    typeof data.eventMode === 'number' && Number.isFinite(data.eventMode)
+      ? data.eventMode
+      : undefined;
+  return {
+    ...(eventMode !== undefined ? { eventMode } : {}),
+    events: uniqueStrings([...genericEvents, ...appEvents, ...userEvents]),
+    appEvents,
+    userEvents,
+  };
+}
+
+/** Parse the callback-state payload (console `getCallback`). */
+export function extractOpenPlatformCallbackState(payload: unknown): OpenPlatformCallbackState {
+  const root = asRecord(payload);
+  const wrapped = asRecord(root.data);
+  const data = Object.keys(wrapped).length > 0 ? wrapped : root;
+  const callbackMode =
+    typeof data.callbackMode === 'number' && Number.isFinite(data.callbackMode)
+      ? data.callbackMode
+      : undefined;
+  return {
+    ...(callbackMode !== undefined ? { callbackMode } : {}),
+    callbacks: extractEventIds(data.callbacks),
+  };
+}
+
+/** A scope entry from the console catalog. */
+export interface OpenPlatformScopeEntry {
+  readonly id: string;
+  readonly name?: string;
+  readonly bucket?: 'tenant' | 'user';
+}
+
+function collectScopeEntries(
+  value: unknown,
+  bucket: 'tenant' | 'user' | undefined,
+  out: OpenPlatformScopeEntry[],
+): void {
+  if (Array.isArray(value)) {
+    for (const item of value) collectScopeEntries(item, bucket, out);
+    return;
+  }
+  const record = asRecord(value);
+  const id = pickString(record, ['scope_id', 'scopeId', 'id']);
+  if (id)
+    out.push({
+      id,
+      ...(typeof record.name === 'string' ? { name: record.name } : {}),
+      ...(bucket ? { bucket } : {}),
+    });
+  if (record.data) collectScopeEntries(record.data, bucket, out);
+  if (record.tenant) collectScopeEntries(record.tenant, 'tenant', out);
+  if (record.user) collectScopeEntries(record.user, 'user', out);
+  if (record.scopes) collectScopeEntries(record.scopes, bucket, out);
+  if (record.list) collectScopeEntries(record.list, bucket, out);
+}
+
+/** Extract the deduplicated scope catalog from `/developers/v1/scope/all/:appId`. */
+export function extractOpenPlatformScopeEntries(payload: unknown): OpenPlatformScopeEntry[] {
+  const out: OpenPlatformScopeEntry[] = [];
+  collectScopeEntries(payload, undefined, out);
+  const seen = new Set<string>();
+  return out.filter((entry) => {
+    const key = `${entry.bucket ?? 'any'}:${entry.id}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+/** Map manifest scope names to catalog ids; names absent from the catalog are reported. */
+export function mapManifestScopesToOpenPlatformIds(
+  scopes: readonly string[],
+  catalog: readonly OpenPlatformScopeEntry[],
+): { tenantScopeIds: string[]; userScopeIds: string[]; missing: string[] } {
+  const tenant = scopes.filter((scope) => scope.startsWith('im:'));
+  const user = scopes.filter((scope) => !scope.startsWith('im:'));
+  const idsFor = (names: readonly string[], bucket: 'tenant' | 'user'): string[] =>
+    names
+      .map(
+        (name) =>
+          catalog.find(
+            (entry) => entry.bucket === bucket && (entry.id === name || entry.name === name),
+          )?.id,
+      )
+      .filter((id): id is string => id !== undefined);
+  const found = new Set<string>([...idsFor(tenant, 'tenant'), ...idsFor(user, 'user')]);
+  return {
+    tenantScopeIds: idsFor(tenant, 'tenant'),
+    userScopeIds: idsFor(user, 'user'),
+    missing: scopes.filter((scope) => !found.has(scope)),
+  };
+}
+
+/** Compute the next patch version (max existing triple + 1); includes drafts. */
+export function nextAppVersion(payload: unknown): string {
+  const data = asRecord(asRecord(payload).data);
+  const versions = Array.isArray(data.versions) ? data.versions : [];
+  const triples = versions
+    .map((item) => pickString(asRecord(item), ['appVersion']))
+    .filter((version): version is string => version !== undefined)
+    .map((version) => version.split('.').map((part) => Number.parseInt(part, 10)))
+    .filter((parts) => parts.length === 3 && parts.every((part) => Number.isFinite(part)));
+  if (triples.length === 0) return '0.0.1';
+  const max = triples.reduce((a, b) => {
+    for (let i = 0; i < 3; i += 1) {
+      const aPart = a[i] ?? 0;
+      const bPart = b[i] ?? 0;
+      if (bPart !== aPart) return bPart > aPart ? b : a;
+    }
+    return a;
+  });
+  return [max[0] ?? 0, max[1] ?? 0, (max[2] ?? 0) + 1].join('.');
+}
+
+/** Extract the version id from `app_version/create` (several response shapes). */
+export function extractVersionId(payload: unknown): string | undefined {
+  const direct = pickString(asRecord(payload), ['versionId', 'version_id', 'id']);
+  if (direct) return direct;
+  const data = asRecord(asRecord(payload).data);
+  return (
+    pickString(data, ['versionId', 'version_id', 'id']) ??
+    pickString(asRecord(data.appVersion), ['versionId', 'version_id', 'id'])
+  );
+}
+
+/** A self-built app listed by `/developers/v1/app/list`. */
+export interface OpenPlatformAppSummary {
+  readonly clientId: string;
+  readonly name: string;
+  readonly description?: string;
+}
+
+/** List apps visible to the current session (console `getAppList`). */
+export async function listOpenPlatformApps(
+  client: OpenPlatformApiClient,
+  options: { pageSize?: number; maxApps?: number } = {},
+): Promise<OpenPlatformAppSummary[]> {
+  const pageSize = options.pageSize ?? 100;
+  const maxApps = options.maxApps ?? 500;
+  const out: OpenPlatformAppSummary[] = [];
+  for (let cursor = 0; cursor < maxApps; cursor += pageSize) {
+    const payload = await client.postJson('/developers/v1/app/list', {
+      Count: pageSize,
+      Cursor: cursor,
+      QueryFilter: {},
+    });
+    const record = asRecord(payload);
+    const data = asRecord(record.data);
+    const apps = Array.isArray(data.apps)
+      ? data.apps
+      : Array.isArray(record.apps)
+        ? (record.apps as unknown[])
+        : [];
+    for (const item of apps) {
+      const rec = asRecord(item);
+      const clientId = pickString(rec, ['clientId', 'client_id', 'appId', 'app_id', 'appID']);
+      if (!clientId?.startsWith('cli_')) continue;
+      const name = pickString(rec, ['name', 'appName', 'app_name']) ?? clientId;
+      const description = pickString(rec, ['description', 'desc', 'appDesc', 'app_desc']);
+      out.push({ clientId, name, ...(description ? { description } : {}) });
+    }
+    const totalCount =
+      typeof data.totalCount === 'number'
+        ? data.totalCount
+        : typeof record.totalCount === 'number'
+          ? (record.totalCount as number)
+          : undefined;
+    if (apps.length < pageSize) break;
+    if (totalCount !== undefined && cursor + pageSize >= totalCount) break;
+  }
+  return out;
+}
+
+/** Read an app's secret (read-only; never hits the reset endpoints). */
+export async function fetchOpenPlatformAppSecret(
+  client: OpenPlatformApiClient,
+  clientId: string,
+): Promise<string> {
+  const payload = await client.postJson(`/developers/v1/secret/${clientId}`, {});
+  const record = asRecord(payload);
+  const secret = pickString(asRecord(record.data), ['secret']) ?? pickString(record, ['secret']);
+  if (!secret) throw new Error('The Open Platform did not return a secret field');
+  return secret;
+}
+
+/** The surface's required subscriptions; used by the fail-closed check. */
+export const REQUIRED_EVENTS = APP_EVENTS;
+export const REQUIRED_CALLBACKS = CARD_CALLBACKS;
+export { LONG_CONNECTION_EVENT_MODE };

--- a/src/setup/profile-writer.ts
+++ b/src/setup/profile-writer.ts
@@ -1,0 +1,103 @@
+/**
+ * Write the Feishu credentials into a dsh profile's `cordis.patch.yml` so the
+ * surface boots configured. The patch file is a YAML list of rows
+ * (`- id: … / name: … / config: …`); the `feishu` row's `config.appId` /
+ * `config.appSecret` are updated idempotently, the row is created when
+ * missing, and the original file is backed up before any change.
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { dump, load } from 'js-yaml';
+
+/** Resolve the dsh home: `$DSH_HOME`, else `~/.dsh`. */
+export function dshHome(env = process.env): string {
+  const override = env.DSH_HOME;
+  if (override && override !== '') return override;
+  return join(homedir(), '.dsh');
+}
+
+/** The `cordis.patch.yml` path for a profile under a dsh home. */
+export function profilePatchPath(dshHomeDir: string, profileName: string): string {
+  return join(dshHomeDir, 'profiles', profileName, 'cordis.patch.yml');
+}
+
+/** Credentials to write. */
+export interface ProfileCredentials {
+  readonly appId: string;
+  readonly appSecret: string;
+}
+
+export interface WriteProfileResult {
+  readonly changed: boolean;
+  readonly path: string;
+  readonly backupPath?: string;
+}
+
+type PatchRow = Record<string, unknown> & { id?: unknown };
+
+/** Load a patch file as a row list; an empty/missing file is an empty list. */
+export function loadPatchRows(filePath: string): PatchRow[] {
+  if (!existsSync(filePath)) return [];
+  const parsed = load(readFileSync(filePath, 'utf8'));
+  if (parsed === undefined || parsed === null) return [];
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${filePath} is not a YAML list (profile patch must be a list of rows)`);
+  }
+  return parsed as PatchRow[];
+}
+
+/**
+ * Update the `feishu` row of a patch row list with the given config values.
+ * @returns a new array when changed, the same array when already present.
+ */
+export function upsertFeishuConfig(rows: PatchRow[], credentials: ProfileCredentials): PatchRow[] {
+  const feishu = rows.find((row) => row.id === 'feishu');
+  if (feishu) {
+    const config = (feishu.config ?? {}) as Record<string, unknown>;
+    if (config.appId === credentials.appId && config.appSecret === credentials.appSecret) {
+      return rows;
+    }
+    return rows.map((row) =>
+      row.id === 'feishu'
+        ? {
+            ...row,
+            config: { ...config, appId: credentials.appId, appSecret: credentials.appSecret },
+          }
+        : row,
+    );
+  }
+  return [
+    ...rows,
+    {
+      id: 'feishu',
+      name: '@dsh-feishu/dsh-feishu',
+      config: { appId: credentials.appId, appSecret: credentials.appSecret },
+    },
+  ];
+}
+
+/**
+ * Write credentials into a profile's patch file (with a `.bak` backup).
+ * @returns whether the file changed and the backup path (when one was made).
+ */
+export function writeProfileCredentials(
+  dshHomeDir: string,
+  profileName: string,
+  credentials: ProfileCredentials,
+): WriteProfileResult {
+  const path = profilePatchPath(dshHomeDir, profileName);
+  const rows = loadPatchRows(path);
+  const updated = upsertFeishuConfig(rows, credentials);
+  if (updated === rows) {
+    return { changed: false, path };
+  }
+  const backupPath = `${path}.bak`;
+  if (existsSync(path)) {
+    renameSync(path, backupPath);
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, dump(updated, { lineWidth: 100 }), 'utf8');
+  return { changed: true, path, backupPath };
+}

--- a/src/setup/qr-login.ts
+++ b/src/setup/qr-login.ts
@@ -1,0 +1,251 @@
+/**
+ * Feishu Web QR login: initialize `/accounts/qrlogin/init`, render the QR in
+ * the terminal, poll `/accounts/qrlogin/polling` until the scan completes,
+ * follow the cross-login redirect, and return the resulting cookie jar.
+ * Mirrors botmux's `loginFeishuWebSession`
+ * (`_tmp/botmux/src/setup/open-platform-automation.ts`).
+ */
+
+import qrcode from 'qrcode-terminal';
+import { MutableCookieJar, type StoredCookie } from './cookies.js';
+
+const FEISHU_ACCOUNTS_ORIGIN = 'https://accounts.feishu.cn';
+const FEISHU_APP_ID = '12';
+const FEISHU_COMMON_HEADERS = {
+  'x-api-version': '1.0.28',
+  'x-device-info':
+    'device_id=0;device_name=Chrome;device_os=Mac;device_model=Chrome;lark_version=;' +
+    'channel=Release;package_name=feishu;tt_app_id=1658;is_dpop_support=true;is_iframe=false',
+};
+
+/** Terminal QR input payload: the console renders `{qrlogin:{token}}`. */
+export function buildFeishuQrPayload(token: string): string {
+  return JSON.stringify({ qrlogin: { token } });
+}
+
+/** Human text for a QR polling status code. */
+export function mapFeishuQrPollingStatus(status: number | null): string {
+  if (status === 2) return 'scanned — confirm on your phone';
+  if (status === 5) return 'QR code expired';
+  return 'waiting for the Feishu scan';
+}
+
+/** Login-flow outcomes for error classification. */
+export type FeishuLoginFailureReason =
+  | 'login_failed'
+  | 'qr_expired'
+  | 'timeout'
+  | 'network'
+  | 'invalid_session';
+
+class FeishuWebSessionError extends Error {
+  constructor(
+    message: string,
+    readonly reason: FeishuLoginFailureReason,
+  ) {
+    super(message);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function pickString(record: Record<string, unknown>, keys: readonly string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value) return value;
+  }
+  return undefined;
+}
+
+function assertFeishuApiOk(payload: unknown, message: string): void {
+  const record = asRecord(payload);
+  if (record.code === 0) return;
+  const msg = pickString(record, ['message', 'msg']) ?? 'unknown error';
+  throw new FeishuWebSessionError(`${message}: ${msg}`, 'login_failed');
+}
+
+interface QrInitResult {
+  flowKey: string;
+  token: string;
+}
+
+async function initFeishuQrLogin(
+  session: MutableCookieJar,
+  fetcher: typeof fetch,
+  authorizeUrl: string,
+): Promise<QrInitResult> {
+  const endpoint =
+    `${FEISHU_ACCOUNTS_ORIGIN}/accounts/qrlogin/init` +
+    `?_r${10000 + Math.floor(Math.random() * 80000)}=${Date.now()}`;
+  const { response } = await session.fetchRaw(fetcher, endpoint, {
+    method: 'POST',
+    headers: {
+      ...FEISHU_COMMON_HEADERS,
+      'x-app-id': FEISHU_APP_ID,
+      accept: 'application/json',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ biz_type: null, redirect_uri: authorizeUrl }),
+  });
+  const data = (await response.json()) as unknown;
+  assertFeishuApiOk(data, 'Feishu QR init failed');
+  const stepInfo = asRecord(asRecord(asRecord(data).data).step_info);
+  const token = pickString(stepInfo, ['token']);
+  const flowKey = response.headers.get('x-flow-key') ?? '';
+  if (!flowKey || !token) {
+    throw new FeishuWebSessionError('Feishu QR init missing flow key or token', 'login_failed');
+  }
+  return { flowKey, token };
+}
+
+interface QrPollResult {
+  nextStep: string | null;
+  status: number | null;
+  crossLoginUri: string | null;
+}
+
+async function pollFeishuQrLogin(
+  session: MutableCookieJar,
+  fetcher: typeof fetch,
+  flowKey: string,
+): Promise<QrPollResult> {
+  const endpoint =
+    `${FEISHU_ACCOUNTS_ORIGIN}/accounts/qrlogin/polling` +
+    `?_r${10000 + Math.floor(Math.random() * 80000)}=${Date.now()}`;
+  const { response } = await session.fetchRaw(fetcher, endpoint, {
+    method: 'POST',
+    headers: {
+      ...FEISHU_COMMON_HEADERS,
+      'x-app-id': FEISHU_APP_ID,
+      'x-flow-key': flowKey,
+      accept: 'application/json',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ biz_type: null }),
+  });
+  const data = (await response.json()) as unknown;
+  assertFeishuApiOk(data, 'Feishu QR polling failed');
+  const payload = asRecord(asRecord(data).data);
+  const stepInfo = asRecord(payload.step_info);
+  return {
+    nextStep: pickString(payload, ['next_step']) ?? null,
+    status: typeof stepInfo.status === 'number' ? stepInfo.status : null,
+    crossLoginUri: pickString(stepInfo, ['cross_login_uri']) ?? null,
+  };
+}
+
+/** Render a QR code as terminal text (small, compact). */
+export function renderTerminalQr(payload: string): Promise<string> {
+  return new Promise((resolve) => qrcode.generate(payload, { small: true }, (qr) => resolve(qr)));
+}
+
+/** Validate a freshly obtained cookie jar against the Feishu web. */
+async function validateFeishuWebSession(
+  cookies: readonly StoredCookie[],
+  fetcher: typeof fetch,
+): Promise<boolean> {
+  if (cookies.length === 0) return false;
+  const session = new MutableCookieJar(cookies);
+  try {
+    const { response } = await session.fetchRaw(fetcher, 'https://ask.feishu.cn/', {
+      method: 'GET',
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/** Options for {@link loginFeishuWebSession}. */
+export interface FeishuQrLoginOptions {
+  /** Callback receiving the terminal QR text (default: print to stderr). */
+  onQrCode?: (info: { qrText: string; qrPayload: string }) => void | Promise<void>;
+  /** Status text callback (waiting / scanned / expired). */
+  onStatus?: (message: string) => void | Promise<void>;
+  /** Poll interval (default 1500 ms). */
+  pollIntervalMs?: number;
+  /** Max wait for the scan (default 180 s). */
+  maxWaitMs?: number;
+  /** Injectable fetch for tests. */
+  fetchImpl?: typeof fetch;
+}
+
+function defaultPrintFeishuQrCode(info: { qrText: string }): void {
+  process.stderr.write('\nScan with the Feishu app to log in to the Open Platform:\n\n');
+  process.stderr.write(`${info.qrText}\n`);
+  process.stderr.write(
+    'If this environment cannot display a QR code, re-run with --no-open-platform-auto ' +
+      'to configure manually.\n\n',
+  );
+}
+
+/**
+ * Run the full QR login and return a validated cookie jar.
+ * @returns cookies on success.
+ * @throws {@link FeishuWebSessionError} with a classification reason.
+ */
+export async function loginFeishuWebSession(
+  options: FeishuQrLoginOptions = {},
+): Promise<StoredCookie[]> {
+  const fetcher = options.fetchImpl ?? fetch;
+  const session = new MutableCookieJar();
+  const redirectUrl = 'https://ask.feishu.cn/';
+  const qrInit = await initFeishuQrLogin(session, fetcher, redirectUrl);
+  const qrPayload = buildFeishuQrPayload(qrInit.token);
+  const qrText = await renderTerminalQr(qrPayload);
+  const onQrCode = options.onQrCode ?? defaultPrintFeishuQrCode;
+  await onQrCode({ qrText, qrPayload });
+
+  const pollIntervalMs = options.pollIntervalMs ?? 1500;
+  const maxWaitMs = options.maxWaitMs ?? 180_000;
+  const start = Date.now();
+  let lastStatusMessage = '';
+  for (;;) {
+    if (Date.now() - start > maxWaitMs) {
+      throw new FeishuWebSessionError('Timed out waiting for the Feishu scan', 'timeout');
+    }
+    const poll = await pollFeishuQrLogin(session, fetcher, qrInit.flowKey);
+    if (poll.nextStep === 'enter_app') {
+      if (poll.crossLoginUri) {
+        await session.fetchRaw(fetcher, poll.crossLoginUri, { method: 'GET' });
+      }
+      await session.fetchRaw(fetcher, redirectUrl, { method: 'GET' });
+      const cookies = session.toJSON();
+      if (!(await validateFeishuWebSession(cookies, fetcher))) {
+        throw new FeishuWebSessionError(
+          'Scan completed but no reusable Web session was obtained',
+          'invalid_session',
+        );
+      }
+      return cookies;
+    }
+    const statusMessage = mapFeishuQrPollingStatus(poll.status);
+    if (options.onStatus && statusMessage !== lastStatusMessage) {
+      lastStatusMessage = statusMessage;
+      await options.onStatus(statusMessage);
+    }
+    if (poll.status === 5) {
+      throw new FeishuWebSessionError('QR code expired', 'qr_expired');
+    }
+    await sleep(pollIntervalMs);
+  }
+}
+
+/** Classify an unexpected login error into a failure reason. */
+export function classifyFeishuLoginError(err: unknown): FeishuLoginFailureReason {
+  if (err instanceof FeishuWebSessionError) return err.reason;
+  const message = err instanceof Error ? err.message : String(err);
+  if (/timeout|timed out|超时/i.test(message)) return 'timeout';
+  if (/expired|过期/i.test(message)) return 'qr_expired';
+  if (/ETIMEDOUT|ECONNREFUSED|ENOTFOUND|ECONNRESET|fetch failed|network/i.test(message))
+    return 'network';
+  return 'login_failed';
+}

--- a/src/setup/session.ts
+++ b/src/setup/session.ts
@@ -1,0 +1,180 @@
+/**
+ * Feishu Open Platform Web-session persistence: read/write the cookie jar to
+ * a machine-level file (`~/.dsh-feishu/feishu-session.json`, overridable via
+ * `DSH_FEISHU_SESSION`) and extract the console page's `window.csrfToken` /
+ * `window.user` identity. Reusing a cached session means a later run needs no
+ * new QR scan.
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+import { pruneExpiredCookies, type StoredCookie } from './cookies.js';
+
+/** Default location of the reusable Feishu Web session file. */
+export function feishuSessionFilePath(env = process.env): string {
+  const override = env.DSH_FEISHU_SESSION;
+  if (override && override !== '') return override;
+  return join(homedir(), '.dsh-feishu', 'feishu-session.json');
+}
+
+/** Read stored cookies from the session file; `null` when absent or corrupt. */
+export function readStoredCookiesFromSessionFile(filePath: string): StoredCookie[] | null {
+  if (!existsSync(filePath)) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  const cookies = (parsed as { cookies?: unknown }).cookies;
+  if (!Array.isArray(cookies)) return null;
+  return pruneExpiredCookies(
+    cookies.filter(isStoredCookieRecord).map((cookie) => ({ ...(cookie as StoredCookie) })),
+  );
+}
+
+/** Persist cookies atomically (temp file + rename) with 0600 permissions. */
+export function writeStoredCookiesToSessionFile(
+  filePath: string,
+  cookies: readonly StoredCookie[],
+): void {
+  const dir = dirname(filePath);
+  mkdirSync(dir, { recursive: true });
+  try {
+    chmodSync(dir, 0o700);
+  } catch {
+    // Best-effort on non-POSIX filesystems.
+  }
+  const tmpPath = join(dir, `.${basename(filePath)}.${process.pid}.${Date.now()}.tmp`);
+  try {
+    writeFileSync(tmpPath, JSON.stringify({ cookies: pruneExpiredCookies(cookies) }, null, 2), {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
+    renameSync(tmpPath, filePath);
+  } finally {
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // Temp cleanup is best-effort.
+    }
+  }
+  try {
+    chmodSync(filePath, 0o600);
+  } catch {
+    // Best-effort on non-POSIX filesystems.
+  }
+}
+
+/** Extract `window.csrfToken` from an Open Platform console page. */
+export function extractOpenPlatformCsrfToken(html: string): string | null {
+  const match =
+    html.match(/\bwindow\.csrfToken\s*=\s*(['"])([^'"]+)\1/) ??
+    html.match(/\bcsrfToken\s*:\s*(['"])([^'"]+)\1/);
+  return match?.[2] ?? null;
+}
+
+/** The logged-in user/tenant, as written into `window.user` by the console. */
+export interface FeishuWebSessionIdentity {
+  readonly userId: string;
+  readonly userName: string;
+  readonly email?: string;
+  readonly tenantId: string;
+  readonly tenantName: string;
+}
+
+function extractBalancedJsonObject(input: string, start: number): string | null {
+  if (input[start] !== '{') return null;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < input.length; i += 1) {
+    const char = input[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === '{') depth += 1;
+    else if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return input.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function pickString(record: Record<string, unknown>, keys: readonly string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value) return value;
+    if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  }
+  return undefined;
+}
+
+/**
+ * Extract the console's `window.user` identity. Only stable display fields
+ * are kept; used to show who is logged in and to supply the creator user id
+ * for the first version's visibility.
+ */
+export function extractOpenPlatformSessionIdentity(html: string): FeishuWebSessionIdentity | null {
+  const marker = /\bwindow\.user\s*=\s*/g;
+  const match = marker.exec(html);
+  if (!match) return null;
+  const start = match.index + match[0].length;
+  const json = extractBalancedJsonObject(html, start);
+  if (!json) return null;
+  let user: Record<string, unknown>;
+  try {
+    user = asRecord(JSON.parse(json));
+  } catch {
+    return null;
+  }
+  const userId = pickString(user, ['id', 'userId', 'user_id']);
+  const userName =
+    pickString(user, ['name', 'userName', 'user_name']) ??
+    pickString(asRecord(user.displayName), ['value']);
+  const tenantId = pickString(user, ['tenantId', 'tenant_id']);
+  const tenantName =
+    pickString(asRecord(user.tenantDisplayName), ['value']) ??
+    pickString(user, ['tenantName', 'tenant_name']);
+  if (!userId || !userName || !tenantId || !tenantName) return null;
+  const email = pickString(user, ['email']);
+  return { userId, userName, ...(email ? { email } : {}), tenantId, tenantName };
+}
+
+function isStoredCookieRecord(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const cookie = value as Partial<StoredCookie>;
+  return (
+    typeof cookie.name === 'string' &&
+    typeof cookie.value === 'string' &&
+    typeof cookie.domain === 'string' &&
+    typeof cookie.path === 'string' &&
+    typeof cookie.secure === 'boolean' &&
+    typeof cookie.httpOnly === 'boolean' &&
+    typeof cookie.hostOnly === 'boolean'
+  );
+}

--- a/tests/setup.spec.ts
+++ b/tests/setup.spec.ts
@@ -1,0 +1,572 @@
+/**
+ * Unit tests for the quick-setup automation (`src/setup/*`): cookie jar
+ * semantics, session persistence, QR helpers, payload builders, response
+ * extractors, the fail-closed verification, the profile writer, and the
+ * configure flow driven through a fake fetcher. The live Open Platform
+ * console is never exercised here.
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createOpenPlatformApiClient, type OpenPlatformApiClient } from '../src/setup/client.js';
+import { configureFeishuApp } from '../src/setup/configure.js';
+import {
+  getCookieHeader,
+  MutableCookieJar,
+  parseSetCookie,
+  pruneExpiredCookies,
+  type StoredCookie,
+} from '../src/setup/cookies.js';
+import { makePlaceholderIconPng } from '../src/setup/create-app.js';
+import {
+  APP_EVENTS,
+  CARD_CALLBACKS,
+  LONG_CONNECTION_EVENT_MODE,
+  SCOPES,
+} from '../src/setup/manifest.js';
+import {
+  buildAppVersionCreatePayload,
+  buildCallbackSubscriptionPayload,
+  buildEventSubscriptionPayload,
+  buildManifestTemplateCreatePayload,
+  buildSafeSettingPayload,
+  buildScopeUpdatePayload,
+  extractOpenPlatformCallbackState,
+  extractOpenPlatformEventState,
+  extractOpenPlatformScopeEntries,
+  extractVersionId,
+  mapManifestScopesToOpenPlatformIds,
+  nextAppVersion,
+  parseOnlineVisibility,
+} from '../src/setup/payloads.js';
+import {
+  loadPatchRows,
+  profilePatchPath,
+  upsertFeishuConfig,
+  writeProfileCredentials,
+} from '../src/setup/profile-writer.js';
+import { buildFeishuQrPayload, mapFeishuQrPollingStatus } from '../src/setup/qr-login.js';
+import {
+  extractOpenPlatformCsrfToken,
+  extractOpenPlatformSessionIdentity,
+  readStoredCookiesFromSessionFile,
+  writeStoredCookiesToSessionFile,
+} from '../src/setup/session.js';
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-feishu-setup-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+// ─── Manifest ───────────────────────────────────────────────────────────────
+
+describe('manifest', () => {
+  it('lists the surface requirements without duplicates', () => {
+    expect(new Set(APP_EVENTS).size).toBe(APP_EVENTS.length);
+    expect(new Set(CARD_CALLBACKS).size).toBe(CARD_CALLBACKS.length);
+    expect(new Set(SCOPES).size).toBe(SCOPES.length);
+    expect(APP_EVENTS).toContain('im.message.receive_v1');
+    expect(CARD_CALLBACKS).toContain('card.action.trigger');
+  });
+});
+
+// ─── Cookie jar ─────────────────────────────────────────────────────────────
+
+describe('cookie jar', () => {
+  it('parses a Set-Cookie header with attributes', () => {
+    const cookie = parseSetCookie(
+      'https://open.feishu.cn/app',
+      'sid=abc; Path=/; Domain=feishu.cn; Secure; HttpOnly; SameSite=Lax',
+    );
+    expect(cookie).toMatchObject({
+      name: 'sid',
+      value: 'abc',
+      domain: 'feishu.cn',
+      path: '/',
+      secure: true,
+      httpOnly: true,
+      hostOnly: false,
+    });
+  });
+
+  it('keeps host-only cookies for the exact host only', () => {
+    const cookie: StoredCookie = {
+      name: 'a',
+      value: '1',
+      domain: 'open.feishu.cn',
+      path: '/',
+      secure: true,
+      httpOnly: false,
+      hostOnly: true,
+    };
+    expect(getCookieHeader([cookie], 'https://open.feishu.cn/app')).toContain('a=1');
+    expect(getCookieHeader([cookie], 'https://other.feishu.cn/app')).toBe('');
+  });
+
+  it('matches domain cookies on subdomains', () => {
+    const cookie: StoredCookie = {
+      name: 'a',
+      value: '1',
+      domain: 'feishu.cn',
+      path: '/',
+      secure: true,
+      httpOnly: false,
+      hostOnly: false,
+    };
+    expect(getCookieHeader([cookie], 'https://open.feishu.cn/app')).toContain('a=1');
+  });
+
+  it('prunes expired cookies', () => {
+    const expired: StoredCookie = {
+      name: 'old',
+      value: '1',
+      domain: 'feishu.cn',
+      path: '/',
+      secure: false,
+      httpOnly: false,
+      hostOnly: false,
+      expiresAt: Date.now() - 1000,
+    };
+    expect(pruneExpiredCookies([expired])).toHaveLength(0);
+  });
+
+  it('follows redirects and captures Set-Cookie along the way', async () => {
+    const fetcher = async (url: string): Promise<Response> => {
+      if (url === 'https://example.com/start') {
+        return new Response(null, {
+          status: 302,
+          headers: {
+            location: 'https://example.com/landing',
+            'set-cookie': 'mid=42; Path=/; Domain=example.com',
+          },
+        });
+      }
+      if (url === 'https://example.com/landing') {
+        return new Response('ok', { status: 200, headers: { 'set-cookie': 'final=yes; Path=/' } });
+      }
+      throw new Error(`unexpected url ${url}`);
+    };
+    const jar = new MutableCookieJar();
+    const { response, finalUrl } = await jar.fetchRaw(
+      fetcher as typeof fetch,
+      'https://example.com/start',
+      {
+        method: 'GET',
+      },
+    );
+    expect(response.status).toBe(200);
+    expect(finalUrl).toBe('https://example.com/landing');
+    expect(
+      jar
+        .toJSON()
+        .map((c) => c.name)
+        .sort(),
+    ).toEqual(['final', 'mid']);
+  });
+});
+
+// ─── Session persistence + page extraction ─────────────────────────────────
+
+describe('session file', () => {
+  it('round-trips cookies with 0600 permissions', () => {
+    const dir = tempDir();
+    const file = join(dir, 'feishu-session.json');
+    const cookie: StoredCookie = {
+      name: 'sid',
+      value: 'v',
+      domain: 'open.feishu.cn',
+      path: '/',
+      secure: true,
+      httpOnly: true,
+      hostOnly: true,
+    };
+    writeStoredCookiesToSessionFile(file, [cookie]);
+    const loaded = readStoredCookiesFromSessionFile(file);
+    expect(loaded).toEqual([cookie]);
+  });
+
+  it('returns null for a corrupt session file', () => {
+    const dir = tempDir();
+    const file = join(dir, 'feishu-session.json');
+    writeFileSync(file, 'not json', 'utf8');
+    expect(readStoredCookiesFromSessionFile(file)).toBeNull();
+  });
+
+  it('extracts the csrf token from a console page', () => {
+    const html = '<script>window.csrfToken = "tok_123";</script>';
+    expect(extractOpenPlatformCsrfToken(html)).toBe('tok_123');
+  });
+
+  it('extracts the session identity from window.user', () => {
+    const html = `<!doctype html><script>window.user = {"id":"ou_1","name":"Ada","tenantId":"t1","tenantDisplayName":{"value":"ACME"},"email":"a@x.cn"};</script>`;
+    const identity = extractOpenPlatformSessionIdentity(html);
+    expect(identity).toMatchObject({
+      userId: 'ou_1',
+      userName: 'Ada',
+      tenantId: 't1',
+      tenantName: 'ACME',
+      email: 'a@x.cn',
+    });
+  });
+});
+
+// ─── QR helpers ─────────────────────────────────────────────────────────────
+
+describe('qr-login helpers', () => {
+  it('builds the console QR payload', () => {
+    expect(buildFeishuQrPayload('tok')).toBe(JSON.stringify({ qrlogin: { token: 'tok' } }));
+  });
+
+  it('maps polling statuses to human text', () => {
+    expect(mapFeishuQrPollingStatus(2)).toContain('scanned');
+    expect(mapFeishuQrPollingStatus(5)).toContain('expired');
+    expect(mapFeishuQrPollingStatus(null)).toContain('waiting');
+  });
+});
+
+// ─── Payload builders ───────────────────────────────────────────────────────
+
+describe('payload builders', () => {
+  it('builds the scope update payload', () => {
+    expect(
+      buildScopeUpdatePayload('cli_a', { tenantScopeIds: ['s1'], userScopeIds: [] }),
+    ).toMatchObject({ clientId: 'cli_a', operation: 'add', appScopeIDs: ['s1'], userScopeIDs: [] });
+  });
+
+  it('builds the event subscription payload with the current mode', () => {
+    expect(buildEventSubscriptionPayload('cli_a', 4, ['im.message.receive_v1'])).toMatchObject({
+      clientId: 'cli_a',
+      operation: 'add',
+      appEvents: ['im.message.receive_v1'],
+      eventMode: 4,
+    });
+  });
+
+  it('builds the callback subscription payload', () => {
+    expect(buildCallbackSubscriptionPayload('cli_a', 4, ['card.action.trigger'])).toMatchObject({
+      clientId: 'cli_a',
+      operation: 'add',
+      callbacks: ['card.action.trigger'],
+      callbackMode: 4,
+    });
+  });
+
+  it('builds the version payload with full-overwrite visibility', () => {
+    const payload = buildAppVersionCreatePayload('1.2.3', {
+      departments: ['d1'],
+      members: ['ou_1'],
+      groups: [],
+      isAll: 0,
+    });
+    expect(payload.appVersion).toBe('1.2.3');
+    expect(payload.visibleSuggest).toEqual({
+      departments: ['d1'],
+      members: ['ou_1'],
+      groups: [],
+      isAll: 0,
+    });
+  });
+
+  it('builds the manifest template payload', () => {
+    const payload = buildManifestTemplateCreatePayload('Name', 'Desc', 'http://a.png', 'cid');
+    expect(payload.appManifestTemplateID).toBe('developer_console');
+    const custom = payload.createAppUserCustomField as { i18n?: { zh_cn?: { name?: string } } };
+    expect(custom.i18n?.zh_cn?.name).toBe('Name');
+  });
+
+  it('builds the safe settings payload (empty redirect whitelist)', () => {
+    expect(buildSafeSettingPayload('cli_a')).toEqual({ clientId: 'cli_a', redirectURL: [] });
+  });
+});
+
+// ─── Response extractors ────────────────────────────────────────────────────
+
+describe('response extractors', () => {
+  it('extracts event state incl. app events and mode', () => {
+    const state = extractOpenPlatformEventState({
+      code: 0,
+      data: {
+        eventMode: 4,
+        appEvents: [{ id: 'im.message.receive_v1' }],
+      },
+    });
+    expect(state.eventMode).toBe(4);
+    expect(state.appEvents).toContain('im.message.receive_v1');
+  });
+
+  it('extracts event ids from detail groups', () => {
+    const state = extractOpenPlatformEventState({
+      data: { appEventDetails: [{ items: [{ id: 'im.message.receive_v1' }] }] },
+    });
+    expect(state.events).toContain('im.message.receive_v1');
+  });
+
+  it('extracts callback state', () => {
+    const state = extractOpenPlatformCallbackState({
+      data: { callbackMode: 4, callbacks: [{ id: 'card.action.trigger' }] },
+    });
+    expect(state.callbackMode).toBe(4);
+    expect(state.callbacks).toContain('card.action.trigger');
+  });
+
+  it('parses online visibility and fails loud on an empty payload', () => {
+    const visibility = parseOnlineVisibility({
+      data: { visibleSuggest: { departments: [], members: ['ou_1'], groups: [], isAll: 0 } },
+    });
+    expect(visibility.visibleSuggest.members).toEqual(['ou_1']);
+    expect(() => parseOnlineVisibility({ data: {} })).toThrow();
+  });
+
+  it('extracts the scope catalog and maps manifest scopes', () => {
+    const catalog = extractOpenPlatformScopeEntries({
+      data: { tenant: [{ scope_id: 'id_im_message', name: 'im:message' }] },
+    });
+    const mapped = mapManifestScopesToOpenPlatformIds(SCOPES, catalog);
+    expect(mapped.tenantScopeIds).toContain('id_im_message');
+    expect(mapped.missing.length).toBeGreaterThan(0);
+  });
+
+  it('computes the next version including drafts', () => {
+    expect(nextAppVersion({ data: { versions: [{ appVersion: '1.0.0' }] } })).toBe('1.0.1');
+    expect(nextAppVersion({ data: { versions: [{ appVersion: '0.1.9' }] } })).toBe('0.1.10');
+    expect(nextAppVersion({ data: { versions: [] } })).toBe('0.0.1');
+  });
+
+  it('extracts a version id from several response shapes', () => {
+    expect(extractVersionId({ data: { versionId: 'v1' } })).toBe('v1');
+    expect(extractVersionId({ versionId: 'v2' })).toBe('v2');
+    expect(extractVersionId({ data: { appVersion: { id: 'v3' } } })).toBe('v3');
+  });
+});
+
+// ─── Placeholder icon ───────────────────────────────────────────────────────
+
+describe('placeholder icon', () => {
+  it('produces a valid PNG', () => {
+    const png = makePlaceholderIconPng();
+    expect(png.subarray(0, 8)).toEqual(
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    );
+    expect(png.includes(Buffer.from('IHDR'))).toBe(true);
+    expect(png.includes(Buffer.from('IEND'))).toBe(true);
+  });
+});
+
+// ─── Profile writer ─────────────────────────────────────────────────────────
+
+describe('profile writer', () => {
+  it('creates the feishu row when missing', () => {
+    const rows = upsertFeishuConfig([], { appId: 'cli_x', appSecret: 's' });
+    expect(rows).toEqual([
+      { id: 'feishu', name: '@dsh-feishu/dsh-feishu', config: { appId: 'cli_x', appSecret: 's' } },
+    ]);
+  });
+
+  it('updates an existing row and preserves other rows', () => {
+    const rows = upsertFeishuConfig(
+      [
+        { id: 'feishu', name: '@dsh-feishu/dsh-feishu', config: { repoRoots: ['/x'] } },
+        { id: 'other', name: 'x' },
+      ],
+      { appId: 'cli_x', appSecret: 's' },
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      id: 'feishu',
+      config: { appId: 'cli_x', appSecret: 's', repoRoots: ['/x'] },
+    });
+  });
+
+  it('is idempotent when credentials are unchanged', () => {
+    const rows = [{ id: 'feishu', config: { appId: 'cli_x', appSecret: 's' } }];
+    expect(upsertFeishuConfig(rows, { appId: 'cli_x', appSecret: 's' })).toBe(rows);
+  });
+
+  it('writes a backup and round-trips YAML', () => {
+    const dir = tempDir();
+    const dshHomeDir = join(dir, 'dsh-home');
+    const patchPath = profilePatchPath(dshHomeDir, 'feishu-dev');
+    writeProfileCredentials(dshHomeDir, 'feishu-dev', { appId: 'cli_a', appSecret: 's1' });
+    expect(readFileSync(patchPath, 'utf8')).toContain('cli_a');
+    const second = writeProfileCredentials(dshHomeDir, 'feishu-dev', {
+      appId: 'cli_b',
+      appSecret: 's2',
+    });
+    expect(second.changed).toBe(true);
+    expect(second.backupPath).toBe(`${patchPath}.bak`);
+    const rows = loadPatchRows(patchPath);
+    expect(rows.find((row) => row.id === 'feishu')).toMatchObject({ id: 'feishu' });
+  });
+});
+
+// ─── Configure flow with a fake fetcher ─────────────────────────────────────
+
+const CONSOLE_PAGE_HTML =
+  '<!doctype html><script>window.csrfToken = "csrf1";</script>' +
+  '<script>window.user = {"id":"ou_creator","name":"Ada","tenantId":"t1","tenantDisplayName":{"value":"ACME"}};</script>';
+
+interface FakeFetcherOptions {
+  /** Initial event subscriptions (default: mode 4 + im.message.receive_v1). */
+  eventState?: { eventMode?: number; events: string[] };
+  /** Initial callback subscriptions (default: mode 4 + card.action.trigger). */
+  callbackState?: { callbackMode?: number; callbacks: string[] };
+  /** When false, update calls do not change the read-back state (fail-closed tests). */
+  applyUpdates?: boolean;
+}
+
+function createFakeFetcher(options: FakeFetcherOptions = {}): {
+  fetcher: typeof fetch;
+  requests: Array<{ url: string; body?: unknown }>;
+} {
+  const requests: Array<{ url: string; body?: unknown }> = [];
+  let eventMode = options.eventState?.eventMode ?? LONG_CONNECTION_EVENT_MODE;
+  let events = [...(options.eventState?.events ?? ['im.message.receive_v1'])];
+  let callbackMode = options.callbackState?.callbackMode ?? LONG_CONNECTION_EVENT_MODE;
+  let callbacks = [...(options.callbackState?.callbacks ?? ['card.action.trigger'])];
+  const applyUpdates = options.applyUpdates !== false;
+
+  const fetcher = async (url: string, init?: RequestInit): Promise<Response> => {
+    const parsed = new URL(url);
+    const body = init?.body
+      ? (JSON.parse(String(init.body)) as Record<string, unknown>)
+      : undefined;
+    requests.push({ url: parsed.pathname, body });
+    const json = (data: unknown, code = 0): Response =>
+      new Response(JSON.stringify({ code, ...(data ? { data } : {}) }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    if (parsed.pathname === '/app' || parsed.pathname === '/') {
+      return new Response(CONSOLE_PAGE_HTML, { status: 200 });
+    }
+    if (parsed.pathname.startsWith('/developers/v1/scope/all/')) {
+      return json({ tenant: [{ scope_id: 's_im_message', name: 'im:message' }] });
+    }
+    if (parsed.pathname.startsWith('/developers/v1/scope/update/')) return json({});
+    if (parsed.pathname.startsWith('/developers/v1/robot/switch/')) return json({});
+    if (parsed.pathname.startsWith('/developers/v1/event/switch/')) {
+      if (applyUpdates && typeof body?.eventMode === 'number') eventMode = body.eventMode;
+      return json({});
+    }
+    if (parsed.pathname.startsWith('/developers/v1/event/update/')) {
+      if (applyUpdates) {
+        const added = Array.isArray(body?.appEvents) ? (body.appEvents as string[]) : [];
+        events = [...new Set([...events, ...added])];
+      }
+      return json({});
+    }
+    if (parsed.pathname.startsWith('/developers/v1/event/')) {
+      return json({ eventMode, appEvents: events.map((id) => ({ id })) });
+    }
+    if (parsed.pathname.startsWith('/developers/v1/callback/switch/')) {
+      if (applyUpdates && typeof body?.callbackMode === 'number') callbackMode = body.callbackMode;
+      return json({});
+    }
+    if (parsed.pathname.startsWith('/developers/v1/callback/update/')) {
+      if (applyUpdates) {
+        const added = Array.isArray(body?.callbacks) ? (body.callbacks as string[]) : [];
+        callbacks = [...new Set([...callbacks, ...added])];
+      }
+      return json({});
+    }
+    if (parsed.pathname.startsWith('/developers/v1/callback/')) {
+      return json({ callbackMode, callbacks: callbacks.map((id) => ({ id })) });
+    }
+    if (parsed.pathname.startsWith('/developers/v1/safe_setting/update/')) return json({});
+    if (parsed.pathname.startsWith('/developers/v1/visible/online/')) {
+      return json({
+        visibleSuggest: { departments: [], members: ['ou_creator'], groups: [], isAll: 0 },
+      });
+    }
+    if (parsed.pathname.startsWith('/developers/v1/app_version/list/')) {
+      return json({ versions: [{ appVersion: '1.0.0' }] });
+    }
+    if (parsed.pathname.startsWith('/developers/v1/app_version/create/')) {
+      return json({ versionId: 'v_1' });
+    }
+    if (parsed.pathname.startsWith('/developers/v1/publish/commit/')) return json({});
+    throw new Error(`unexpected url in fake fetcher: ${url}`);
+  };
+  return { fetcher: fetcher as typeof fetch, requests };
+}
+
+async function makeClient(fetcher: typeof fetch): Promise<OpenPlatformApiClient> {
+  const result = await createOpenPlatformApiClient([], { fetchImpl: fetcher });
+  if (!result.ok) throw new Error(result.message);
+  return result.client;
+}
+
+describe('configureFeishuApp', () => {
+  it('configures, verifies, and publishes on a fully working console', async () => {
+    const { fetcher, requests } = createFakeFetcher();
+    const client = await makeClient(fetcher);
+    const result = await configureFeishuApp(client, 'cli_app', { publish: true });
+    expect(result.ok).toBe(true);
+    expect(result.subscribedEventCount).toBe(2);
+    expect(result.versionId).toBe('v_1');
+    const paths = requests.map((r) => r.url);
+    expect(paths).toContain('/developers/v1/robot/switch/cli_app');
+    expect(paths).toContain('/developers/v1/event/switch/cli_app');
+    expect(paths).toContain('/developers/v1/safe_setting/update/cli_app');
+    expect(paths).toContain('/developers/v1/app_version/create/cli_app');
+    expect(paths).toContain('/developers/v1/publish/commit/cli_app/v_1');
+    // Already-subscribed events/callbacks need no incremental update.
+    expect(paths.some((p) => p.startsWith('/developers/v1/event/update/'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('/developers/v1/callback/update/'))).toBe(false);
+    // Scopes were mapped and sent.
+    const scopeUpdate = requests.find((r) => r.url.startsWith('/developers/v1/scope/update/'));
+    expect(scopeUpdate?.body).toMatchObject({ clientId: 'cli_app', appScopeIDs: ['s_im_message'] });
+  });
+
+  it('subscribes missing events and callbacks before verifying', async () => {
+    const { fetcher, requests } = createFakeFetcher({
+      eventState: { eventMode: LONG_CONNECTION_EVENT_MODE, events: [] },
+      callbackState: { callbackMode: LONG_CONNECTION_EVENT_MODE, callbacks: [] },
+    });
+    const client = await makeClient(fetcher);
+    const result = await configureFeishuApp(client, 'cli_app', { publish: false });
+    expect(result.ok).toBe(true);
+    const eventUpdate = requests.find((r) => r.url.startsWith('/developers/v1/event/update/'));
+    expect(eventUpdate?.body).toMatchObject({ appEvents: ['im.message.receive_v1'] });
+    const callbackUpdate = requests.find((r) =>
+      r.url.startsWith('/developers/v1/callback/update/'),
+    );
+    expect(callbackUpdate?.body).toMatchObject({ callbacks: ['card.action.trigger'] });
+  });
+
+  it('fails closed when a critical subscription cannot be confirmed', async () => {
+    // applyUpdates:false — the update call never changes the read-back, so
+    // the re-read verification can never confirm im.message.receive_v1.
+    const { fetcher } = createFakeFetcher({
+      eventState: { eventMode: LONG_CONNECTION_EVENT_MODE, events: [] },
+      callbackState: { callbackMode: LONG_CONNECTION_EVENT_MODE, callbacks: [] },
+      applyUpdates: false,
+    });
+    const client = await makeClient(fetcher);
+    const result = await configureFeishuApp(client, 'cli_app', { publish: false });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('event_verification_failed');
+  });
+
+  it('fails closed when the receive mode is not the long connection', async () => {
+    // The switch call reports success but the read-back stays mode 1 (the
+    // switch "succeeded" without taking effect, like a stale console state).
+    const { fetcher } = createFakeFetcher({
+      eventState: { eventMode: 1, events: ['im.message.receive_v1'] },
+      applyUpdates: false,
+    });
+    const client = await makeClient(fetcher);
+    const result = await configureFeishuApp(client, 'cli_app', { publish: false });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('event_verification_failed');
+    expect(result.message).toMatch(/[Ll]ong connection/);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["ES2023"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
     "types": ["node"],
     "strict": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
## What

`pnpm run setup:feishu` automates the Feishu Open Platform setup that used to
require ~6 web-console steps — **one QR scan** is now the only human step.
The console is driven over a reusable Web session (raw HTTP + cookie jar, no
browser automation), mirroring botmux's `setup` wizard:

1. Creates a 企业自建应用 (or reconfigures an existing one via `--app-id`)
2. Enables the bot capability
3. Subscribes `im.message.receive_v1` (event) + `card.action.trigger` (card
   callback) in **long-connection** mode — read-back verified, **fail-closed**
   (a bot that can't receive messages/card clicks is never reported as done)
4. Grants `im:message` / `im:message:send_as_bot` / `im:chat`
5. Publishes a version with **"visible to me only"** visibility (instant
   approval, no admin wait)
6. Writes `appId`/`appSecret` into the profile's `cordis.patch.yml` (backed
   up) or prints export lines (`--print-env`)

The session file (`~/.dsh-feishu/feishu-session.json`) is reused across runs.
`--no-open-platform-auto` keeps a manual fallback (paste credentials →
validated against the Feishu tenant-token API → config written + checklist).
Other flags: `--list`, `--force-login`, `--lark`, `--verify-boot`.

## Changes

- `src/setup/` — manifest (events/callbacks/scopes single source of truth),
  RFC 6265 cookie jar, session file persistence, QR login
  (`accounts.feishu.cn/accounts/qrlogin/*`), console API client (CSRF from
  the console page), payload builders + response extractors, configure +
  create-app flows, profile writer, CLI entry
- `scripts/setup-feishu.mjs` launcher; `package.json` gains
  `setup:feishu` script and `dsh-feishu-setup` bin
- New runtime deps: `qrcode-terminal`, `js-yaml` (both small; the WS
  transport is untouched)
- `docs/feishu-setup.md` restructured around the quick path; CHANGELOG entry

## Verification

- 34 new unit tests (cookie jar, session file, QR helpers, payload builders,
  response extractors, fail-closed verification, profile writer, and the
  configure flow driven through a fake fetcher) — full suite **333/333**
  with `FEISHU_INT_REQUIRED=1`, all gates green locally
- The live QR → console flow needs a real Feishu account and a terminal QR;
  acceptance is manual (one scan → `dsh --profile` boots with
  "long connection ready"). The pure logic and the fail-closed paths are
  CI-tested; the console contract is protected by read-back verification and
  the always-available `--no-open-platform-auto` fallback.
