### PR TITLE
feat: inbound attachments — images to the agent, files as receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Inbound attachments.** `image` and `file` messages are no longer
+  ignored. An image is downloaded (`im.v1.image.get`), committed through
+  the host's attachment service, and injected as an `image` content block
+  of the agent's user message — but ONLY when the chat's current model
+  advertises image input (the DeepSeek adapter rejects image content with
+  `UNSUPPORTED_CONTENT`, which would error the whole turn; pi-ai accepts
+  it). Under a text-only model (or absent attachment service), the image
+  degrades to a `📎 File received` receipt card + a file-name note, exactly
+  like a `file` message — the message is acknowledged, the turn never
+  errors because of an attachment. Reuses the existing `im:resource`
+  scope.
 - **Canary workflow** (`.github/workflows/canary.yml`): runs the full suite
   daily (UTC 02:00) and on demand against the newest `@deepseek-ai/*`
   release (`@next` dist-tag), surfacing upstream breaking changes before

--- a/docs/features.md
+++ b/docs/features.md
@@ -17,7 +17,7 @@ Feature list and TODO tracker for dsh-feishu. ✅ = shipped, 📋 = planned
 | Allowlists | `allowedChats` / `allowedUsers` gate who can talk to the bot | Env/config-driven, applied to messages and card actions | ✅ |
 | Session-log export | `/export` sends the chat's session log as a downloadable file message | File message with markdown transcript | ✅ |
 | Diagnostics | `/feishu-status` shows a diagnostic card (connection state, sessions, last inbound) | Read-only status card, usable mid-turn | ✅ |
-| Inbound attachments | Images/files the user sends are no longer ignored: images go to the agent, files become downloadable links | Image → agent processes it (reads it); file → download-link card | 📋 |
+| Inbound attachments | Images/files the user sends are no longer ignored: images are injected into the agent (image-capable models) or receipt-noted, files become receipt cards | Image → agent processes it (model supports images) / 📎 receipt; file → receipt card | ✅ |
 | Outbound files/images | Agent-produced images/files send as native Feishu image/file messages | Tap to view original / download | 📋 |
 | Session hard delete | Remove a session from the active list (archive + hide, restorable from the archived list) | Session-detail card Delete + confirm view | 📋 |
 | Agent preset selection | Pick an agent preset (e.g. PTC mode) when choosing a working directory | Mode dropdown on the `/repo` / `/cd` picker card; preset binds to the new session | 📋 |

--- a/docs/feishu-setup.md
+++ b/docs/feishu-setup.md
@@ -119,7 +119,7 @@ Current scopes (权限):
 | `im:chat` | Read chat metadata |
 | `im:chat.members:read` | Read group members (multi-bot / roster awareness) |
 | `im:chat.members:write_only` | Invite members into groups (botmux parity for group flows) |
-| `im:resource` | Upload file messages (`/export`) |
+| `im:resource` | Upload file messages (`/export`) and download inbound image/file messages (attachments) |
 
 ### 4. Publish
 

--- a/docs/feishu-setup.zh.md
+++ b/docs/feishu-setup.zh.md
@@ -101,7 +101,7 @@ endpoint、宿主机无需公网 IP（所有流量均为出站）。在 **Events
 | `im:chat` | 读取群信息 |
 | `im:chat.members:read` | 读取群成员（多机器人 / 名单感知） |
 | `im:chat.members:write_only` | 拉人进群（群流程，与 botmux 对齐） |
-| `im:resource` | 上传文件消息（`/export`） |
+| `im:resource` | 上传文件消息（`/export`）与下载入站图片/文件消息（附件） |
 
 ### 4. 发布
 

--- a/docs/ux-specification.md
+++ b/docs/ux-specification.md
@@ -682,3 +682,100 @@ deployments. `canMutateSessions` flips from `apiProxy !== undefined` to
 - `@deepseek-ai/dsh-storage-domain` — durable KV domain backing the
   workspace registry; web-app bundle mounts storage ×3 + workspace
   (`packages/bundle/web-app/cordis.patch.yml`).**
+
+
+## Part: inbound-attachments
+
+> Inbound images/files from Feishu are no longer ignored: images are injected
+> into the agent's user message (the model sees them), files surface as a
+> receipt card with the agent informed by name.
+
+### Intended behavior
+
+**Trigger** — an `im.message.receive_v1` event whose `message_type` is
+`image` or `file` (the surface today only accepts `text`). The message may
+arrive in a p2p chat or a group (mention gate applies exactly as for text).
+
+**Message normalization** — `normalizeMessageEvent` learns two more types:
+
+| message_type | content JSON | Normalized |
+|---|---|---|
+| `image` | `{"image_key": "img_v2_…"}` | `text: ''`, one image attachment |
+| `file` | `{"file_key": "file_v2_…"}` | `text: ''`, one file attachment |
+
+`FeishuMessage` gains an optional `attachments` array
+(`{kind:'image'|'file'; key: string; name?: string}`). Unknown types stay
+ignored. A mixed message is not a Feishu concept — each message is one type.
+
+**Image path (agent sees the image)** — the transport downloads the image
+bytes (`im.v1.image.get`, needs the existing `im:resource` scope), then the
+bridge saves them through the host's attachment store (`ctx.attachments`
+— `dsh-attachment-local` is part of the dsh-base bundle, so the seam is
+REALLY mounted, unlike `apiProxy`) and injects
+`{type:'image', attachment}` as a content block of the agent's user message
+(the reference is `packages/host/apiproxy/src/api-proxy.ts` →
+`durablePromptContent`: `saveImages(bytes) → refs → {type:'image'}` blocks).
+The turn then runs normally; the model can describe/read the image.
+
+**Image capability gate** — the DeepSeek chat-completions adapter REJECTS
+image content (`UNSUPPORTED_CONTENT` → the whole turn ends in error), while
+pi-ai accepts it. The bridge therefore injects an `image` block ONLY when
+the chat's current model advertises `image` in its input modalities
+(`ctx.llm.listModels` → `inputModalities`, via the same model directory the
+`/model` picker reads). Unknown model capability → conservative: treat the
+image as a file (receipt + name note). A turn must never error because of
+an attachment.
+
+**File path (receipt card)** — the agent cannot read arbitrary file bytes,
+so the file becomes a receipt: the bridge posts a small
+`📎 File received` card (file name when derivable, else the key) and the
+agent's user message carries a text note `[user sent a file: <name>]` so
+the model knows a file exists and can ask for its content. There is no
+downloadable URL for a Feishu `file_key` — the receipt is the surface's
+acknowledgement (user requirement "files become downloadable links" is not
+achievable on the platform; the receipt replaces it).
+
+**States & transitions** — this feature has NO new state machine: it feeds
+the existing turn pipeline. The only new branch is inside
+`deliverTurn` (build the content blocks before `createUserMessage`):
+
+| Step | Image (model supports) | Image (not) / File |
+|---|---|---|
+| Download | `image.get` → bytes + mediaType | `file.get` / `image.get` → bytes + name |
+| Save | `ctx.attachments.saveImage` → ref | — (not injected) |
+| Content | `[text, {type:'image', attachment}]` | `[text note]` |
+| Card | none (streaming card already opens) | `📎 File received` receipt card |
+| Failure | card + text notice, turn still runs text-only | same |
+
+**Card/panel shape** — no new panel views. The receipt card is a plain
+markdown card (like the approval/question notices), posted before
+`beginTurn` so it never interferes with the streaming card.
+
+**Failure modes**:
+- `image.get` / `file.get` download fails (scope missing, key expired):
+  log loudly, post a `⚠️ Could not download` text notice, and run the turn
+  text-only — a broken attachment must never wedge the chat.
+- `ctx.attachments` absent (attachment-local not mounted): feature-detect
+  and degrade — images fall back to the file path (receipt + text note)
+  with a loud log, matching the "hide the row, don't fail" seam rule.
+- `saveImage` rejects bytes (unsupported format, over limits): loud log +
+  text notice; turn continues without the image block.
+- Group message without mention: the existing mention gate drops it before
+  any download — no attachment handling for ignored messages.
+- Stale/unknown `image_key` at download time: same as download failure.
+
+**Acceptance checklist**:
+- [ ] `image` message + image-capable model → agent's user message carries an
+      `image` content block (unit-tested via a fake image-capable llm)
+- [ ] `image` message + text-only model → degrades to a `📎 File received`
+      receipt + name note; turn completes (no UNSUPPORTED_CONTENT error)
+      (unit + integration tested)
+- [ ] `file` message → receipt card posted, agent's message carries the
+      file-name note (unit + integration tested)
+- [ ] Group messages still gated by the mention gate (no attachment handling
+      for ignored messages)
+- [ ] Download failure → loud notice, turn continues text-only (unit-tested)
+- [ ] `attachments` service absent → image degrades to the file path, loud log
+      (unit-tested)
+- [ ] `im:resource` scope reused — manifest unchanged, feishu-setup.md
+      description updated

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -15,13 +15,14 @@
  */
 
 import type { Agent } from '@deepseek-ai/dsh-agent';
-import { createUserMessage } from '@deepseek-ai/dsh-llm';
+import { type ContentBlock, createUserMessage } from '@deepseek-ai/dsh-llm';
 import type { SessionEvent } from '@deepseek-ai/dsh-session';
 import {
   InteractionCardController,
   type InteractionCardHost,
 } from './cards/InteractionCardController.js';
 import {
+  buildInboundFileCard,
   buildPanelCard,
   buildResultCard,
   type ModelOptionView,
@@ -36,7 +37,13 @@ import type { StreamingCardManager } from './cards/streaming.js';
 import { registerSurfaceCommands, type SurfaceCommandHost } from './commands/surface.js';
 import { CommandRegistry, type CommandResult, parseSlash } from './commands.js';
 import { resolveDirectory } from './directory.js';
-import type { CardAction, CardJson, FeishuMessage, FeishuTransport } from './feishu/types.js';
+import type {
+  CardAction,
+  CardJson,
+  FeishuMessage,
+  FeishuTransport,
+  InboundAttachment,
+} from './feishu/types.js';
 import { MessageDeduplicator } from './message-dedup.js';
 import { parseModelArg } from './model-args.js';
 import type { PanelActionContext } from './panel/actions/PanelAction.js';
@@ -143,6 +150,12 @@ export interface LlmModelView {
   readonly provider: string;
   readonly id: string;
   readonly name: string;
+  /**
+   * Input modalities the model accepts (`'image'` when it can see images).
+   * Used by the inbound-attachment gate: an `image` content block is only
+   * injected when the chat's current model advertises image input.
+   */
+  readonly inputModalities?: readonly string[];
 }
 
 /** Structural subset of `ctx.llm` (`@deepseek-ai/dsh-llm`, mounted by
@@ -188,6 +201,21 @@ export interface AskQuestionsAnswerLike {
     readonly selected: readonly string[];
     readonly custom?: string;
   }[];
+}
+
+/**
+ * Structural subset of the dsh `ImageAttachmentRef` (the value `saveImage`
+ * resolves with): the agent's `image` content block carries it, so the
+ * surface must pass it through verbatim. Type-only — no runtime dependency
+ * on `@deepseek-ai/dsh-attachment`.
+ */
+export interface ImageAttachmentRefLike {
+  readonly attachmentId: string;
+  readonly mediaType: string;
+  readonly bytes: number;
+  readonly width: number;
+  readonly height: number;
+  readonly name?: string;
 }
 
 /** Options for {@link Bridge}. */
@@ -274,6 +302,20 @@ export interface BridgeOptions {
         archiveSession(sessionId: string): Promise<unknown>;
         readonly archivedSessionIds: readonly string[];
       }
+    | undefined;
+  /**
+   * Inbound-image seam (`ctx.attachments`, mounted by dsh-base's
+   * `dsh-attachment-local`): validate + durably commit one image so the
+   * agent's user message can carry an `image` content block. Resolved lazily
+   * (async-init service). Absent, inbound images degrade to the file path
+   * (receipt + name note) with a loud log — never a dropped message.
+   */
+  readonly getSaveImage?: () =>
+    | ((input: {
+        data: Uint8Array;
+        mediaType: string;
+        name?: string;
+      }) => Promise<ImageAttachmentRefLike>)
     | undefined;
   /**
    * Permission-preset service (`ctx.permissionPresets`, mounted by
@@ -1078,6 +1120,31 @@ export class Bridge {
   }
 
   /**
+   * Whether the chat's current model can SEE images (advertises `image` in
+   * its input modalities). The DeepSeek adapter rejects image content
+   * (`UNSUPPORTED_CONTENT` ends the whole turn in error), so image blocks
+   * are only injected when this is true; unknown → false (conservative: the
+   * image degrades to a file receipt instead of breaking the turn).
+   * @param chatId - the chat whose model to probe.
+   * @returns true when the model advertises image input, false otherwise.
+   */
+  private async supportsImageInput(chatId: string): Promise<boolean> {
+    const selection = this.currentModelSelection(chatId);
+    const llm = this.options.llm;
+    if (selection === undefined || llm === undefined) return false;
+    const [provider, modelId] = selection.split('/');
+    if (provider === undefined || modelId === undefined) return false;
+    try {
+      const models = await llm.listModels(provider);
+      const model = models.find((m) => m.id === modelId);
+      return model?.inputModalities?.includes('image') ?? false;
+    } catch (error: unknown) {
+      this.options.logger.warn(`image-capability probe for ${selection} failed: ${String(error)}`);
+      return false;
+    }
+  }
+
+  /**
    * Load the model catalog for the /model picker: every registered provider
    * × its advisory model list (a failing provider catalog is skipped, loud
    * in the log). `undefined` when the llm service is absent.
@@ -1170,6 +1237,10 @@ export class Bridge {
     // who started this turn.
     this.requesterOpenIds.set(message.chatId, message.senderOpenId);
     this.chatTypes.set(message.chatId, message.chatType === 'group' ? 'group' : 'p2p');
+    // Inbound media (image/file messages): download and inject BEFORE the
+    // turn starts — a broken attachment notices loudly but never wedges the
+    // chat (the turn continues, text-only when the attachment failed).
+    const content = await this.inboundContent(message);
     // Two-stage ack stage 1 + the working card state + the card open (the
     // streaming controller's beginTurn; a failed reaction or card post must
     // never block the turn).
@@ -1180,10 +1251,108 @@ export class Bridge {
     this.options.logger.info(`delivering message ${message.messageId} to agent`);
     agent.followup(
       createUserMessage({
-        content: [{ type: 'text', text: message.text }],
+        content,
         source: { kind: 'user' },
       }),
     );
+  }
+
+  /**
+   * Build the agent-visible content blocks for one inbound message. Text
+   * messages pass through unchanged. Image attachments are downloaded and
+   * committed through the attachment seam, then injected as `image` content
+   * blocks; file attachments post a receipt card and contribute a
+   * file-name note. Failures notice loudly and degrade to text-only — the
+   * message is never silently dropped.
+   * @param message - the normalized inbound message.
+   * @returns the content blocks for the agent's user message.
+   */
+  private async inboundContent(message: FeishuMessage): Promise<ContentBlock[]> {
+    const blocks: ContentBlock[] = [];
+    if (message.text !== '') blocks.push({ type: 'text', text: message.text });
+    // `attachments` is always present on normalized messages; the guard
+    // covers transport-level JSON without the field (defensive only).
+    for (const attachment of message.attachments ?? []) {
+      if (attachment.kind === 'image') {
+        const block = await this.inboundImage(message.chatId, attachment, blocks);
+        if (block !== undefined) blocks.push(block);
+      } else {
+        await this.inboundFile(message.chatId, attachment, blocks);
+      }
+    }
+    if (blocks.length === 0) blocks.push({ type: 'text', text: message.text });
+    return blocks;
+  }
+
+  /** Download + commit one inbound image; returns an `image` content block,
+   *  or `undefined` (with a loud notice) when the download/save fails. The
+   *  image is only injected when the chat's model supports image input — a
+   *  model that cannot see images (e.g. DeepSeek) would otherwise end the
+   *  whole turn in error (`UNSUPPORTED_CONTENT`). On degrade (service absent
+   *  or model not image-capable) the file path appends its note to `blocks`
+   *  — the message is never left content-less. */
+  private async inboundImage(
+    chatId: string,
+    attachment: InboundAttachment,
+    blocks: ContentBlock[],
+  ): Promise<ContentBlock | undefined> {
+    const saveImage = this.options.getSaveImage?.();
+    const imageCapable = await this.supportsImageInput(chatId);
+    if (saveImage === undefined || !imageCapable) {
+      // Attachment service not mounted, or the model cannot see images:
+      // degrade to the file path (receipt + name note) instead of dropping
+      // the message or erroring the turn (seam rule).
+      this.options.logger.warn(
+        `inbound image ${attachment.key}: ${saveImage === undefined ? 'attachment service absent' : `model does not support image input (${this.currentModelSelection(chatId) ?? 'unknown'})`}, treating as a file notice`,
+      );
+      await this.inboundFile(chatId, attachment, blocks);
+      return undefined;
+    }
+    try {
+      const downloaded = await this.options.transport.downloadImage(attachment.key);
+      const saved = await saveImage({
+        data: downloaded.data,
+        mediaType: downloaded.mediaType,
+      });
+      this.options.logger.debug(
+        `inbound image ${attachment.key} -> attachment ${saved.attachmentId} (${downloaded.data.length} bytes)`,
+      );
+      // The image block's `attachment` field is branded (`AttachmentId`) in
+      // the dsh types; the surface passes the saved ref through verbatim —
+      // the agent loop consumes it structurally.
+      return { type: 'image', attachment: saved } as ContentBlock;
+    } catch (error: unknown) {
+      this.options.logger.warn(
+        `inbound image ${attachment.key} could not be processed: ${String(error)}`,
+      );
+      await this.options.transport.sendText(
+        chatId,
+        '⚠️ An image you sent could not be read — sending as text only.',
+      );
+      return undefined;
+    }
+  }
+
+  /** Post the file-receipt card and append a file-name note to `blocks`.
+   *  Failures notice loudly and still let the turn run text-only. */
+  private async inboundFile(
+    chatId: string,
+    attachment: InboundAttachment,
+    blocks: ContentBlock[],
+  ): Promise<void> {
+    const name = attachment.name ?? attachment.key;
+    try {
+      await this.options.transport.downloadFile(attachment.key);
+      this.options.logger.debug(`inbound file ${attachment.key}: ${name} downloaded (${chatId})`);
+    } catch (error: unknown) {
+      this.options.logger.warn(`inbound file ${attachment.key} download failed: ${String(error)}`);
+    }
+    try {
+      await this.options.transport.sendCard(chatId, buildInboundFileCard(name));
+    } catch (error: unknown) {
+      this.options.logger.warn(`file receipt card failed: ${String(error)}`);
+    }
+    blocks.push({ type: 'text', text: `[user sent a file: ${name}]` });
   }
 
   /**

--- a/src/cards/render.ts
+++ b/src/cards/render.ts
@@ -905,6 +905,20 @@ export function buildPanelNoticeCard(options: {
 }
 
 /**
+ * The inbound-file receipt card: posted when a user sends a file message.
+ * The agent cannot read arbitrary file bytes, so the surface acknowledges
+ * the file (name) as a standalone card and tells the agent the file exists
+ * by name — there is no downloadable URL for a Feishu `file_key`.
+ */
+export function buildInboundFileCard(name: string): CardJson {
+  return {
+    config: { wide_screen_mode: true },
+    header: { title: { tag: 'plain_text', content: '📎 File received' }, template: 'blue' },
+    elements: [{ tag: 'markdown', content: `**${name}**\n\nTell me what to do with it.` }],
+  };
+}
+
+/**
  * A busy/operating placeholder card (NO buttons — blocks mis-taps while an
  * async panel operation runs). Posted FIRST in the callback so the panel
  * always carries an immediate patch (Lark otherwise restores the pre-click

--- a/src/feishu/types.ts
+++ b/src/feishu/types.ts
@@ -15,7 +15,8 @@ export interface FeishuMessage {
   readonly chatType: 'p2p' | 'group';
   /** The sender's app-scoped open id (not portable across apps). */
   readonly senderOpenId: string;
-  /** Plain text content, mentions stripped for group chats. */
+  /** Plain text content, mentions stripped for group chats. Empty for pure
+   *  image/file messages. */
   readonly text: string;
   /**
    * Open ids of mentioned members (the bot's own open id included when it is
@@ -23,8 +24,26 @@ export interface FeishuMessage {
    * p2p messages and for group messages without mentions.
    */
   readonly mentions: readonly string[];
+  /**
+   * Inbound media attachments carried by the message (image/file message
+   * types). Empty for text messages. Each entry names the platform resource
+   * key the transport can download (image_key / file_key).
+   */
+  readonly attachments: readonly InboundAttachment[];
   /** Unix epoch milliseconds from the Feishu `create_time` string. */
   readonly createdAt: number;
+}
+
+/** One inbound media attachment normalized from a Feishu message. */
+export interface InboundAttachment {
+  /** `image` (image_key) or `file` (file_key) — the download API to use. */
+  readonly kind: 'image' | 'file';
+  /** The platform resource key (`image_key` / `file_key`) to download. */
+  readonly key: string;
+  /** Derivable display name (files); images carry none. */
+  readonly name?: string;
+  /** The sender-declared media type (images only), when derivable. */
+  readonly mediaType?: string;
 }
 
 /** Result of sending a card message. */
@@ -235,6 +254,19 @@ export interface FeishuTransport {
   updateCard(messageId: string, card: CardJson): Promise<void>;
   /** Recall (delete) a previously sent message. Fire-and-forget-safe: never throws. */
   deleteMessage(messageId: string): Promise<void>;
+  /**
+   * Download an inbound image message's bytes (`im.v1.image.get`, keyed by
+   * the normalized `image_key`). Resolves with the raw bytes and the
+   * platform-declared media type; throws when the key is unknown/stale or
+   * the scope is missing.
+   */
+  downloadImage(key: string): Promise<{ data: Uint8Array; mediaType: string }>;
+  /**
+   * Download an inbound file message's bytes (`im.v1.file.get`, keyed by the
+   * normalized `file_key`). Resolves with the raw bytes; throws when the key
+   * is unknown/stale or the scope is missing.
+   */
+  downloadFile(key: string): Promise<Uint8Array>;
   /**
    * Membership counts for a chat, or `undefined` when unknown/unavailable.
    * Used for the 1-person-1-bot solo relaxation of the group mention gate.

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@
  * approvals, and questions land in later iterations.
  */
 
+import { readdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { Context } from '@deepseek-ai/cordis';
@@ -299,9 +300,43 @@ function defaultTransportFactory(
           : {}),
         // Solo-group relaxation tests inject member counts ('2u,1b').
         ...(mockStats !== undefined ? { chatStats: mockStats } : {}),
+        // Inbound-attachment integration tests seed download bytes from
+        // FEISHU_MEMORY_ATTACHMENTS: `<key>.bin` holds the bytes, and an
+        // optional `<key>.mediaType` file declares the media type.
+        ...(process.env.FEISHU_MEMORY_ATTACHMENTS !== undefined
+          ? { attachments: loadMemoryAttachments(process.env.FEISHU_MEMORY_ATTACHMENTS) }
+          : {}),
       });
   }
   return createLarkTransport;
+}
+
+/** Load seeded inbound-attachment bytes from a directory (`<key>.bin` +
+ *  optional `<key>.mediaType`). The test-only seam that lets the memory
+ *  transport serve `downloadImage`/`downloadFile` without Feishu. */
+function loadMemoryAttachments(
+  dir: string,
+): ReadonlyMap<string, { data: Uint8Array; mediaType?: string }> {
+  const map = new Map<string, { data: Uint8Array; mediaType?: string }>();
+  let files: string[];
+  try {
+    files = readdirSync(dir);
+  } catch {
+    return map;
+  }
+  for (const file of files) {
+    if (!file.endsWith('.bin')) continue;
+    const key = file.slice(0, -'.bin'.length);
+    const data = new Uint8Array(readFileSync(join(dir, file)));
+    let mediaType: string | undefined;
+    try {
+      mediaType = readFileSync(join(dir, `${key}.mediaType`), 'utf8').trim();
+    } catch {
+      // No media type file: leave undefined (defaults to image/png).
+    }
+    map.set(key, mediaType === undefined ? { data } : { data, mediaType });
+  }
+  return map;
 }
 
 /** Parse `FEISHU_MOCK_CHAT_STATS` ('<users>u,<bots>b' — a test-only seam) into
@@ -478,6 +513,26 @@ export function apply(ctx: Context, config: Config, deps: ApplyDeps = {}): void 
       const registry = ctx.get('workspaceRegistry');
       return registry === undefined ? undefined : (registry as WorkspaceRegistryLike);
     },
+    // Inbound-image seam: ctx.attachments (dsh-attachment-local, mounted by
+    // dsh-base) validates + durably commits one image. Resolved lazily —
+    // the service initializes asynchronously. Absent, images degrade to the
+    // file path (loud log) instead of dropping the message.
+    getSaveImage: () => {
+      const attachments = ctx.get('attachments') as
+        | {
+            saveImage(input: { data: Uint8Array; mediaType: string; name?: string }): Promise<{
+              attachmentId: string;
+              mediaType: string;
+              bytes: number;
+              width: number;
+              height: number;
+              name?: string;
+            }>;
+          }
+        | undefined;
+      if (attachments === undefined) return undefined;
+      return (input) => attachments.saveImage(input);
+    },
     // Feature-detect the two stateful web-command services (both mounted by
     // dsh-base); absent, the /permission and /plan wrappers degrade.
     ...(ctx.get('permissionPresets') !== undefined
@@ -497,7 +552,7 @@ export function apply(ctx: Context, config: Config, deps: ApplyDeps = {}): void 
       `permissionPresets=${ctx.get('permissionPresets') !== undefined} ` +
       `planMode=${ctx.get('planMode') !== undefined} ` +
       `agentDefaultModel=${ctx.get('agentDefaultModel') !== undefined} ` +
-      `llm=${ctx.get('llm') !== undefined}`,
+      `llm=${ctx.get('llm') !== undefined} attachments=${ctx.get('attachments') !== undefined}`,
   );
   // Interactive approvals: answer every `approval/request` with a Feishu
   // approval card. Fail-closed semantics are the service's own (throwing or

--- a/src/memory-transport.ts
+++ b/src/memory-transport.ts
@@ -43,6 +43,12 @@ export interface MemoryTransportOptions {
   readonly botOpenId?: string;
   /** Membership counts served for every chat (mention-gate tests). */
   readonly chatStats?: ChatStats;
+  /**
+   * Seeded inbound attachment bytes, keyed by the resource key
+   * (image_key / file_key). `downloadImage`/`downloadFile` resolve from here,
+   * so integration tests can exercise the download path without Feishu.
+   */
+  readonly attachments?: ReadonlyMap<string, { data: Uint8Array; mediaType?: string }>;
 }
 
 /** One recorded send/update in the outbox. */
@@ -72,6 +78,7 @@ export class MemoryTransport implements FeishuTransport {
   private timer: ReturnType<typeof setInterval> | null = null;
   private readonly botOpenId: string | undefined;
   private readonly stats: ChatStats | undefined;
+  private readonly seededAttachments: ReadonlyMap<string, { data: Uint8Array; mediaType?: string }>;
   private seq = 0;
   private readonly inboxDir: string;
   private readonly actionsDir: string;
@@ -85,6 +92,7 @@ export class MemoryTransport implements FeishuTransport {
     this.pollIntervalMs = options.pollIntervalMs ?? 200;
     this.botOpenId = options.botOpenId;
     this.stats = options.chatStats;
+    this.seededAttachments = options.attachments ?? new Map();
   }
 
   /** The bot's own open id configured for this transport. */
@@ -177,6 +185,24 @@ export class MemoryTransport implements FeishuTransport {
   /** Record a message recall in the outbox. */
   async deleteMessage(messageId: string): Promise<void> {
     this.record({ kind: 'delete', messageId });
+  }
+
+  /** Resolve an inbound image's bytes from the seeded attachment map. */
+  async downloadImage(key: string): Promise<{ data: Uint8Array; mediaType: string }> {
+    const seeded = this.seededAttachments.get(key);
+    if (seeded === undefined) {
+      throw new Error(`memory transport: no seeded image for key ${key}`);
+    }
+    return { data: seeded.data, mediaType: seeded.mediaType ?? 'image/png' };
+  }
+
+  /** Resolve an inbound file's bytes from the seeded attachment map. */
+  async downloadFile(key: string): Promise<Uint8Array> {
+    const seeded = this.seededAttachments.get(key);
+    if (seeded === undefined) {
+      throw new Error(`memory transport: no seeded file for key ${key}`);
+    }
+    return seeded.data;
   }
 
   /** Direct same-process delivery (bypasses the file channel) for tests. */

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -30,6 +30,7 @@ import type {
   ChatStats,
   FeishuMessage,
   FeishuTransport,
+  InboundAttachment,
   SentCard,
 } from './feishu/types.js';
 
@@ -104,7 +105,28 @@ export class FeishuApiError extends Error {
 const MENTION_PATTERN = /<at[^>]*>.*?<\/at>/g;
 
 /** Message types the surface understands; everything else is ignored. */
-const SUPPORTED_MESSAGE_TYPE = 'text';
+const SUPPORTED_MESSAGE_TYPES = new Set(['text', 'image', 'file']);
+
+/** Parse an image/file message's content JSON into its attachment, or
+ *  `undefined` when the content is malformed. */
+function parseAttachment(content: string, messageType: string): InboundAttachment | undefined {
+  try {
+    const parsed = JSON.parse(content) as Record<string, string>;
+    if (messageType === 'image') {
+      const key = parsed.image_key;
+      if (typeof key === 'string' && key !== '') return { kind: 'image', key };
+      return undefined;
+    }
+    const key = parsed.file_key;
+    if (typeof key === 'string' && key !== '') {
+      const name = parsed.file_name;
+      return { kind: 'file', key, ...(typeof name === 'string' && name !== '' ? { name } : {}) };
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Normalize a raw Feishu `im.message.receive_v1` payload into a surface
@@ -115,22 +137,30 @@ const SUPPORTED_MESSAGE_TYPE = 'text';
  */
 export function normalizeMessageEvent(data: RawMessageEvent): FeishuMessage | undefined {
   const message = data.message;
-  if (message.message_type !== SUPPORTED_MESSAGE_TYPE) return undefined;
+  if (!SUPPORTED_MESSAGE_TYPES.has(message.message_type)) return undefined;
   const senderOpenId = data.sender?.sender_id?.open_id ?? '';
   let text = '';
-  try {
-    const parsed = JSON.parse(message.content) as { text?: string };
-    text = parsed.text ?? '';
-  } catch {
-    return undefined;
+  let attachment: InboundAttachment | undefined;
+  if (message.message_type === 'text') {
+    try {
+      const parsed = JSON.parse(message.content) as { text?: string };
+      text = parsed.text ?? '';
+    } catch {
+      return undefined;
+    }
+    text = text.replace(MENTION_PATTERN, ' ').replace(/\s+/g, ' ').trim();
+  } else {
+    attachment = parseAttachment(message.content, message.message_type);
+    // A malformed image/file content (no key) is not a usable message.
+    if (attachment === undefined) return undefined;
   }
-  text = text.replace(MENTION_PATTERN, ' ').replace(/\s+/g, ' ').trim();
   return {
     messageId: message.message_id,
     chatId: message.chat_id,
     chatType: message.chat_type === 'group' ? 'group' : 'p2p',
     senderOpenId,
     text,
+    attachments: attachment === undefined ? [] : [attachment],
     mentions: (message.mentions ?? [])
       .map((mention) => mention.id?.open_id)
       .filter((id): id is string => id !== undefined && id !== ''),
@@ -415,6 +445,42 @@ export class LarkTransport implements FeishuTransport {
     } catch (error: unknown) {
       this.logger?.warn(`message recall failed for ${messageId}: ${String(error)}`);
     }
+  }
+
+  /**
+   * Download an inbound image message's bytes (`im.v1.image.get`). The image
+   * resource endpoint returns the raw raster bytes (not JSON); the declared
+   * media type is derived from the message event. Throws on unknown/stale
+   * keys or a missing `im:resource` scope.
+   */
+  async downloadImage(key: string): Promise<{ data: Uint8Array; mediaType: string }> {
+    this.logger?.debug(`transport downloadImage ${key}`);
+    // im.v1.image.get streams the resource; the SDK resolves the response
+    // body as a Buffer for binary resources.
+    const response = (await this.client.im.v1.image.get({
+      path: { image_key: key },
+    })) as unknown as { file?: Buffer; data?: { image?: Buffer } };
+    const bytes = response.file ?? response.data?.image;
+    if (bytes === undefined) {
+      throw new FeishuApiError('im.v1.image.get', -1, 'response carried no image bytes');
+    }
+    // The image resource API does not echo the media type; the message
+    // content declares it, so callers pass it through. Default to png when
+    // unknown — saveImage re-detects the real format from bytes.
+    return { data: new Uint8Array(bytes), mediaType: 'image/png' };
+  }
+
+  /** Download an inbound file message's bytes (`im.v1.file.get`). */
+  async downloadFile(key: string): Promise<Uint8Array> {
+    this.logger?.debug(`transport downloadFile ${key}`);
+    const response = (await this.client.im.v1.file.get({
+      path: { file_key: key },
+    })) as unknown as { file?: Buffer; data?: { file?: Buffer } };
+    const bytes = response.file ?? response.data?.file;
+    if (bytes === undefined) {
+      throw new FeishuApiError('im.v1.file.get', -1, 'response carried no file bytes');
+    }
+    return new Uint8Array(bytes);
   }
 
   /** Create a message in a chat; assert the API succeeded. */

--- a/tests/bridge.spec.ts
+++ b/tests/bridge.spec.ts
@@ -105,6 +105,18 @@ class RecordingTransport implements FeishuTransport {
   async deleteMessage(messageId: string): Promise<void> {
     this.deletedMessages.push(messageId);
   }
+  /** Configurable inbound-download behavior (default: fail — tests seed
+   *  success/failure per scenario). */
+  downloadImageImpl?: (key: string) => Promise<{ data: Uint8Array; mediaType: string }>;
+  downloadFileImpl?: (key: string) => Promise<Uint8Array>;
+  async downloadImage(key: string): Promise<{ data: Uint8Array; mediaType: string }> {
+    if (this.downloadImageImpl === undefined) throw new Error(`no downloadImage for ${key}`);
+    return this.downloadImageImpl(key);
+  }
+  async downloadFile(key: string): Promise<Uint8Array> {
+    if (this.downloadFileImpl === undefined) throw new Error(`no downloadFile for ${key}`);
+    return this.downloadFileImpl(key);
+  }
   deliver(message: FeishuMessage): void {
     this.handler?.(message);
   }
@@ -221,6 +233,7 @@ function makeHarness(
     readSession?: NonNullable<BridgeOptions['readSession']>;
     sessionTitle?: NonNullable<BridgeOptions['sessionTitle']>;
     getWorkspaceRegistry?: NonNullable<BridgeOptions['getWorkspaceRegistry']>;
+    getSaveImage?: NonNullable<BridgeOptions['getSaveImage']>;
   } = {},
 ): Harness {
   const transport = new RecordingTransport();
@@ -271,6 +284,7 @@ function makeHarness(
     ...(options.getWorkspaceRegistry !== undefined
       ? { getWorkspaceRegistry: options.getWorkspaceRegistry }
       : {}),
+    ...(options.getSaveImage !== undefined ? { getSaveImage: options.getSaveImage } : {}),
     // Tests default the working-directory gate OFF (production defaults it
     // ON); the gate's own tests enable it explicitly.
     requireWorkingDir: options.requireWorkingDir ?? false,
@@ -298,6 +312,7 @@ function message(overrides: Partial<FeishuMessage> = {}): FeishuMessage {
     senderOpenId: 'ou_user',
     text: 'hello',
     mentions: [],
+    attachments: [],
     createdAt: 1_700_000_000_000,
     ...overrides,
   };
@@ -360,6 +375,149 @@ describe('Bridge', () => {
     expect(followups).toHaveLength(1);
     expect(followups?.[0]?.content).toEqual([{ type: 'text', text: 'hello' }]);
     expect(h.transport.sentCards).toHaveLength(1);
+  });
+
+  describe('inbound attachments', () => {
+    const pngBytes = new Uint8Array([137, 80, 78, 71]);
+
+    /** An llm catalog where the current model advertises image input. */
+    const imageCapableLlm = (): LlmService => ({
+      listProviders: () => [{ id: 'pi-ai', name: 'pi-ai' }],
+      async listModels(provider: string) {
+        return [
+          { provider, id: 'pi-1.5-vision', name: 'pi vision', inputModalities: ['text', 'image'] },
+        ];
+      },
+    });
+    /** Point the default model at the image-capable entry. */
+    const imageCapableDefault = (): NonNullable<BridgeOptions['agentDefaultModel']> => ({
+      currentSelection: () => ({ provider: 'pi-ai', model: 'pi-1.5-vision' }),
+      saveSelection: async () => {},
+    });
+
+    it('injects an image message as an image content block', async () => {
+      const saved: unknown[] = [];
+      const h = makeHarness({
+        llm: imageCapableLlm(),
+        agentDefaultModel: imageCapableDefault(),
+        getSaveImage: () => (input: { data: Uint8Array; mediaType: string }) => {
+          saved.push(input);
+          return Promise.resolve({
+            attachmentId: 'att-1',
+            mediaType: input.mediaType,
+            bytes: input.data.length,
+            width: 1,
+            height: 1,
+          });
+        },
+      });
+      h.transport.downloadImageImpl = async () => ({ data: pngBytes, mediaType: 'image/png' });
+      await h.bridge.handleMessage(
+        message({
+          text: '',
+          attachments: [{ kind: 'image', key: 'img-1' }],
+        }),
+      );
+      const followups = h.agentStore.followups.get('feishu-session-1');
+      expect(saved).toEqual([{ data: pngBytes, mediaType: 'image/png' }]);
+      const blocks = followups?.[0]?.content as unknown[];
+      expect(blocks?.[0]).toMatchObject({ type: 'image' });
+      // No receipt card for images.
+      expect(h.transport.sentCards).toHaveLength(1);
+    });
+
+    it('posts a file receipt card and names the file to the agent', async () => {
+      const h = makeHarness();
+      h.transport.downloadFileImpl = async () => new Uint8Array([1, 2, 3]);
+      await h.bridge.handleMessage(
+        message({
+          text: '',
+          attachments: [{ kind: 'file', key: 'file-1', name: 'notes.txt' }],
+        }),
+      );
+      // Receipt card + streaming card.
+      expect(h.transport.sentCards).toHaveLength(2);
+      expect(h.transport.sentCards[0]?.header?.title.content).toBe('📎 File received');
+      const followups = h.agentStore.followups.get('feishu-session-1');
+      const blocks = followups?.[0]?.content as unknown[];
+      expect(blocks?.[0]).toEqual({ type: 'text', text: '[user sent a file: notes.txt]' });
+    });
+
+    it('a failed image download notices loudly and the turn continues text-only', async () => {
+      const h = makeHarness({
+        llm: imageCapableLlm(),
+        agentDefaultModel: imageCapableDefault(),
+        getSaveImage: () => (input: { data: Uint8Array; mediaType: string }) =>
+          Promise.resolve({
+            attachmentId: 'att-1',
+            mediaType: input.mediaType,
+            bytes: input.data.length,
+            width: 1,
+            height: 1,
+          }),
+      });
+      // downloadImageImpl left unset → throws.
+      await h.bridge.handleMessage(
+        message({
+          text: '',
+          attachments: [{ kind: 'image', key: 'missing' }],
+        }),
+      );
+      expect(h.transport.sentTexts.some((t) => t.text.includes('could not be read'))).toBe(true);
+      // The turn still ran (text-only).
+      expect(h.agentStore.followups.get('feishu-session-1')).toHaveLength(1);
+    });
+
+    it('degrades to the file path when the attachment service is absent', async () => {
+      const h = makeHarness({
+        llm: imageCapableLlm(),
+        agentDefaultModel: imageCapableDefault(),
+      }); // no getSaveImage
+      h.transport.downloadImageImpl = async () => ({ data: pngBytes, mediaType: 'image/png' });
+      await h.bridge.handleMessage(
+        message({
+          text: '',
+          attachments: [{ kind: 'image', key: 'img-1' }],
+        }),
+      );
+      // Degraded: receipt card (file path) + file-name note; image NOT saved.
+      expect(h.transport.sentCards[0]?.header?.title.content).toBe('📎 File received');
+      const followups = h.agentStore.followups.get('feishu-session-1');
+      const blocks = followups?.[0]?.content as unknown[];
+      expect(JSON.stringify(blocks)).toContain('img-1');
+      expect(JSON.stringify(blocks)).not.toContain('"type":"image"');
+    });
+
+    it('degrades to the file path when the model cannot see images', async () => {
+      // FakeLlmService (DeepSeek, no image modality) + no capability → the
+      // image becomes a file receipt, never an injected image block.
+      const h = makeHarness({
+        llm: new FakeLlmService(),
+        agentDefaultModel: {
+          currentSelection: () => ({ provider: 'deepseek-official', model: 'deepseek-v4-flash' }),
+          saveSelection: async () => {},
+        },
+        getSaveImage: () => (input: { data: Uint8Array; mediaType: string }) =>
+          Promise.resolve({
+            attachmentId: 'att-1',
+            mediaType: input.mediaType,
+            bytes: input.data.length,
+            width: 1,
+            height: 1,
+          }),
+      });
+      h.transport.downloadImageImpl = async () => ({ data: pngBytes, mediaType: 'image/png' });
+      await h.bridge.handleMessage(
+        message({
+          text: '',
+          attachments: [{ kind: 'image', key: 'img-1' }],
+        }),
+      );
+      expect(h.transport.sentCards[0]?.header?.title.content).toBe('📎 File received');
+      const followups = h.agentStore.followups.get('feishu-session-1');
+      const blocks = followups?.[0]?.content as unknown[];
+      expect(JSON.stringify(blocks)).not.toContain('"type":"image"');
+    });
   });
 
   it('wires inbound transport messages into the bridge', async () => {

--- a/tests/cards/InteractionCardController.spec.ts
+++ b/tests/cards/InteractionCardController.spec.ts
@@ -49,8 +49,13 @@ class RecordingTransport implements FeishuTransport {
     this.updatedCards.push(card);
   }
   async deleteMessage(_messageId: string): Promise<void> {}
+  async downloadImage(_key: string): Promise<{ data: Uint8Array; mediaType: string }> {
+    throw new Error('downloadImage not implemented in this fake');
+  }
+  async downloadFile(_key: string): Promise<Uint8Array> {
+    throw new Error('downloadFile not implemented in this fake');
+  }
 }
-
 /** A minimal agent fake (session id only). */
 function makeAgent(sessionId = 'feishu-session-1'): Agent {
   return {

--- a/tests/cards/StreamingCardController.spec.ts
+++ b/tests/cards/StreamingCardController.spec.ts
@@ -69,8 +69,13 @@ class RecordingTransport implements FeishuTransport {
     this.updatedCards.push(card);
   }
   async deleteMessage(_messageId: string): Promise<void> {}
+  async downloadImage(_key: string): Promise<{ data: Uint8Array; mediaType: string }> {
+    throw new Error('downloadImage not implemented in this fake');
+  }
+  async downloadFile(_key: string): Promise<Uint8Array> {
+    throw new Error('downloadFile not implemented in this fake');
+  }
 }
-
 /** A minimal live agent fake for stop/retry. */
 function makeAgent(): {
   agent: Agent;

--- a/tests/cards/streaming.spec.ts
+++ b/tests/cards/streaming.spec.ts
@@ -63,8 +63,13 @@ class RecordingTransport implements FeishuTransport {
     this.updated.push(card);
   }
   async deleteMessage(_messageId: string): Promise<void> {}
+  async downloadImage(_key: string): Promise<{ data: Uint8Array; mediaType: string }> {
+    throw new Error('downloadImage not implemented in this fake');
+  }
+  async downloadFile(_key: string): Promise<Uint8Array> {
+    throw new Error('downloadFile not implemented in this fake');
+  }
 }
-
 function snapshot(overrides: Partial<CardSnapshot> = {}): CardSnapshot {
   return { title: 'T', content: '', rows: [], status: 'working', ...overrides };
 }

--- a/tests/commands-surface.spec.ts
+++ b/tests/commands-surface.spec.ts
@@ -50,8 +50,13 @@ class FakeTransport implements FeishuTransport {
   }
   async updateCard(_messageId: string, _card: CardJson): Promise<void> {}
   async deleteMessage(_messageId: string): Promise<void> {}
+  async downloadImage(_key: string): Promise<{ data: Uint8Array; mediaType: string }> {
+    throw new Error('downloadImage not implemented in this fake');
+  }
+  async downloadFile(_key: string): Promise<Uint8Array> {
+    throw new Error('downloadFile not implemented in this fake');
+  }
 }
-
 /** A fake agent (cast — only session id is used by the commands). */
 function makeAgent(): Agent {
   return {

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -68,8 +68,13 @@ class FakeTransport implements FeishuTransport {
   }
   async updateCard(_messageId: string, _card: CardJson): Promise<void> {}
   async deleteMessage(_messageId: string): Promise<void> {}
+  async downloadImage(_key: string): Promise<{ data: Uint8Array; mediaType: string }> {
+    throw new Error('downloadImage not implemented in this fake');
+  }
+  async downloadFile(_key: string): Promise<Uint8Array> {
+    throw new Error('downloadFile not implemented in this fake');
+  }
 }
-
 /** Minimal fake of the cordis context surface the plugin touches. */
 function makeFakeContext(
   options: {

--- a/tests/integration/inbound-attachments.spec.ts
+++ b/tests/integration/inbound-attachments.spec.ts
@@ -1,0 +1,286 @@
+/**
+ * Real-composition integration tests for inbound attachments (F1): a real
+ * dsh process booted from the real profile, with only Feishu (memory
+ * transport) and the LLM API (mock server) mocked. Asserts that an inbound
+ * `image` message reaches the agent as an `image` content block, and an
+ * inbound `file` message posts a receipt card + file-name note.
+ *
+ * Self-skips when the environment lacks a prepared profile or the dsh CLI,
+ * like the sibling real-composition suite (see docs/development.md →
+ * "Integration test").
+ */
+
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { MemoryOutboxRecord } from '../../src/memory-transport.js';
+import { type MockLlmServer, startMockLlmServer } from './mock-llm-server.js';
+
+const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+const DSH_HOME = process.env.FEISHU_INT_DSH_HOME ?? join(REPO_ROOT, '_dev', 'dsh-home');
+const PROFILE_DIR = join(DSH_HOME, 'profiles', 'feishu-dev');
+const MEMORY_DIR = join(REPO_ROOT, '_dev', 'int-memory-attachments');
+const INBOX_DIR = join(MEMORY_DIR, 'inbox');
+const OUTBOX_DIR = join(MEMORY_DIR, 'outbox');
+const ATTACH_DIR = join(REPO_ROOT, '_dev', 'int-attachments-seed');
+const INT_CWD = join(REPO_ROOT, '_dev', 'int-cwd-attachments');
+
+function resolveDshBin(): string | undefined {
+  if (process.env.DSH_BIN !== undefined && process.env.DSH_BIN !== '') return process.env.DSH_BIN;
+  const probe = spawnSync('sh', ['-c', 'command -v dsh'], { encoding: 'utf8' });
+  if (probe.status === 0 && probe.stdout.trim() !== '') return probe.stdout.trim();
+  return undefined;
+}
+
+function readOutbox(): MemoryOutboxRecord[] {
+  let files: string[];
+  try {
+    files = readdirSync(OUTBOX_DIR).filter((file) => file.endsWith('.json'));
+  } catch {
+    return [];
+  }
+  return files
+    .map((file) => {
+      try {
+        return JSON.parse(readFileSync(join(OUTBOX_DIR, file), 'utf8')) as MemoryOutboxRecord;
+      } catch {
+        return undefined;
+      }
+    })
+    .filter((record): record is MemoryOutboxRecord => record !== undefined)
+    .sort((a, b) => a.seq - b.seq);
+}
+
+async function waitFor(
+  description: string,
+  predicate: () => boolean,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (predicate()) return;
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${description}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+}
+
+const dshBin = resolveDshBin();
+const profileReady = existsSync(join(PROFILE_DIR, 'package.json'));
+const built = existsSync(join(REPO_ROOT, 'lib', 'index.js'));
+const integrationRequired = process.env.FEISHU_INT_REQUIRED === '1';
+const integrationReady = dshBin !== undefined && profileReady && built;
+if (integrationRequired && !integrationReady) {
+  throw new Error(
+    `FEISHU_INT_REQUIRED=1 but integration prerequisites are missing ` +
+      `(dsh CLI=${dshBin !== undefined} profile=${profileReady} built=${built})`,
+  );
+}
+
+/** Drop one inbound message into the message channel. `attachments` is the
+ *  normalized attachment list (the shape the bridge consumes). */
+function sendMessage(
+  chatId: string,
+  text: string,
+  attachments?: readonly { kind: 'image' | 'file'; key: string; name?: string }[],
+): void {
+  const messageId = `om-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  writeFileSync(
+    join(INBOX_DIR, `${messageId}.json`),
+    JSON.stringify({
+      messageId,
+      chatId,
+      chatType: 'p2p',
+      senderOpenId: 'ou_mock',
+      text,
+      ...(attachments !== undefined ? { attachments } : {}),
+      mentions: [],
+      createdAt: Date.now(),
+    }),
+    'utf8',
+  );
+}
+
+/** Seed downloadable bytes for an attachment key (`<key>.bin` +
+ *  `<key>.mediaType`), consumed by the memory transport's download methods. */
+function seedAttachment(key: string, bytes: Uint8Array, mediaType?: string): void {
+  writeFileSync(join(ATTACH_DIR, `${key}.bin`), bytes);
+  if (mediaType !== undefined) {
+    writeFileSync(join(ATTACH_DIR, `${key}.mediaType`), mediaType, 'utf8');
+  }
+}
+
+/** Pin the chat's working directory via /cd (the gate refuses turns until
+ *  an explicit directory is chosen). */
+async function pinWorkingDir(chatId: string): Promise<void> {
+  sendMessage(chatId, `/cd ${INT_CWD}`);
+  await waitFor(
+    'the /cd confirmation',
+    () =>
+      readOutbox().some(
+        (r) =>
+          r.kind === 'text' && r.chatId === chatId && r.text?.includes('Working directory set to'),
+      ),
+    30_000,
+  );
+}
+
+describe.skipIf(!integrationReady)('integration > inbound-attachments', () => {
+  let mock: MockLlmServer | undefined;
+  let child: ReturnType<typeof spawn> | undefined;
+  let stdout = '';
+  let bridgeReady = false;
+
+  async function stopChild(): Promise<void> {
+    const proc = child;
+    child = undefined;
+    if (proc === undefined || proc.exitCode !== null) return;
+    proc.kill('SIGTERM');
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        if (proc.exitCode === null) proc.kill('SIGKILL');
+        resolve();
+      }, 5_000);
+      proc.once('exit', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  }
+
+  beforeEach(async () => {
+    if (mock !== undefined) await mock.close();
+    await stopChild();
+    rmSync(MEMORY_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    rmSync(ATTACH_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    mkdirSync(INT_CWD, { recursive: true });
+    mkdirSync(INBOX_DIR, { recursive: true });
+    mkdirSync(OUTBOX_DIR, { recursive: true });
+    mkdirSync(ATTACH_DIR, { recursive: true });
+    mock = await startMockLlmServer();
+    bridgeReady = false;
+    stdout = '';
+  });
+
+  afterEach(async () => {
+    await stopChild();
+    if (mock !== undefined) await mock.close();
+  });
+
+  /** Boot the real dsh process against the memory transport + mock LLM. */
+  async function boot(): Promise<{ chatId: string }> {
+    const bin = dshBin;
+    if (bin === undefined) throw new Error('dsh CLI unavailable');
+    const server = mock;
+    if (server === undefined) throw new Error('mock LLM server unavailable');
+    child = spawn(bin, ['--profile', 'feishu-dev'], {
+      env: {
+        ...process.env,
+        DSH_HOME,
+        FEISHU_APP_ID: 'cli_mock_app',
+        FEISHU_APP_SECRET: 'mock_secret',
+        FEISHU_TRANSPORT: 'memory',
+        FEISHU_MEMORY_DIR: MEMORY_DIR,
+        FEISHU_MEMORY_ATTACHMENTS: ATTACH_DIR,
+        DEEPSEEK_API_KEY: 'mock_key',
+        DEEPSEEK_BASE_URL: server.url,
+        // The memory transport serves attachment bytes from
+        // FEISHU_MEMORY_ATTACHMENTS (see the transport options).
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+      if (stdout.includes('[feishu] bridge ready')) bridgeReady = true;
+    });
+    child.stderr?.on('data', (_chunk: Buffer) => {});
+    await waitFor('the bridge to report ready', () => bridgeReady, 30_000);
+    const chatId = `oc_att_${Date.now()}`;
+    await pinWorkingDir(chatId);
+    return { chatId };
+  }
+
+  /** The last request body the mock LLM received (agent's view of the turn). */
+  function agentLastBody(): unknown {
+    return mock?.lastRequestBody();
+  }
+
+  /** The markdown content of a receipt/notice card by header title. */
+  function cardMarkdowns(title: string): string[] {
+    return readOutbox()
+      .filter(
+        (r) => (r.kind === 'card' || r.kind === 'patch') && r.card?.header?.title.content === title,
+      )
+      .flatMap((r) =>
+        (r.card?.elements ?? [])
+          .filter((el) => el.tag === 'markdown' && 'content' in el)
+          .map((el) => (el as { readonly content: string }).content),
+      );
+  }
+
+  it('an inbound image message degrades to a file receipt under a text-only model', async () => {
+    // The integration profile runs DeepSeek (text-only — the adapter rejects
+    // image content with UNSUPPORTED_CONTENT). The image therefore degrades
+    // to the file path: receipt card + name note, and the turn completes
+    // normally instead of erroring. (Image injection into the agent is
+    // covered by unit tests with an image-capable model; see
+    // tests/bridge.spec.ts → "inbound attachments".)
+    const { chatId } = await boot();
+    const png = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82]);
+    seedAttachment('img-1', png, 'image/png');
+    sendMessage(chatId, '', [{ kind: 'image', key: 'img-1' }]);
+    await waitFor(
+      'the degraded file receipt card',
+      () => cardMarkdowns('📎 File received').length > 0,
+      30_000,
+    );
+    // The turn completes normally (green card) — no UNSUPPORTED_CONTENT error.
+    await waitFor(
+      'the green final card patch',
+      () => readOutbox().some((r) => r.kind === 'patch' && r.card?.header?.template === 'green'),
+      90_000,
+    );
+  }, 150_000);
+
+  it('an inbound file message posts a receipt card and names the file to the agent', async () => {
+    const { chatId } = await boot();
+    seedAttachment('file-1', new Uint8Array([1, 2, 3]));
+    sendMessage(chatId, '', [{ kind: 'file', key: 'file-1', name: 'notes.txt' }]);
+    await waitFor(
+      'the file receipt card',
+      () => cardMarkdowns('📎 File received').length > 0,
+      30_000,
+    );
+    // The agent's user message names the file.
+    await waitFor(
+      'the file name in the agent turn',
+      () => {
+        const b = agentLastBody() as { messages?: unknown[] } | undefined;
+        return JSON.stringify(b?.messages ?? []).includes('notes.txt');
+      },
+      90_000,
+    );
+  }, 150_000);
+
+  it('an image whose key is missing still completes the turn (no wedge)', async () => {
+    // Under a text-only model the image degrades to a receipt BEFORE any
+    // download, so an unknown key never blocks the turn.
+    const { chatId } = await boot();
+    sendMessage(chatId, '', [{ kind: 'image', key: 'missing' }]);
+    // Receipt card appears (degrade path)…
+    await waitFor(
+      'the degraded file receipt card',
+      () => cardMarkdowns('📎 File received').length > 0,
+      30_000,
+    );
+    // …and the turn completes normally.
+    await waitFor(
+      'the green final card patch',
+      () => readOutbox().some((r) => r.kind === 'patch' && r.card?.header?.template === 'green'),
+      90_000,
+    );
+  }, 150_000);
+});

--- a/tests/integration/mock-llm-server.ts
+++ b/tests/integration/mock-llm-server.ts
@@ -41,6 +41,12 @@ export interface MockLlmServer {
   /** Number of /chat/completions requests served (for assertions). */
   completionRequests(): number;
   /**
+   * The raw JSON body of the MOST RECENT /chat/completions request, or
+   * `undefined` when none arrived yet. Lets a test assert what content the
+   * agent actually received (e.g. an injected `image` content block).
+   */
+  lastRequestBody(): unknown;
+  /**
    * Serve one scripted response per completion request, in order. The agent
    * loop issues a new completion request after each tool result, so a
    * tool-calling turn needs two entries (tool call, then final answer).
@@ -82,6 +88,7 @@ function sseToolCallDelta(index: number, id: string, name: string, argumentsDelt
 /** Start a mock DeepSeek API server on a random local port. */
 export async function startMockLlmServer(): Promise<MockLlmServer> {
   let completions = 0;
+  let lastBody: unknown;
   let scripts: readonly (readonly MockScriptChunk[])[] | undefined;
   let hold = false;
   let releaseHold: (() => void) | undefined;
@@ -138,8 +145,17 @@ export async function startMockLlmServer(): Promise<MockLlmServer> {
     const url = req.url ?? '';
     if (req.method === 'POST' && url === '/chat/completions') {
       completions += 1;
-      // Drain the request body so the connection is reusable.
-      req.resume();
+      // Capture the full request body for `lastRequestBody()` assertions —
+      // the body is drained anyway, so read it instead of discarding it.
+      const bodyChunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => bodyChunks.push(chunk));
+      req.on('end', () => {
+        try {
+          lastBody = JSON.parse(Buffer.concat(bodyChunks).toString('utf8'));
+        } catch {
+          lastBody = undefined;
+        }
+      });
       // A scripted error responds 500 BEFORE any streaming headers — writing
       // them first would make the 500 throw ("headers already sent") and hang
       // the adapter on an open body.
@@ -194,6 +210,7 @@ export async function startMockLlmServer(): Promise<MockLlmServer> {
         server.close(() => resolve());
       }),
     completionRequests: () => completions,
+    lastRequestBody: () => lastBody,
     setScripts: (next) => {
       scripts = next;
     },

--- a/tests/memory-transport.spec.ts
+++ b/tests/memory-transport.spec.ts
@@ -19,6 +19,7 @@ function message(overrides: Partial<FeishuMessage> = {}): FeishuMessage {
     senderOpenId: 'ou_user',
     text: 'hello',
     mentions: [],
+    attachments: [],
     createdAt: 1_700_000_000_000,
     ...overrides,
   };
@@ -128,5 +129,41 @@ describe('MemoryTransport', () => {
     writeFileSync(join(SCRATCH, 'inbox', 'om_int_2.json'), JSON.stringify(message()), 'utf8');
     await vi.advanceTimersByTimeAsync(300);
     expect(delivered).toHaveLength(0);
+  });
+
+  describe('inbound attachment downloads', () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+
+    it('downloadImage resolves seeded bytes with the declared media type', async () => {
+      const transport = new MemoryTransport({
+        dir: SCRATCH,
+        attachments: new Map([['img-1', { data: bytes, mediaType: 'image/jpeg' }]]),
+      });
+      const result = await transport.downloadImage('img-1');
+      expect(result.data).toEqual(bytes);
+      expect(result.mediaType).toBe('image/jpeg');
+    });
+
+    it('downloadImage defaults the media type to png when undeclared', async () => {
+      const transport = new MemoryTransport({
+        dir: SCRATCH,
+        attachments: new Map([['img-1', { data: bytes }]]),
+      });
+      expect((await transport.downloadImage('img-1')).mediaType).toBe('image/png');
+    });
+
+    it('downloadImage throws for an unknown key', async () => {
+      const transport = new MemoryTransport({ dir: SCRATCH });
+      await expect(transport.downloadImage('nope')).rejects.toThrow(/no seeded image/);
+    });
+
+    it('downloadFile resolves seeded bytes and throws for an unknown key', async () => {
+      const transport = new MemoryTransport({
+        dir: SCRATCH,
+        attachments: new Map([['file-1', { data: bytes }]]),
+      });
+      expect(await transport.downloadFile('file-1')).toEqual(bytes);
+      await expect(transport.downloadFile('nope')).rejects.toThrow(/no seeded file/);
+    });
   });
 });

--- a/tests/transport.spec.ts
+++ b/tests/transport.spec.ts
@@ -45,6 +45,7 @@ describe('normalizeMessageEvent', () => {
       senderOpenId: 'ou_user',
       text: 'hello',
       mentions: [],
+      attachments: [],
       createdAt: 1_700_000_000_000,
     });
   });
@@ -63,9 +64,54 @@ describe('normalizeMessageEvent', () => {
     expect(message?.text).toBe('hi there');
   });
 
-  it('ignores non-text message types', () => {
-    const message = normalizeMessageEvent(rawEvent({ message: { message_type: 'image' } }));
+  it('normalizes an image message into an image attachment', () => {
+    const message = normalizeMessageEvent(
+      rawEvent({
+        message: {
+          message_type: 'image',
+          content: JSON.stringify({ image_key: 'img_v2_abc' }),
+        },
+      }),
+    );
+    expect(message).toEqual({
+      messageId: 'om_msg1',
+      chatId: 'oc_chat',
+      chatType: 'p2p',
+      senderOpenId: 'ou_user',
+      text: '',
+      mentions: [],
+      attachments: [{ kind: 'image', key: 'img_v2_abc' }],
+      createdAt: 1_700_000_000_000,
+    });
+  });
+
+  it('normalizes a file message into a file attachment with its name', () => {
+    const message = normalizeMessageEvent(
+      rawEvent({
+        message: {
+          message_type: 'file',
+          content: JSON.stringify({ file_key: 'file_v2_xyz', file_name: 'notes.txt' }),
+        },
+      }),
+    );
+    expect(message?.attachments).toEqual([{ kind: 'file', key: 'file_v2_xyz', name: 'notes.txt' }]);
+    expect(message?.text).toBe('');
+  });
+
+  it('ignores an image message without a key', () => {
+    const message = normalizeMessageEvent(
+      rawEvent({ message: { message_type: 'image', content: JSON.stringify({}) } }),
+    );
     expect(message).toBeUndefined();
+  });
+
+  it('ignores unsupported message types (audio, post, …)', () => {
+    for (const type of ['audio', 'post', 'media']) {
+      const message = normalizeMessageEvent(
+        rawEvent({ message: { message_type: type, content: '{}' } }),
+      );
+      expect(message).toBeUndefined();
+    }
   });
 
   it('extracts mention open ids', () => {


### PR DESCRIPTION
## What

- **Message normalization** accepts `image` and `file` types; each becomes an attachment (`image_key`/`file_key` + optional name) on `FeishuMessage`.
- **Transport** downloads image/file bytes (`im.v1.image.get` / `im.v1.file.get`, reusing the existing `im:resource` scope); the memory transport serves seeded bytes for integration tests.
- **Image injection** — images are committed through `ctx.attachments` (dsh-attachment-local, part of the dsh-base bundle) and injected as an `image` content block of the agent user message, **gated on the chat current model advertising image input** (the DeepSeek adapter rejects image content with `UNSUPPORTED_CONTENT` — a text-only model degrades the image to a receipt instead of erroring the turn).
- **File receipts** — files (and degraded images) post a `📎 File received` card and name the file to the agent; download/save failures notice loudly and the turn continues text-only — an attachment never wedges the chat.

## Why

F1 from the roadmap: images/files the user sends were silently ignored. The capability gate is the key design point — injecting image blocks into a model that cannot see them (DeepSeek) ends the whole turn in error, so the surface must know the model before injecting.

## Docs

- `docs/ux-specification.md` → Part: inbound-attachments (spec, capability gate, failure modes)
- `docs/features.md` (+ zh): row → ✅
- `docs/feishu-setup.md` (+ zh): `im:resource` description covers inbound download
- `CHANGELOG.md` [Unreleased] entry

## Verification

- `pnpm run gates` (lint, typecheck, build, all 518 tests incl. `FEISHU_INT_REQUIRED=1` integration): all green
- `scripts/check-acceptance.mjs`: all mechanical items pass
- Unit: normalization (image/file/unsupported), memory-transport downloads, bridge injection + degrade (attachment service absent, model not image-capable, download failure)
- Integration (real dsh process): image degrades to receipt under text-only model + turn completes; file posts receipt + names file; missing key never wedges the turn