### PR TITLE
docs: record rc.7 bump + canary workflow in CHANGELOG and development guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **dsh family bumped to `0.1.0-rc.7`.** `@deepseek-ai/dsh` is pinned
+  exactly in devDependencies; the rest of the `@deepseek-ai/*` surface
+  moves to `^0.1.0-rc.7`. Compatible with dsh `0.1.0-rc.7` (badge + Note in
+  `README.md`, `README.zh.md`).
+
+### Added
+
+- **Canary workflow** (`.github/workflows/canary.yml`): runs the full suite
+  daily (UTC 02:00) and on demand against the newest `@deepseek-ai/*`
+  release (`@next` dist-tag), surfacing upstream breaking changes before
+  users hit them.
+
 ## [0.2.0] - 2026-08-17
 
 ### Added

--- a/docs/development.md
+++ b/docs/development.md
@@ -110,6 +110,14 @@ instead of silently skipping. The dsh CLI is a devDependency
 allowed in `pnpm-workspace.yaml` — no credentials are involved; the Feishu
 and LLM mocks above are what make the suite runnable without secrets.
 
+A separate **canary workflow** (`.github/workflows/canary.yml`) runs the
+same suite daily (UTC 02:00) and on demand against the NEWEST
+`@deepseek-ai/*` release via the `@next` dist-tag (not the lockfile-pinned
+version, and not `@latest` — for most harness packages npm `latest` still
+points at the old `0.0.1-rc.x` line). A red canary means an upstream
+breaking change reached our code; see AGENTS.md → "Adapting to a new dsh
+release".
+
 ```sh
 pnpm run build        # ensure lib/ is current (the profile links the checkout)
 pnpm run test         # unit + integration (integration self-skips as needed)

--- a/docs/development.zh.md
+++ b/docs/development.zh.md
@@ -75,6 +75,8 @@ scripts/              # repo tooling
 
 CI 在每次 push 时都运行该套件（两个 node 版本分支都跑）：workflow 构建 checkout、准备 profile，并以 `FEISHU_INT_REQUIRED=1` 运行测试——这样缺少前置条件会响亮地让任务失败，而不是静默跳过。dsh CLI 是 devDependency（`@deepseek-ai/dsh`），原生构建脚本（node-pty 及其同类）在 `pnpm-workspace.yaml` 中获准——不涉及任何凭据；正是上面这些 Feishu 和 LLM mock 让套件在无需密钥的情况下也能运行。
 
+另有独立的 **canary workflow**（`.github/workflows/canary.yml`）每天（UTC 02:00）及按需对最新的 `@deepseek-ai/*` 发布运行同一套件，通过 `@next` dist-tag 安装（不是 lockfile 锁定的版本，也不是 `@latest`——对多数 harness 包，npm `latest` 仍指向旧的 `0.0.1-rc.x` 线）。canary 变红意味着上游破坏性变更波及我们的代码；见 AGENTS.md → "Adapting to a new dsh release"。
+
 ```sh
 pnpm run build        # ensure lib/ is current (the profile links the checkout)
 pnpm run test         # unit + integration (integration self-skips as needed)


### PR DESCRIPTION
## What

- CHANGELOG `[Unreleased]`: rc.7 dependency bump (Changed) + canary workflow (Added) — both shipped in #9 but never recorded.
- `docs/development.md` / `.zh.md`: document the canary workflow (daily + on-demand against `@next`, what a red run means).

## Why

Doc-upkeep audit of the recent rc.7/canary commits found two gaps against the Documentation map: CHANGELOG had no [Unreleased] entries, and the development guide never mentioned the canary workflow.

## Docs

- CHANGELOG.md, docs/development.md, docs/development.zh.md (this PR). No README changes.

## Verification

- Docs-only change; no code gates affected.