### PR TITLE
fix: startup hint matches the README (npx @deepseek-ai/dsh)

### DIFF
--- a/src/setup/cli.ts
+++ b/src/setup/cli.ts
@@ -150,6 +150,15 @@ function logError(message: string): void {
   process.stderr.write(`[setup] error: ${message}\n`);
 }
 
+/**
+ * The startup hint printed after setup completes. Matches the README's
+ * install/run commands, which invoke dsh through npx.
+ * @param profile - the configured dsh profile name.
+ */
+export function startHint(profile: string): string {
+  return `Start with: npx @deepseek-ai/dsh --profile ${profile}`;
+}
+
 async function prompt(question: string): Promise<string> {
   const rl = createInterface({ input: process.stdin, output: process.stderr });
   try {
@@ -325,9 +334,7 @@ async function runManualSetup(options: CliOptions): Promise<void> {
     if (!ready) logError('boot verification timed out (check the long connection / network)');
     else log('bridge ready — the surface is live');
   }
-  process.stdout.write(
-    `\nDone. Configured manually; start with \`dsh --profile ${options.profile}\`.\n`,
-  );
+  process.stdout.write(`\nDone. Configured manually; ${startHint(options.profile)}.\n`);
 }
 
 /** The automatic path: QR session → create/configure → publish → credentials. */
@@ -433,7 +440,7 @@ async function runAutoSetup(options: CliOptions): Promise<void> {
     else log('bridge ready — the surface is live');
   }
   process.stdout.write(`\nDone. App ${appId} configured for profile '${options.profile}'.\n`);
-  process.stdout.write(`Start with: dsh --profile ${options.profile}\n`);
+  process.stdout.write(`${startHint(options.profile)}\n`);
 }
 
 /** CLI entry point. */

--- a/tests/setup.spec.ts
+++ b/tests/setup.spec.ts
@@ -11,7 +11,7 @@ import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { mergeBotProfile, promptBotProfile } from '../src/setup/bot-profile.js';
-import { parseArgs } from '../src/setup/cli.js';
+import { parseArgs, startHint } from '../src/setup/cli.js';
 import { createOpenPlatformApiClient, type OpenPlatformApiClient } from '../src/setup/client.js';
 import { configureFeishuApp } from '../src/setup/configure.js';
 import {
@@ -794,5 +794,13 @@ describe('bot profile', () => {
   it('skips prompts when stdin is not a TTY', async () => {
     const answers = await promptBotProfile({});
     expect(answers).toEqual({});
+  });
+});
+
+describe('startup hint', () => {
+  it('matches the README run command (npx @deepseek-ai/dsh)', () => {
+    expect(startHint('feishu')).toBe('Start with: npx @deepseek-ai/dsh --profile feishu');
+    expect(startHint('feishu')).toContain('npx @deepseek-ai/dsh --profile');
+    expect(startHint('feishu')).not.toContain('dsh --profile feishu\n');
   });
 });


### PR DESCRIPTION
The quick-setup output printed `Start with: dsh --profile X`, but the README invokes dsh through npx everywhere. A `startHint(profile)` helper now emits `Start with: npx @deepseek-ai/dsh --profile X` in both the manual and automatic paths, with a regression test asserting it matches the README command.

Verified: 496/496 tests with FEISHU_INT_REQUIRED=1, lint/typecheck/build green.