### PR TITLE
docs: codify PR title, body, and squash-merge conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,16 +139,11 @@ scripts/              # repo tooling (release, verification)
 - Comments state contracts and context, not reasoning transcripts.
 - Conventional Commits: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`,
   `chore:`. The CHANGELOG (Keep a Changelog format) is updated per change.
-- **PR titles follow Conventional Commits too.** A PR title is the summary
-  of its change and should read as a Conventional Commit (`fix: …`,
-  `feat: …`, `docs: …`, `chore: …`) with a scope where it helps
-  (`chore(ci): …`); multi-type PRs pick the dominant type.
-- **PRs are SQUASH-merged.** The PR's commits collapse into ONE commit on
-  `main` whose title is `<PR title> (#<number>)` — `git log` reads as one
-  Conventional Commit per PR, each traceable to its PR number. Never use
-  "merge" (merge commit) or "rebase" (per-commit replay) for the merge.
-  PR bodies follow the What / Why / Verification template in
-  `docs/development.md` → "Pull requests and CI".
+- **PR titles follow Conventional Commits too** (`fix: …`, `chore(ci): …`;
+  multi-type PRs pick the dominant type).
+- **Squash-merge every PR** into one `main` commit titled
+  `<PR title> (#<number>)`; PR bodies use the What / Why / Verification
+  template (`docs/development.md` → "Pull requests and CI").
 
 ## Iterating
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,8 +142,13 @@ scripts/              # repo tooling (release, verification)
 - **PR titles follow Conventional Commits too.** A PR title is the summary
   of its change and should read as a Conventional Commit (`fix: …`,
   `feat: …`, `docs: …`, `chore: …`) with a scope where it helps
-  (`chore(ci): …`); multi-type PRs pick the dominant type. Merge titles
-  keep the convention and may append `(#<number>)`.
+  (`chore(ci): …`); multi-type PRs pick the dominant type.
+- **PRs are SQUASH-merged.** The PR's commits collapse into ONE commit on
+  `main` whose title is `<PR title> (#<number>)` — `git log` reads as one
+  Conventional Commit per PR, each traceable to its PR number. Never use
+  "merge" (merge commit) or "rebase" (per-commit replay) for the merge.
+  PR bodies follow the What / Why / Verification template in
+  `docs/development.md` → "Pull requests and CI".
 
 ## Iterating
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,11 @@ scripts/              # repo tooling (release, verification)
 - Comments state contracts and context, not reasoning transcripts.
 - Conventional Commits: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`,
   `chore:`. The CHANGELOG (Keep a Changelog format) is updated per change.
+- **PR titles follow Conventional Commits too.** A PR title is the summary
+  of its change and should read as a Conventional Commit (`fix: …`,
+  `feat: …`, `docs: …`, `chore: …`) with a scope where it helps
+  (`chore(ci): …`); multi-type PRs pick the dominant type. Merge titles
+  keep the convention and may append `(#<number>)`.
 
 ## Iterating
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -212,7 +212,10 @@ echo it:
 TOKEN=$(cat _dev/gh-token)
 ```
 
-Open a PR (head = your pushed branch, base = `main`):
+Open a PR (head = your pushed branch, base = `main`). The PR title must be a
+Conventional Commit (`feat: …`, `fix: …`, `docs: …`, `chore: …`, optionally
+scoped like `chore(ci): …`) — it is what lands on `main` as the merge title,
+and history stays uniform when every PR reads as one commit:
 
 ```sh
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \

--- a/docs/development.md
+++ b/docs/development.md
@@ -253,11 +253,9 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 ```
 
 Merge once the PR's `mergeable_state` is `clean` (checks green). Always
-**squash-merge** (`merge_method: "squash"`): the PR's commits collapse into
-ONE commit on `main`, and the commit title must be the PR title with the PR
-number appended — `git log` then reads as one Conventional Commit per PR and
-every change is traceable back to its PR. `commit_title` must be
-`"<PR title> (#<number>)"`:
+**squash-merge** (`merge_method: "squash"`) with
+`commit_title: "<PR title> (#<number>)"` — one Conventional Commit per PR on
+`main`, each traceable to its PR:
 
 ```sh
 curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
@@ -266,9 +264,8 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
   --data '{"commit_title":"<PR title> (#<number>)","merge_method":"squash"}'
 ```
 
-Do NOT use "merge" (adds a merge commit and buries the PR's changes in the
-history) or "rebase" (replays the PR's commits individually, so a multi-commit
-PR splits across several `main` commits with no PR-number trace).
+Do NOT use "merge" (adds a merge commit) or "rebase" (replays a multi-commit
+PR as several `main` commits with no PR trace).
 
 Before opening the PR, rebase onto the latest `origin/main` and re-run the
 gates: the main tree moves under concurrent work, and conflicts are cheapest

--- a/docs/development.md
+++ b/docs/development.md
@@ -224,6 +224,24 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
   --data '{"title":"...","head":"<branch>","base":"main","body":"..."}'
 ```
 
+The PR body follows a fixed template — what changed, why, and how it was
+verified (a reviewer reads the body, not the commits; the merge only keeps
+the title):
+
+```md
+## What
+
+<one line per change, concrete>
+
+## Why
+
+<context: the problem this solves, references to issues/PRs if any>
+
+## Verification
+
+<gates run + how the behavior was confirmed (manual steps, test names)>
+```
+
 Watch CI until it concludes — the workflow runs the full gate matrix,
 including the real-composition integration suite:
 
@@ -234,16 +252,23 @@ curl -s -H "Authorization: Bearer $TOKEN" \
   "https://api.github.com/repos/PGZXB/dsh-feishu/actions/runs?head_sha=$SHA"
 ```
 
-Merge once the PR's `mergeable_state` is `clean` (checks green). Use
-`merge_method: "rebase"` to keep `main` linear — "merge" always adds a merge
-commit even when a fast-forward is possible, leaving two commits per PR:
+Merge once the PR's `mergeable_state` is `clean` (checks green). Always
+**squash-merge** (`merge_method: "squash"`): the PR's commits collapse into
+ONE commit on `main`, and the commit title must be the PR title with the PR
+number appended — `git log` then reads as one Conventional Commit per PR and
+every change is traceable back to its PR. `commit_title` must be
+`"<PR title> (#<number>)"`:
 
 ```sh
 curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
   -H 'Accept: application/vnd.github+json' -H 'Content-Type: application/json' \
   https://api.github.com/repos/PGZXB/dsh-feishu/pulls/<number>/merge \
-  --data '{"commit_title":"...","merge_method":"rebase"}'
+  --data '{"commit_title":"<PR title> (#<number>)","merge_method":"squash"}'
 ```
+
+Do NOT use "merge" (adds a merge commit and buries the PR's changes in the
+history) or "rebase" (replays the PR's commits individually, so a multi-commit
+PR splits across several `main` commits with no PR-number trace).
 
 Before opening the PR, rebase onto the latest `origin/main` and re-run the
 gates: the main tree moves under concurrent work, and conflicts are cheapest


### PR DESCRIPTION
## What

- PR titles are Conventional Commits; every PR is **squash-merged** into one `main` commit titled `<PR title> (#<number>)`; PR bodies follow a What / Why / Verification template.
- Recorded in AGENTS.md (Style) and `docs/development.md` → "Pull requests and CI" (merge snippet now uses `merge_method: "squash"`).

## Why

Uniform history: `git log` reads as one Conventional Commit per PR, each traceable to its PR number.

## Verification

Docs-only change; no code gates affected.