### PR TITLE
feat: guided bot branding in the quick-setup tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Guided bot branding in the quick-setup tool.** Creating an app now
+  prompts interactively for the bot's **name**, **avatar image** (PNG path;
+  empty = the bundled serif "dsh" wordmark at
+  `docs/assets/default-avatar.png`) and **description** — empty input keeps
+  the default, and non-TTY runs (CI/scripts) skip the prompts. The
+  `--app-name` / `--avatar` / `--description` flags override the prompts for
+  scripted runs.
+
 - **Env-configurable routing options.** `FEISHU_GROUP_MENTION_MODE`,
   `FEISHU_ALLOWED_CHATS`, and `FEISHU_UNKNOWN_COMMAND` extend the
   config-wins/env-falls-back seam (`FEISHU_ALLOWED_USERS` already existed),

--- a/docs/feishu-setup.md
+++ b/docs/feishu-setup.md
@@ -21,7 +21,10 @@ pnpm run setup:feishu -- --new       # create a new app + configure it
 The wizard then, with no further web-console work:
 
 1. Creates a **企业自建应用** (default name "DSH Agent (dsh-feishu)",
-   `--app-name` to change) and reads back its `app_id` / `app_secret`.
+   `--app-name` to change; `--description` sets the app description) and
+   reads back its `app_id` / `app_secret`. The app avatar is the bundled
+   dsh wordmark by default; `--avatar <path>` uploads a custom image
+   (PNG).
 2. Enables the **bot** capability.
 3. Switches **events and card callbacks to the long connection** and
    subscribes `im.message.receive_v1` (event) + `card.action.trigger`
@@ -42,6 +45,13 @@ Reconfigure an existing app instead of creating one:
 
 ```sh
 pnpm run setup:feishu -- --app-id cli_xxx
+```
+
+Brand the new app (name, avatar, description):
+
+```sh
+pnpm run setup:feishu -- --new --app-name "Team Agent" \
+  --avatar ./team-agent.png --description "The team's dsh agent on Feishu."
 ```
 
 Other options: `--list` (list apps the session can see), `--force-login`

--- a/src/setup/bot-profile.ts
+++ b/src/setup/bot-profile.ts
@@ -1,0 +1,92 @@
+/**
+ * Guided bot-profile prompts: when creating a new app, the wizard asks for
+ * the bot's name, avatar image, and description — an empty input (just
+ * Enter) accepts the default. Values already provided on the command line
+ * (`--app-name` / `--avatar` / `--description`) skip their prompt.
+ * Non-interactive runs (stdin is not a TTY, e.g. CI or scripts) skip the
+ * prompts entirely.
+ *
+ * The merge is a pure function (`mergeBotProfile`) so it is fully
+ * unit-testable; prompting is a thin readline wrapper around it, mirroring
+ * `guided-config.ts`.
+ *
+ * @module @dsh-feishu/dsh-feishu/setup/bot-profile
+ */
+
+import { createInterface } from 'node:readline';
+import { DEFAULT_APP_NAME } from './manifest.js';
+
+/** The effective bot profile used to create the app. */
+export interface BotProfile {
+  readonly name: string;
+  readonly avatarFilePath?: string;
+  readonly description?: string;
+}
+
+/** Values the caller already has (from CLI flags). */
+export interface BotProfileInputs {
+  readonly appName?: string;
+  readonly avatarFilePath?: string;
+  readonly description?: string;
+}
+
+/** One raw answer from the user; an empty string means "use the default". */
+export interface BotProfileAnswers {
+  appName?: string;
+  avatarFilePath?: string;
+  description?: string;
+}
+
+/**
+ * Merge CLI-provided values (highest priority), prompted answers, and
+ * defaults. Empty/blank answers keep the defaults.
+ * @param inputs - values already known from the command line.
+ * @param answers - the raw inputs (empty string = default).
+ */
+export function mergeBotProfile(inputs: BotProfileInputs, answers: BotProfileAnswers): BotProfile {
+  const name = inputs.appName?.trim() || answers.appName?.trim() || DEFAULT_APP_NAME;
+  const avatarFilePath = inputs.avatarFilePath?.trim() || answers.avatarFilePath?.trim() || '';
+  const description = inputs.description?.trim() || answers.description?.trim() || '';
+  return {
+    name,
+    ...(avatarFilePath !== '' ? { avatarFilePath } : {}),
+    ...(description !== '' ? { description } : {}),
+  };
+}
+
+function ask(rl: ReturnType<typeof createInterface>, question: string): Promise<string> {
+  return new Promise((resolve) => {
+    rl.question(question, resolve);
+  });
+}
+
+/**
+ * Ask for the bot-profile values the CLI did not already provide. Returns
+ * no answers when stdin is not a TTY (CI / scripts) so nothing blocks.
+ * @param inputs - values already known from the command line (skipped).
+ */
+export async function promptBotProfile(inputs: BotProfileInputs): Promise<BotProfileAnswers> {
+  if (!process.stdin.isTTY) return {};
+  const answers: BotProfileAnswers = {};
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    if (!inputs.appName?.trim()) {
+      answers.appName = await ask(rl, `Bot app name [${DEFAULT_APP_NAME}]: `);
+    }
+    if (!inputs.avatarFilePath?.trim()) {
+      answers.avatarFilePath = await ask(
+        rl,
+        'Bot avatar image path (PNG; empty = bundled dsh wordmark): ',
+      );
+    }
+    if (!inputs.description?.trim()) {
+      answers.description = await ask(
+        rl,
+        'Bot description (empty = "A dsh agent surface on Feishu."): ',
+      );
+    }
+  } finally {
+    rl.close();
+  }
+  return answers;
+}

--- a/src/setup/cli.ts
+++ b/src/setup/cli.ts
@@ -17,6 +17,7 @@ import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { createInterface } from 'node:readline/promises';
 import { pathToFileURL } from 'node:url';
+import { mergeBotProfile, promptBotProfile } from './bot-profile.js';
 import { createOpenPlatformApiClient } from './client.js';
 import { configureFeishuApp } from './configure.js';
 import type { StoredCookie } from './cookies.js';
@@ -49,7 +50,7 @@ interface CliOptions {
   newApp: boolean;
   appId?: string;
   list: boolean;
-  appName: string;
+  appName?: string;
   profile: string;
   dshHomeDir: string;
   noAuto: boolean;
@@ -58,6 +59,8 @@ interface CliOptions {
   printEnv: boolean;
   verifyBoot: boolean;
   appSecret?: string;
+  avatarFilePath?: string;
+  description?: string;
   help: boolean;
 }
 
@@ -69,7 +72,6 @@ export function parseArgs(argv: readonly string[]): CliOptions {
   const opts: CliOptions = {
     newApp: false,
     list: false,
-    appName: DEFAULT_APP_NAME,
     profile: 'feishu-dev',
     dshHomeDir: dshHome(),
     noAuto: false,
@@ -93,6 +95,8 @@ export function parseArgs(argv: readonly string[]): CliOptions {
     else if (arg === '--app-secret') opts.appSecret = value();
     else if (arg === '--list') opts.list = true;
     else if (arg === '--app-name') opts.appName = value();
+    else if (arg === '--avatar') opts.avatarFilePath = value();
+    else if (arg === '--description') opts.description = value();
     else if (arg === '--profile') opts.profile = value();
     else if (arg === '--dsh-home') opts.dshHomeDir = value();
     else if (arg === '--no-open-platform-auto') opts.noAuto = true;
@@ -116,7 +120,12 @@ Options:
   --app-id <id>             configure an existing app (cli_...)
   --app-secret <secret>     app secret (manual path only)
   --list                    list apps visible to the session, then exit
-  --app-name <name>         name for a new app (default "${DEFAULT_APP_NAME}")
+  --app-name <name>         name for a new app (prompted interactively when
+                            omitted; default "${DEFAULT_APP_NAME}")
+  --avatar <path>           avatar image (PNG) for the new app (prompted
+                            when omitted; default: the bundled dsh wordmark)
+  --description <text>      app description (prompted when omitted; default:
+                            "A dsh agent surface on Feishu.")
   --profile <name>          dsh profile to write credentials into (default feishu-dev)
   --dsh-home <dir>          dsh home (default $DSH_HOME or ~/.dsh)
   --no-open-platform-auto   manual path: paste credentials, write config, print steps
@@ -380,10 +389,19 @@ async function runAutoSetup(options: CliOptions): Promise<void> {
         'cannot create an app without the session identity; re-run with --force-login',
       );
     }
-    log(`creating a new app "${options.appName}"…`);
+    // Bot profile: CLI flags win, else guided prompts (stdin), else defaults.
+    const botInputs = {
+      ...(options.appName !== undefined ? { appName: options.appName } : {}),
+      ...(options.avatarFilePath !== undefined ? { avatarFilePath: options.avatarFilePath } : {}),
+      ...(options.description !== undefined ? { description: options.description } : {}),
+    };
+    const profile = mergeBotProfile(botInputs, await promptBotProfile(botInputs));
+    log(`creating a new app "${profile.name}"…`);
     const created = await createFeishuOpenPlatformApp(client, {
-      name: options.appName,
+      name: profile.name,
       creatorUserId: clientResult.identity.userId,
+      ...(profile.avatarFilePath !== undefined ? { avatarFilePath: profile.avatarFilePath } : {}),
+      ...(profile.description !== undefined ? { description: profile.description } : {}),
     });
     if (!created.ok || !created.appId || !created.appSecret) {
       throw new Error(created.message ?? 'app creation failed');

--- a/src/setup/create-app.ts
+++ b/src/setup/create-app.ts
@@ -10,6 +10,9 @@
  * (`_tmp/botmux/src/setup/open-platform-automation.ts`).
  */
 
+import { existsSync, readFileSync } from 'node:fs';
+import { basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { deflateSync } from 'node:zlib';
 import { type OpenPlatformApiClient, OpenPlatformApiError } from './client.js';
 import { configureFeishuApp } from './configure.js';
@@ -86,6 +89,57 @@ export function makePlaceholderIconPng(
   ]);
 }
 
+/**
+ * The bundled default avatar (serif "dsh" wordmark on the Feishu blue
+ * gradient card). Resolved relative to the built lib/ so it works both from
+ * a checkout and from an installed npm package (the `docs` directory ships
+ * in the package `files`).
+ */
+export const DEFAULT_AVATAR_PATH = fileURLToPath(
+  new URL('../../docs/assets/default-avatar.png', import.meta.url),
+);
+
+/** Read a PNG's pixel dimensions from its IHDR chunk; `null` when not a PNG. */
+export function pngDimensions(buffer: Buffer): { width: number; height: number } | null {
+  if (buffer.length < 24) return null;
+  if (buffer.readUInt32BE(12) !== 0x49484452) return null; // chunk type "IHDR"
+  return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) };
+}
+
+/** An avatar ready for upload. */
+export interface AvatarSource {
+  readonly buffer: Buffer;
+  readonly filename: string;
+  readonly width: number;
+  readonly height: number;
+}
+
+/**
+ * Resolve the avatar to upload: an explicit file path when given and
+ * present, else the bundled default avatar, else the solid-color placeholder.
+ * @param avatarFilePath - optional user-provided avatar image (PNG).
+ */
+export function resolveAvatarBuffer(avatarFilePath?: string): AvatarSource {
+  let buffer: Buffer | undefined;
+  let filename = 'dsh-feishu.png';
+  if (avatarFilePath !== undefined && avatarFilePath !== '' && existsSync(avatarFilePath)) {
+    buffer = readFileSync(avatarFilePath);
+    filename = basename(avatarFilePath);
+  } else if (existsSync(DEFAULT_AVATAR_PATH)) {
+    buffer = readFileSync(DEFAULT_AVATAR_PATH);
+  }
+  if (buffer === undefined) {
+    buffer = makePlaceholderIconPng();
+  }
+  const dims = pngDimensions(buffer);
+  return {
+    buffer,
+    filename,
+    width: dims?.width ?? 64,
+    height: dims?.height ?? 64,
+  };
+}
+
 // ── App creation flow. ──────────────────────────────────────────────────────
 
 /** True when the template endpoint definitively rejected (safe to fall back). */
@@ -124,7 +178,7 @@ function pickPayloadString(payload: unknown, keys: readonly string[]): string | 
  */
 export async function createFeishuOpenPlatformApp(
   client: OpenPlatformApiClient,
-  options: { name: string; description?: string; creatorUserId: string },
+  options: { name: string; description?: string; creatorUserId: string; avatarFilePath?: string },
 ): Promise<CreateAppResult> {
   const name = options.name.trim();
   if (!name) {
@@ -139,18 +193,16 @@ export async function createFeishuOpenPlatformApp(
   }
   const description = options.description?.trim() || 'A dsh agent surface on Feishu.';
 
-  // Upload a placeholder icon (the create endpoints require an avatar url).
+  // Upload the app avatar: an explicit --avatar file, else the bundled
+  // default avatar, else the solid-color placeholder.
   let avatar: string | undefined;
   try {
+    const avatarSrc = resolveAvatarBuffer(options.avatarFilePath);
     const form = new FormData();
-    form.append(
-      'file',
-      new Blob([makePlaceholderIconPng()], { type: 'image/png' }),
-      'dsh-feishu.png',
-    );
+    form.append('file', new Blob([avatarSrc.buffer], { type: 'image/png' }), avatarSrc.filename);
     form.append('uploadType', '4'); // console enum: Icon
     form.append('isIsv', 'false'); // self-built app
-    form.append('scale', JSON.stringify({ width: 64, height: 64 }));
+    form.append('scale', JSON.stringify({ width: avatarSrc.width, height: avatarSrc.height }));
     const uploaded = await client.postForm('/developers/v1/app/upload/image', form);
     avatar = pickPayloadString(uploaded, ['url']);
   } catch (error) {

--- a/tests/setup.spec.ts
+++ b/tests/setup.spec.ts
@@ -10,6 +10,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
+import { mergeBotProfile, promptBotProfile } from '../src/setup/bot-profile.js';
 import { parseArgs } from '../src/setup/cli.js';
 import { createOpenPlatformApiClient, type OpenPlatformApiClient } from '../src/setup/client.js';
 import { configureFeishuApp } from '../src/setup/configure.js';
@@ -20,10 +21,17 @@ import {
   pruneExpiredCookies,
   type StoredCookie,
 } from '../src/setup/cookies.js';
-import { makePlaceholderIconPng } from '../src/setup/create-app.js';
+import {
+  createFeishuOpenPlatformApp,
+  DEFAULT_AVATAR_PATH,
+  makePlaceholderIconPng,
+  pngDimensions,
+  resolveAvatarBuffer,
+} from '../src/setup/create-app.js';
 import {
   APP_EVENTS,
   CARD_CALLBACKS,
+  DEFAULT_APP_NAME,
   LONG_CONNECTION_EVENT_MODE,
   SCOPES,
 } from '../src/setup/manifest.js';
@@ -492,8 +500,10 @@ interface FakeFetcherOptions {
 function createFakeFetcher(options: FakeFetcherOptions = {}): {
   fetcher: typeof fetch;
   requests: Array<{ url: string; body?: unknown }>;
+  uploadedFile: Buffer | undefined;
 } {
   const requests: Array<{ url: string; body?: unknown }> = [];
+  let uploadedFile: Buffer | undefined;
   let eventMode = options.eventState?.eventMode ?? LONG_CONNECTION_EVENT_MODE;
   let events = [...(options.eventState?.events ?? ['im.message.receive_v1'])];
   let callbackMode = options.callbackState?.callbackMode ?? LONG_CONNECTION_EVENT_MODE;
@@ -502,9 +512,15 @@ function createFakeFetcher(options: FakeFetcherOptions = {}): {
 
   const fetcher = async (url: string, init?: RequestInit): Promise<Response> => {
     const parsed = new URL(url);
-    const body = init?.body
-      ? (JSON.parse(String(init.body)) as Record<string, unknown>)
-      : undefined;
+    const isForm = init?.body instanceof FormData;
+    const body =
+      init?.body && !isForm
+        ? (JSON.parse(String(init.body)) as Record<string, unknown>)
+        : undefined;
+    if (isForm) {
+      const file = (init.body as FormData).get('file');
+      if (file instanceof Blob) uploadedFile = Buffer.from(await file.arrayBuffer());
+    }
     requests.push({ url: parsed.pathname, body });
     const json = (data: unknown, code = 0): Response =>
       new Response(JSON.stringify({ code, ...(data ? { data } : {}) }), {
@@ -513,6 +529,15 @@ function createFakeFetcher(options: FakeFetcherOptions = {}): {
       });
     if (parsed.pathname === '/app' || parsed.pathname === '/') {
       return new Response(CONSOLE_PAGE_HTML, { status: 200 });
+    }
+    if (parsed.pathname.startsWith('/developers/v1/app/upload/image')) {
+      return json({ url: 'http://avatar.png' });
+    }
+    if (parsed.pathname.startsWith('/developers/v1/manifest/upsert_by_template')) {
+      return json({ ClientID: 'cli_new' });
+    }
+    if (parsed.pathname.startsWith('/developers/v1/secret/')) {
+      return json({ secret: 's3cr3t' });
     }
     if (parsed.pathname.startsWith('/developers/v1/scope/all/')) {
       return json({ tenant: [{ scope_id: 's_im_message', name: 'im:message' }] });
@@ -562,7 +587,13 @@ function createFakeFetcher(options: FakeFetcherOptions = {}): {
     if (parsed.pathname.startsWith('/developers/v1/publish/commit/')) return json({});
     throw new Error(`unexpected url in fake fetcher: ${url}`);
   };
-  return { fetcher: fetcher as typeof fetch, requests };
+  return {
+    fetcher: fetcher as typeof fetch,
+    requests,
+    get uploadedFile() {
+      return uploadedFile;
+    },
+  };
 }
 
 async function makeClient(fetcher: typeof fetch): Promise<OpenPlatformApiClient> {
@@ -654,5 +685,114 @@ describe('setup CLI parseArgs', () => {
     expect(() => parseArgs(['--nope'])).toThrow('unknown option: --nope');
     // A mid-argument `--` is not the pnpm separator — it is genuinely unknown.
     expect(() => parseArgs(['--new', '--', '--profile', 'feishu'])).toThrow('unknown option: --');
+  });
+});
+
+// ─── Avatar resolution ──────────────────────────────────────────────────────
+
+describe('avatar resolution', () => {
+  it('reports PNG dimensions from the IHDR chunk', () => {
+    const png = makePlaceholderIconPng(64);
+    expect(pngDimensions(png)).toEqual({ width: 64, height: 64 });
+    expect(pngDimensions(Buffer.from('not a png at all, sorry'))).toBeNull();
+  });
+
+  it('resolves the bundled default avatar when no path is given', () => {
+    const src = resolveAvatarBuffer();
+    expect(src.filename).toBe('dsh-feishu.png');
+    expect(src.width).toBe(1024); // the bundled serif wordmark avatar
+    expect(src.buffer.subarray(0, 8)).toEqual(
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    );
+    expect(DEFAULT_AVATAR_PATH).toMatch(/docs[\\/]assets[\\/]default-avatar\.png$/);
+  });
+
+  it('uses a provided avatar file, keeping its filename and size', () => {
+    const dir = tempDir();
+    const file = join(dir, 'custom.png');
+    writeFileSync(file, makePlaceholderIconPng(32));
+    const src = resolveAvatarBuffer(file);
+    expect(src.filename).toBe('custom.png');
+    expect(src.width).toBe(32);
+    expect(src.buffer.subarray(0, 8)).toEqual(
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    );
+  });
+
+  it('falls back to the bundled avatar for a missing path', () => {
+    const src = resolveAvatarBuffer('/nonexistent/avatar.png');
+    expect(src.width).toBe(1024);
+  });
+});
+
+describe('createFeishuOpenPlatformApp', () => {
+  it('uploads the bundled default avatar when none is given', async () => {
+    const fake = createFakeFetcher();
+    const client = await makeClient(fake.fetcher);
+    const result = await createFeishuOpenPlatformApp(client, {
+      name: 'Test Bot',
+      creatorUserId: 'ou_creator',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.appId).toBe('cli_new');
+    expect(result.appSecret).toBe('s3cr3t');
+    expect(fake.uploadedFile).toBeDefined();
+    expect(pngDimensions(fake.uploadedFile as Buffer)).toEqual({ width: 1024, height: 1024 });
+  });
+
+  it('uploads a custom avatar file when provided', async () => {
+    const dir = tempDir();
+    const custom = join(dir, 'my-avatar.png');
+    writeFileSync(custom, makePlaceholderIconPng(48));
+    const fake = createFakeFetcher();
+    const client = await makeClient(fake.fetcher);
+    const result = await createFeishuOpenPlatformApp(client, {
+      name: 'Test Bot',
+      creatorUserId: 'ou_creator',
+      avatarFilePath: custom,
+    });
+    expect(result.ok).toBe(true);
+    expect(fake.uploadedFile).toBeDefined();
+    expect(pngDimensions(fake.uploadedFile as Buffer)).toEqual({ width: 48, height: 48 });
+  });
+});
+
+// ─── Bot profile (guided prompts) ──────────────────────────────────────────
+
+describe('bot profile', () => {
+  it('gives CLI-provided values the highest priority', () => {
+    const p = mergeBotProfile(
+      { appName: 'CLI Bot', avatarFilePath: '/x.png', description: 'cli desc' },
+      { appName: 'Answered', avatarFilePath: '/a.png', description: 'ans desc' },
+    );
+    expect(p).toEqual({
+      name: 'CLI Bot',
+      avatarFilePath: '/x.png',
+      description: 'cli desc',
+    });
+  });
+
+  it('falls back to prompted answers, then to defaults', () => {
+    const answered = mergeBotProfile(
+      {},
+      { appName: 'Answered', avatarFilePath: '/a.png', description: 'd' },
+    );
+    expect(answered).toEqual({ name: 'Answered', avatarFilePath: '/a.png', description: 'd' });
+    const defaults = mergeBotProfile({}, {});
+    expect(defaults.name).toBe(DEFAULT_APP_NAME);
+    expect(defaults.avatarFilePath).toBeUndefined();
+    expect(defaults.description).toBeUndefined();
+  });
+
+  it('treats blank answers as "use the default"', () => {
+    const p = mergeBotProfile({}, { appName: '   ', avatarFilePath: '', description: '' });
+    expect(p.name).toBe(DEFAULT_APP_NAME);
+    expect(p.avatarFilePath).toBeUndefined();
+    expect(p.description).toBeUndefined();
+  });
+
+  it('skips prompts when stdin is not a TTY', async () => {
+    const answers = await promptBotProfile({});
+    expect(answers).toEqual({});
   });
 });


### PR DESCRIPTION
## What

The quick-setup tool now **guides the bot's branding interactively** when
creating an app — instead of only accepting flags. Creating an app prompts
(stdin) for:

- **name** (`--app-name` overrides; default "DSH Agent (dsh-feishu)")
- **avatar image path** (PNG; `--avatar` overrides; empty = the bundled serif
  "dsh" wordmark at `docs/assets/default-avatar.png`, added in #6)
- **description** (`--description` overrides; default "A dsh agent surface on
  Feishu.")

Empty input keeps the default; non-TTY runs (CI/scripts) skip the prompts
entirely. `mergeBotProfile` is a pure merge (CLI > answers > defaults),
mirroring the existing guided-config pattern.

## Changes

- `src/setup/bot-profile.ts` — prompts + pure merge (new)
- `src/setup/create-app.ts` — `resolveAvatarBuffer` (custom file / bundled
  default / solid placeholder) + upload scale derived from the PNG IHDR
- `src/setup/cli.ts` — wire the three prompts + flags into app creation
- `tests/setup.spec.ts` — bot-profile merge, `pngDimensions`, avatar
  resolution, and create-app uploads the default/custom avatar (fake
  fetcher now handles FormData)
- `docs/feishu-setup.md` + CHANGELOG

## Verification

Full suite green locally: **462/462** tests with `FEISHU_INT_REQUIRED=1`
(integration suite runs, 0 skipped); lint/typecheck/build all pass. The live
QR → prompt → create flow needs a real Feishu account (manual acceptance).
