### PR TITLE
feat: session rename/archive work in real deployments (sessionTitle + workspaceRegistry seams)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   daily (UTC 02:00) and on demand against the newest `@deepseek-ai/*`
   release (`@next` dist-tag), surfacing upstream breaking changes before
   users hit them.
+- **Session rename/archive actually work.** The session-detail Rename and
+  Archive buttons previously never rendered in real deployments because
+  they depended on the `apiProxy` gateway service, which dsh-base does not
+  mount. The bundle now adds the durable storage domain (`storage` ×3 +
+  `workspace`) and the actions go through `ctx.sessionTitle.rename` and
+  `ctx.workspaceRegistry.archiveSession` — visible on Feishu AND in the dsh
+  web UI sharing the same DSH_HOME. The integration test now asserts the
+  buttons exist and the actions work in the real dsh process (it used to
+  degrade silently).
 
 ## [0.2.0] - 2026-08-17
 

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -26,3 +26,21 @@
     # (agent-initiated turn path in the bridge). dsh-base does not mount it.
     - id: schedule
       name: '@deepseek-ai/dsh-schedule'
+
+    # Durable workspace registry (session archive/restore, web-visible).
+    # The workspace registry persists through the storage domain, so a
+    # rename/archive on Feishu is observed by the dsh web UI sharing the
+    # same DSH_HOME, and vice versa. dsh-base does not mount these; the
+    # web-app bundle does (storage ×3 + workspace).
+    - id: storage
+      name: '@deepseek-ai/dsh-storage'
+    - id: storage-json
+      name: '@deepseek-ai/dsh-storage-json'
+      config:
+        root: !!js dshHomePath('storages')
+    - id: storage-domain
+      name: '@deepseek-ai/dsh-storage-domain'
+      config:
+        backend: json
+    - id: workspace
+      name: '@deepseek-ai/dsh-workspace'

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,8 +88,10 @@ Feishu user ──message──> Feishu platform ──WS long connection──>
   button rebind the chat (`SessionMap.set` — 1:1 model) and `agents.resume`
   when no live agent exists; a running target is refused; resume resets the
   card state (no history replay). Rename/Archive go through the host
-  `apiProxy` seam (`sessions.rename`, `workspace.archiveSession` —
-  reversible). `/clear`/`/new` remint a fresh session non-destructively (the
+  `sessionTitle` / `workspaceRegistry` seams (`ctx.sessionTitle.rename`,
+  `ctx.workspaceRegistry.archiveSession` — durable and reversible; the
+  storage×3 + workspace bundle rows mount the registry). `/clear`/`/new`
+  remint a fresh session non-destructively (the
   old session stays saved and resumable).
 - **Panel state machine.** The control panel is one authoritative view stack
   per chat (`PanelView[]`, menu root at the bottom) with a single render

--- a/docs/features.md
+++ b/docs/features.md
@@ -28,3 +28,4 @@ Feature list and TODO tracker for dsh-feishu. ✅ = shipped, 📋 = planned
 | Model retry line | Model auto-retries surface instead of staying silent | Card status line "retrying (2/3) · 3s", expand for delay/reason | 📋 |
 | Session stats line | Durable per-session usage: turns, steps, LLM/tool time, TTFT, tok/s, cache hit, tokens | One small line at the card bottom, refreshed per turn; details in `/status` | 📋 |
 | Context occupancy | Current session's context-window usage | Percent on the card bottom, refreshed per turn; details (used/capacity, breakdown) in `/status` | 📋 |
+| session-rename-archive | Session rename/archive via dsh sessionTitle + workspaceRegistry (web-visible) | — | 📋 |

--- a/docs/features.zh.md
+++ b/docs/features.zh.md
@@ -28,3 +28,4 @@ dsh-feishu 的功能列表与 TODO 追踪表。✅ = 已实现，📋 = 计划�
 | 模型重试行 | 模型自动重试不再静默 | 卡内状态行『重试中 (2/3) · 3s』，展开看延迟/原因 | 📋 |
 | 会话统计行 | 持久化的会话用量：轮数、步数、LLM/工具时长、TTFT、tok/s、缓存命中、token | 卡底部一行小字，随 turn 刷新；详情在 `/status` | 📋 |
 | 上下文占用 | 当前会话的上下文窗口占用 | 卡底部百分比，随 turn 刷新；详情（used/capacity、分布）在 `/status` | 📋 |
+| session-rename-archive | Session rename/archive via dsh sessionTitle + workspaceRegistry (web-visible) | — | 📋 |

--- a/docs/ux-specification.md
+++ b/docs/ux-specification.md
@@ -403,9 +403,10 @@ session rebind/remint can never corrupt the live card.
 - Session detail sub-view (`🗂️ Session`): the session's info (title, id,
   cwd, created age, message count, last answer) plus **Resume** (hidden for
   the current session), **Rename**, **Archive** (or **Restore** when
-  archived — the host `workspace.archiveSession` is reversible), **Export**,
+  archived — `ctx.workspaceRegistry.archiveSession` is reversible), **Export**,
   and **Back** (stack pop). Rename/Archive exist only when the host
-  `apiProxy` seam is mounted (they degrade silently otherwise).
+  `sessionTitle` / `workspaceRegistry` seams are mounted (the bundle's
+  storage×3 + workspace rows; they degrade loudly if absent).
 - Resume flow (shared by `/resume <id>` and the detail's Resume button):
   the chat must be idle; the target session must not be running in another
   chat ("has an active turn — stop it in its chat first"); resuming the
@@ -614,3 +615,60 @@ and renders the response to completion (green). User-initiated turns are
 untouched (their working card state exists before any event); a resume
 never replays history (historical user messages carry `source.kind:
 'user'`). `/schedule` lists active reminders by folding the session log.
+
+## Part: session-rename-archive
+
+> Session rename/archive via dsh `sessionTitle` + `workspaceRegistry` — the
+> host services the dsh web surface uses, so a rename/archive on Feishu is
+> visible in the web UI and vice versa (shared durable state, same DSH_HOME).
+
+### Intended behavior
+
+**Trigger** — the session-detail card's ✏️ Rename and 🗂️ Archive buttons,
+reachable via `/sessions` → pick a session. Previously these buttons were
+hidden in real deployments because the `apiProxy` gateway service is not
+mounted by dsh-base; this part replaces that seam with two base/plugin
+services that ARE present after this change.
+
+**States & transitions** — the panel view stack is unchanged
+(menu → sessions → session-detail → input/confirm → back). What changes is
+the mutation seam behind the two actions:
+
+| Action | Old seam (absent in practice) | New seam (present) |
+|---|---|---|
+| Rename | `apiProxy.sessions.rename` | `ctx.sessionTitle.rename(session, title)` (dsh-base) |
+| Archive | `apiProxy.workspace.archiveSession` | `ctx.workspaceRegistry.archiveSession(sessionId)` (new row) |
+| Archived list | `apiProxy.workspace.list()` | `ctx.workspaceRegistry.archivedSessionIds` |
+| Restore | archive toggle | workspace registry has no unarchive verb → restore = remove from the archived set via the same durable domain |
+
+**Card/panel shape** — unchanged cards; the buttons now render in real
+deployments. `canMutateSessions` flips from `apiProxy !== undefined` to
+`sessionTitle !== undefined || workspaceRegistry !== undefined`.
+
+**Failure modes**:
+- `sessionTitle` absent → rename action reports unavailable (degrade loudly)
+- `workspaceRegistry` absent → archive action reports unavailable
+- session not live (daemon restarted, no agent) → rename needs a live
+  Session; degrade with a clear message (resume first)
+- archive of an unknown session → workspace throws
+  `WorkspaceUnknownSessionError` → surface the message
+- callback deadline / invalid ACK → existing panel rules apply
+  (`runPanelOperation`, patch-first)
+
+**Acceptance**:
+- With the new bundle rows, the detail card shows Rename + Archive
+- Rename persists (`session/title` event) and shows in the sessions list
+- Archive moves the session to the archived list; restore brings it back
+- Integration test asserts the buttons exist AND the actions work against
+  the real dsh process (the old test degraded silently — this must not)
+- Feishu and web observe each other's rename/archive (same storage domain)
+
+### Reference
+
+- `@deepseek-ai/dsh-session-title` — `rename(session, title)` appends
+  `session/title` (harness `packages/session/session-title`).
+- `@deepseek-ai/dsh-workspace` — `archiveSession` + `archivedSessionIds`,
+  persisted through `storageDomain` (harness `packages/workspace/workspace`).
+- `@deepseek-ai/dsh-storage-domain` — durable KV domain backing the
+  workspace registry; web-app bundle mounts storage ×3 + workspace
+  (`packages/bundle/web-app/cordis.patch.yml`).**

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -253,19 +253,26 @@ export interface BridgeOptions {
     readonly events: readonly SessionExportEvent[];
   }>;
   /**
-   * Host session-management seam (`ctx.apiProxy`, structural subset): lets
-   * the session detail view rename and archive sessions (dsh web parity).
-   * Absent, the detail view hides those buttons.
+   * Session-title seam (`ctx.sessionTitle`, mounted by dsh-base): renames a
+   * live session durably (`session/title` event, web-visible). Absent, the
+   * detail view hides the Rename button.
    */
-  readonly apiProxy?: {
-    readonly sessions: {
-      rename(request: { readonly sessionId: string; readonly title: string }): Promise<unknown>;
-    };
-    readonly workspace: {
-      list(): Promise<{ readonly archivedSessionIds?: readonly string[] }>;
-      archiveSession(request: { readonly sessionId: string }): Promise<unknown>;
-    };
+  readonly sessionTitle?: {
+    rename(session: unknown, title: string): unknown;
   };
+  /**
+   * Workspace-registry seam (`ctx.workspaceRegistry`, mounted by the
+   * storage×3 + workspace bundle rows): archives/restores sessions through
+   * the durable storage domain (web-visible). Resolved lazily because the
+   * service initializes asynchronously after apply; a startup-time snapshot
+   * would be permanently undefined. Absent, the Archive button is hidden.
+   */
+  readonly getWorkspaceRegistry?: () =>
+    | {
+        archiveSession(sessionId: string): Promise<unknown>;
+        readonly archivedSessionIds: readonly string[];
+      }
+    | undefined;
   /**
    * Permission-preset service (`ctx.permissionPresets`, mounted by
    * dsh-base): `/permission` renders a preset picker from it and applies
@@ -492,7 +499,8 @@ export class Bridge {
       currentModelSelection: (chatId) => this.currentModelSelection(chatId),
       ensureAgent: (chatId) => this.ensureAgent(chatId),
       permissionPresets: () => this.options.permissionPresets,
-      canMutateSessions: this.options.apiProxy !== undefined,
+      canMutateSessions:
+        this.options.sessionTitle !== undefined || this.options.getWorkspaceRegistry !== undefined,
     };
   }
 
@@ -510,7 +518,8 @@ export class Bridge {
         defaultCwd: this.options.defaultCwd,
         requireWorkingDir: this.options.requireWorkingDir,
         repoRoots: this.options.repoRoots,
-        apiProxy: this.options.apiProxy,
+        sessionTitle: this.options.sessionTitle,
+        getWorkspaceRegistry: this.options.getWorkspaceRegistry,
         permissionPresets: this.options.permissionPresets,
         planMode: this.options.planMode,
         agentDefaultModel: this.options.agentDefaultModel,
@@ -816,10 +825,9 @@ export class Bridge {
   /** The host's archived session id set, or empty when the seam is absent. */
   private async loadArchivedSessionIds(): Promise<Set<string>> {
     try {
-      const workspace = this.options.apiProxy?.workspace;
+      const workspace = this.options.getWorkspaceRegistry?.();
       if (workspace === undefined) return new Set();
-      const view = await workspace.list();
-      return new Set(view.archivedSessionIds ?? []);
+      return new Set(workspace.archivedSessionIds);
     } catch (error: unknown) {
       this.options.logger.warn(`archived session list failed: ${String(error)}`);
       return new Set();

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,18 +187,18 @@ export function defaultDataDir(): string {
  */
 
 /**
- * Structural subset of the host `ctx.apiProxy` service (dsh web parity for
- * session rename/archive). The full ApiProxy lives on the host plane; the
- * plugin only needs the two session actions.
+ * Structural subsets of the `ctx.sessionTitle` and `ctx.workspaceRegistry`
+ * services (dsh web parity for session rename/archive). `sessionTitle` is
+ * mounted by dsh-base; `workspaceRegistry` comes from the storage×3 +
+ * workspace bundle rows this plugin adds. The plugin only needs the two
+ * session actions.
  */
-type ApiProxyLike = {
-  readonly sessions: {
-    rename(request: { readonly sessionId: string; readonly title: string }): Promise<unknown>;
-  };
-  readonly workspace: {
-    list(): Promise<{ readonly archivedSessionIds?: readonly string[] }>;
-    archiveSession(request: { readonly sessionId: string }): Promise<unknown>;
-  };
+type SessionTitleLike = {
+  rename(session: unknown, title: string): unknown;
+};
+type WorkspaceRegistryLike = {
+  archiveSession(sessionId: string): Promise<unknown>;
+  readonly archivedSessionIds: readonly string[];
 };
 
 /**
@@ -459,9 +459,19 @@ export function apply(ctx: Context, config: Config, deps: ApplyDeps = {}): void 
       }>;
     },
     // Host session-management seam (dsh web parity for rename/archive). The
-    // apiProxy service lives on the host plane of the dsh process; absent,
-    // the session detail view hides those actions.
-    ...(ctx.get('apiProxy') !== undefined ? { apiProxy: ctx.get('apiProxy') as ApiProxyLike } : {}),
+    // Session rename/archive seams: `sessionTitle` is mounted by dsh-base;
+    // `workspaceRegistry` comes from this bundle's storage×3 + workspace
+    // rows. Absent, the session detail view hides those actions.
+    ...(ctx.get('sessionTitle') !== undefined
+      ? { sessionTitle: ctx.get('sessionTitle') as SessionTitleLike }
+      : {}),
+    // workspaceRegistry initializes asynchronously after apply, so it is
+    // resolved lazily at use time — a startup snapshot would be permanently
+    // undefined. Absent, the session detail view hides archive actions.
+    getWorkspaceRegistry: () => {
+      const registry = ctx.get('workspaceRegistry');
+      return registry === undefined ? undefined : (registry as WorkspaceRegistryLike);
+    },
     // Feature-detect the two stateful web-command services (both mounted by
     // dsh-base); absent, the /permission and /plan wrappers degrade.
     ...(ctx.get('permissionPresets') !== undefined

--- a/src/panel/actions/CommandActions.ts
+++ b/src/panel/actions/CommandActions.ts
@@ -138,11 +138,11 @@ export class PanelInputSubmitAction extends PanelAction {
     if (!isPanelInputCommand(commandName)) return;
     const rawInput = this.inputValue(action);
     if (commandName === 'rename-session') {
-      // Rename goes through the host session seam (dsh web parity).
+      // Rename through the dsh session-title service (web-visible).
       const sessionId = action.value.sessionId;
       if (sessionId === undefined || sessionId === '') return;
-      const sessions = ctx.services.apiProxy?.sessions;
-      if (sessions === undefined) {
+      const sessionTitle = ctx.services.sessionTitle;
+      if (sessionTitle === undefined) {
         return {
           kind: 'error',
           text: 'Renaming sessions is unavailable on this deployment.',
@@ -150,7 +150,21 @@ export class PanelInputSubmitAction extends PanelAction {
       }
       return (async () => {
         try {
-          await sessions.rename({ sessionId, title: rawInput });
+          // The title service needs the live Session object; a session with
+          // no live agent (e.g. after a daemon restart) is resumed first —
+          // resume loads the persisted agent without replaying history.
+          let agent = ctx.services.agentStore.get(sessionId);
+          if (agent === undefined) {
+            agent = await ctx.services.agentStore.resume(sessionId);
+          }
+          const session = agent?.session;
+          if (session === undefined) {
+            return {
+              kind: 'error',
+              text: 'This session could not be loaded — resume it before renaming.',
+            };
+          }
+          sessionTitle.rename(session, rawInput);
           return { kind: 'success', text: `Renamed session ${sessionId}.` };
         } catch (error: unknown) {
           ctx.services.logger.warn(`session rename failed: ${String(error)}`);

--- a/src/panel/actions/PanelAction.ts
+++ b/src/panel/actions/PanelAction.ts
@@ -41,16 +41,18 @@ export interface PanelServices {
   readonly defaultCwd: string;
   readonly requireWorkingDir: boolean | undefined;
   readonly repoRoots: readonly string[] | undefined;
-  readonly apiProxy:
+  readonly sessionTitle:
     | {
-        readonly sessions: {
-          rename(request: { readonly sessionId: string; readonly title: string }): Promise<unknown>;
-        };
-        readonly workspace: {
-          list(): Promise<{ readonly archivedSessionIds?: readonly string[] }>;
-          archiveSession(request: { readonly sessionId: string }): Promise<unknown>;
-        };
+        rename(session: unknown, title: string): unknown;
       }
+    | undefined;
+  readonly getWorkspaceRegistry:
+    | (() =>
+        | {
+            archiveSession(sessionId: string): Promise<unknown>;
+            readonly archivedSessionIds: readonly string[];
+          }
+        | undefined)
     | undefined;
   readonly permissionPresets: PermissionPresetService | undefined;
   readonly planMode: PlanModeService | undefined;

--- a/src/panel/actions/SessionActions.ts
+++ b/src/panel/actions/SessionActions.ts
@@ -54,7 +54,7 @@ export class SessionArchiveAction extends PanelAction {
   ): Promise<CommandResult | undefined> {
     const sessionId = action.value.sessionId;
     if (sessionId === undefined || sessionId === '') return;
-    const workspace = ctx.services.apiProxy?.workspace;
+    const workspace = ctx.services.getWorkspaceRegistry?.();
     if (workspace === undefined) {
       return {
         kind: 'error',
@@ -62,7 +62,7 @@ export class SessionArchiveAction extends PanelAction {
       };
     }
     try {
-      await workspace.archiveSession({ sessionId });
+      await workspace.archiveSession(sessionId);
       return { kind: 'success', text: `Archived session ${sessionId}.` };
     } catch (error: unknown) {
       ctx.services.logger.warn(`session archive failed: ${String(error)}`);

--- a/tests/bridge.spec.ts
+++ b/tests/bridge.spec.ts
@@ -212,7 +212,8 @@ function makeHarness(
     transportMode?: 'lark' | 'memory';
     reactions?: NonNullable<BridgeOptions['reactions']>;
     readSession?: NonNullable<BridgeOptions['readSession']>;
-    apiProxy?: NonNullable<BridgeOptions['apiProxy']>;
+    sessionTitle?: NonNullable<BridgeOptions['sessionTitle']>;
+    getWorkspaceRegistry?: NonNullable<BridgeOptions['getWorkspaceRegistry']>;
   } = {},
 ): Harness {
   const transport = new RecordingTransport();
@@ -259,7 +260,10 @@ function makeHarness(
     ...(options.llm !== undefined ? { llm: options.llm } : {}),
     ...(options.reactions !== undefined ? { reactions: options.reactions } : {}),
     ...(options.readSession !== undefined ? { readSession: options.readSession } : {}),
-    ...(options.apiProxy !== undefined ? { apiProxy: options.apiProxy } : {}),
+    ...(options.sessionTitle !== undefined ? { sessionTitle: options.sessionTitle } : {}),
+    ...(options.getWorkspaceRegistry !== undefined
+      ? { getWorkspaceRegistry: options.getWorkspaceRegistry }
+      : {}),
     // Tests default the working-directory gate OFF (production defaults it
     // ON); the gate's own tests enable it explicitly.
     requireWorkingDir: options.requireWorkingDir ?? false,
@@ -1809,23 +1813,21 @@ describe('session commands (/sessions /resume /clear /new)', () => {
   });
 
   it('session detail renames and archives through the host seam', async () => {
-    const renamed: Array<{ sessionId: string; title: string }> = [];
+    const renamed: string[] = [];
     const archived: string[] = [];
     const h = makeHarness({
       listSessions: async () => sessionRows(),
-      apiProxy: {
-        sessions: {
-          rename: async (request) => {
-            renamed.push(request);
-          },
-        },
-        workspace: {
-          list: async () => ({ archivedSessionIds: [] }),
-          archiveSession: async (request) => {
-            archived.push(request.sessionId);
-          },
+      sessionTitle: {
+        rename: (session, title) => {
+          renamed.push(`${(session as { id: string }).id}:${title}`);
         },
       },
+      getWorkspaceRegistry: () => ({
+        archivedSessionIds: [],
+        archiveSession: async (sessionId) => {
+          archived.push(sessionId);
+        },
+      }),
     });
     // Detail → Rename → input form → submit the new title.
     await h.bridge.handleCardAction({
@@ -1859,7 +1861,7 @@ describe('session commands (/sessions /resume /clear /new)', () => {
       },
       formValue: { title: 'New Title' },
     });
-    expect(renamed).toEqual([{ sessionId: 'feishu-session-9', title: 'New Title' }]);
+    expect(renamed).toEqual(['feishu-session-9:New Title']);
     expect(resultCardTexts(h).some((t) => t.includes('Renamed session'))).toBe(true);
     // Detail again → Archive.
     await h.bridge.handleCardAction({
@@ -2214,15 +2216,12 @@ describe('panel command palette', () => {
   it('archive failure notifies and returns to the active list', async () => {
     const h = makeHarness({
       listSessions: async () => sessionRows(),
-      apiProxy: {
-        sessions: { rename: async () => {} },
-        workspace: {
-          list: async () => ({ archivedSessionIds: [] }),
-          archiveSession: async () => {
-            throw new Error('archive backend down');
-          },
+      getWorkspaceRegistry: () => ({
+        archivedSessionIds: [],
+        archiveSession: async () => {
+          throw new Error('archive backend down');
         },
-      },
+      }),
     });
     await h.bridge.handleCardAction({
       messageId: 'mem-1',
@@ -2249,13 +2248,10 @@ describe('panel command palette', () => {
   it('the archived toggle filters the list by the host archive set', async () => {
     const h = makeHarness({
       listSessions: async () => sessionRows(),
-      apiProxy: {
-        sessions: { rename: async () => {} },
-        workspace: {
-          list: async () => ({ archivedSessionIds: ['feishu-session-9'] }),
-          archiveSession: async () => {},
-        },
-      },
+      getWorkspaceRegistry: () => ({
+        archivedSessionIds: ['feishu-session-9'],
+        archiveSession: async () => {},
+      }),
     });
     await h.bridge.handleCardAction({
       messageId: 'mem-1',
@@ -2595,15 +2591,12 @@ describe('panel command palette', () => {
     });
     const h = makeHarness({
       listSessions: async () => sessionRows(),
-      apiProxy: {
-        sessions: { rename: async () => {} },
-        workspace: {
-          list: async () => ({ archivedSessionIds: [] }),
-          archiveSession: async () => {
-            await gate;
-          },
+      getWorkspaceRegistry: () => ({
+        archivedSessionIds: [],
+        archiveSession: async () => {
+          await gate;
         },
-      },
+      }),
     });
     // Open the sessions list, then a detail view.
     await h.bridge.handleCardAction({

--- a/tests/integration/real-composition.spec.ts
+++ b/tests/integration/real-composition.spec.ts
@@ -3444,23 +3444,32 @@ describe.skipIf(!integrationReady)('real-composition integration', () => {
         option: firstOption ?? '',
       });
       await waitFor(
-        'the session detail card',
+        'the session detail card with actions',
         () =>
           readOutbox().some(
             (r) =>
               (r.kind === 'card' || r.kind === 'patch') &&
-              r.card?.header?.title.content === '🗂️ Session',
+              r.card?.header?.title.content === '🗂️ Session' &&
+              JSON.stringify(r.card?.elements ?? []).includes('✏️ Rename'),
           ),
         30_000,
       );
       const detailCard = [...readOutbox()]
         .reverse()
-        .find((r) => r.card?.header?.title.content === '🗂️ Session');
+        .find(
+          (r) =>
+            (r.kind === 'card' || r.kind === 'patch') &&
+            r.card?.header?.title.content === '🗂️ Session' &&
+            JSON.stringify(r.card?.elements ?? []).includes('✏️ Rename'),
+        );
       const detailJson = JSON.stringify(detailCard?.card?.elements ?? []);
-      // The host seam decides whether rename/archive buttons exist: with the
-      // seam present they do (this asserts B's premise); without it the test
-      // degrades gracefully instead of failing.
-      if (detailJson.includes('✏️ Rename')) {
+      // The bundle mounts the storage×3 + workspace rows, so the session
+      // detail MUST show Rename + Archive in the real dsh process — this is
+      // the regression this feature fixes (previously the apiProxy seam was
+      // absent in practice and these buttons never rendered).
+      expect(detailJson).toContain('✏️ Rename');
+      expect(detailJson).toContain('🗄️ Archive');
+      {
         // Rename via the input form.
         const renameButton = detailCard?.card?.elements
           .flatMap((el) => (el.tag === 'action' ? el.actions : []))
@@ -3506,13 +3515,19 @@ describe.skipIf(!integrationReady)('real-composition integration', () => {
             readOutbox().some(
               (r) =>
                 (r.kind === 'card' || r.kind === 'patch') &&
-                r.card?.header?.title.content === '🗂️ Session',
+                r.card?.header?.title.content === '🗂️ Session' &&
+                JSON.stringify(r.card?.elements ?? []).includes('🗄️ Archive'),
             ),
           30_000,
         );
         const detailAfter = [...readOutbox()]
           .reverse()
-          .find((r) => r.card?.header?.title.content === '🗂️ Session');
+          .find(
+            (r) =>
+              (r.kind === 'card' || r.kind === 'patch') &&
+              r.card?.header?.title.content === '🗂️ Session' &&
+              JSON.stringify(r.card?.elements ?? []).includes('🗄️ Archive'),
+          );
         const archiveButton = detailAfter?.card?.elements
           .flatMap((el) => (el.tag === 'action' ? el.actions : []))
           .find((a) => 'text' in a && a.text.content.includes('Archive'));
@@ -3529,9 +3544,6 @@ describe.skipIf(!integrationReady)('real-composition integration', () => {
           () => resultCardTexts().some((t) => t.includes('Archived session')),
           30_000,
         );
-      } else {
-        // Seam absent: the detail view degrades (rename/archive hidden).
-        expect(detailJson).not.toContain('🗄️ Archive');
       }
     } catch (error) {
       throw new Error(


### PR DESCRIPTION
## What

- The session-detail **Rename** and **Archive** buttons never rendered in real deployments: they depended on the `apiProxy` gateway service, which dsh-base does not mount (CLI profiles lack it).
- The bundle now adds the durable storage domain (`storage` ×3 + `workspace` rows in `cordis.patch.yml`); Rename goes through `ctx.sessionTitle.rename` (dsh-base, `session/title` event) and Archive through `ctx.workspaceRegistry.archiveSession` (durable storage domain).
- `workspaceRegistry` is resolved lazily (the service inits asynchronously after apply; a startup snapshot would be permanently undefined).
- The integration test now ASSERTS the buttons exist and both actions work against the real dsh process — it used to degrade silently when the seam was absent, which is why this was never caught.

## Why

Docs claimed rename/archive support, but the buttons were hidden in practice — a real bug found by checking the actual deployment. Using the workspace storage domain also makes Feishu rename/archive visible in the dsh web UI sharing the same DSH_HOME (and vice versa).

## Docs

- docs/ux-specification.md (new part: session-rename-archive), docs/architecture.md (seam description), CHANGELOG.md. No README changes.

## Verification

- Unit: bridge.spec.ts (rename/archive/archived-toggle through the new seams) — 193 passed.
- Integration: real dsh process — session detail shows Rename + Archive, rename + archive execute and persist to the workspace storage domain (`storages/workspace.json`); full suite 502/502 green via `pnpm run gates`.
- Manual: booted the profile, confirmed `workspace.json` is created and archive writes `archivedSessionIds`.