### PR TITLE
feat: inbound files saved to the workspace — agent reads by path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,15 +35,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Inbound attachments.** `image` and `file` messages are no longer
-  ignored. An image is downloaded (`im.v1.image.get`), committed through
-  the host's attachment service, and injected as an `image` content block
-  of the agent's user message — but ONLY when the chat's current model
-  advertises image input (the DeepSeek adapter rejects image content with
-  `UNSUPPORTED_CONTENT`, which would error the whole turn; pi-ai accepts
-  it). Under a text-only model (or absent attachment service), the image
-  degrades to a `📎 File received` receipt card + a file-name note, exactly
-  like a `file` message — the message is acknowledged, the turn never
-  errors because of an attachment. Reuses the existing `im:resource`
+  ignored. An image is downloaded through the message-resource endpoint
+  (`im.v1.messageResource.get` — `im.v1.image.get` can only fetch
+  bot-uploaded images), committed through the host's attachment service,
+  and injected as an `image` content block of the agent's user message —
+  but ONLY when the chat's current model advertises image input (the
+  DeepSeek adapter rejects image content with `UNSUPPORTED_CONTENT`, which
+  would error the whole turn; pi-ai accepts it). A file (and an image
+  under a text-only model or absent attachment service) is saved under the
+  chat's working directory at
+  `<cwd>/.dsh_feishu/attachments/<appId>/<messageId>/<key>.<ext>` (a
+  hidden, per-app+message-bucketed subdirectory; name derived from the
+  resource key + a content-sniffed extension, since Feishu file events
+  carry no original name) — the agent receives the REAL path and reads the
+  file with its workspace tools. A `📎 File received` receipt card posts;
+  download/save failures notice loudly and the turn continues text-only —
+  an attachment never wedges the chat. Reuses the existing `im:resource`
   scope.
 - **Canary workflow** (`.github/workflows/canary.yml`): runs the full suite
   daily (UTC 02:00) and on demand against the newest `@deepseek-ai/*`

--- a/docs/features.md
+++ b/docs/features.md
@@ -17,7 +17,7 @@ Feature list and TODO tracker for dsh-feishu. ✅ = shipped, 📋 = planned
 | Allowlists | `allowedChats` / `allowedUsers` gate who can talk to the bot | Env/config-driven, applied to messages and card actions | ✅ |
 | Session-log export | `/export` sends the chat's session log as a downloadable file message | File message with markdown transcript | ✅ |
 | Diagnostics | `/feishu-status` shows a diagnostic card (connection state, sessions, last inbound) | Read-only status card, usable mid-turn | ✅ |
-| Inbound attachments | Images/files the user sends are no longer ignored: images are injected into the agent (image-capable models) or receipt-noted, files become receipt cards | Image → agent processes it (model supports images) / 📎 receipt; file → receipt card | ✅ |
+| Inbound attachments | Images/files the user sends are no longer ignored: images are injected into the agent (image-capable models) or receipt-noted, files become receipt cards | Image → agent processes it (model supports images) / 📎 receipt; file → saved to workspace, agent reads by path | ✅ |
 | Outbound files/images | Agent-produced images/files send as native Feishu image/file messages | Tap to view original / download | 📋 |
 | Session hard delete | Remove a session from the active list (archive + hide, restorable from the archived list) | Session-detail card Delete + confirm view | 📋 |
 | Agent preset selection | Pick an agent preset (e.g. PTC mode) when choosing a working directory | Mode dropdown on the `/repo` / `/cd` picker card; preset binds to the new session | 📋 |

--- a/docs/ux-specification.md
+++ b/docs/ux-specification.md
@@ -708,7 +708,10 @@ arrive in a p2p chat or a group (mention gate applies exactly as for text).
 ignored. A mixed message is not a Feishu concept — each message is one type.
 
 **Image path (agent sees the image)** — the transport downloads the image
-bytes (`im.v1.image.get`, needs the existing `im:resource` scope), then the
+bytes through the message-resource endpoint (`im.v1.messageResource.get` —
+`/messages/{message_id}/resources/{image_key}?type=image`; `im.v1.image.get`
+can only fetch bot-uploaded images, so user-sent images MUST use the
+message-resource API; needs the existing `im:resource` scope), then the
 bridge saves them through the host's attachment store (`ctx.attachments`
 — `dsh-attachment-local` is part of the dsh-base bundle, so the seam is
 REALLY mounted, unlike `apiProxy`) and injects
@@ -726,14 +729,34 @@ the chat's current model advertises `image` in its input modalities
 image as a file (receipt + name note). A turn must never error because of
 an attachment.
 
-**File path (receipt card)** — the agent cannot read arbitrary file bytes,
-so the file becomes a receipt: the bridge posts a small
-`📎 File received` card (file name when derivable, else the key) and the
-agent's user message carries a text note `[user sent a file: <name>]` so
-the model knows a file exists and can ask for its content. There is no
-downloadable URL for a Feishu `file_key` — the receipt is the surface's
-acknowledgement (user requirement "files become downloadable links" is not
-achievable on the platform; the receipt replaces it).
+**File path (save to the workspace, agent reads by path)** — the agent
+cannot ingest arbitrary file bytes as a content block (the attachment
+domain is image-only), but it CAN read files under its working directory
+(its bash/read tools run under the fs sandbox, which permits
+`workspace-write` inside the workspace root). The bridge therefore:
+1. downloads the file bytes through the message-resource endpoint
+   (`im.v1.messageResource.get` — `/messages/{message_id}/resources/{file_key}?type=file`;
+   `im.v1.file.get` can only fetch bot-uploaded files, so user-sent files
+   MUST use the message-resource API);
+2. saves them under the chat's working directory at
+   `<cwd>/.dsh_feishu/attachments/<appId>/<messageId>/<key>.<ext>` — a
+   hidden subdirectory so uploads never pollute the workspace root,
+   bucketed per app + message (botmux's `attachment-path.ts` layout) so
+   concurrent chats and apps never collide. The name is derived from the
+   resource key + a content sniff for the extension (Feishu file events do
+   NOT carry the original file name, so the surface cannot preserve it).
+   Files are kept permanently — the agent can re-read them any time, and
+   they are visible to the same tools that see the rest of the workspace;
+3. posts a small `📎 File received` receipt card (name/extension + path);
+4. injects a text note with the REAL path:
+   `[user sent a file: <key>.<ext> — saved at <cwd>/.dsh_feishu/attachments/<appId>/<messageId>/<file>]`
+   so the model can read it (e.g. `read` the file, grep it, run a script
+   over it).
+
+There is no downloadable URL for a Feishu `file_key` — the workspace file IS
+the deliverable. A file whose download/save fails still posts the receipt
+with a loud log and runs the turn text-only (an attachment never wedges the
+chat).
 
 **States & transitions** — this feature has NO new state machine: it feeds
 the existing turn pipeline. The only new branch is inside
@@ -741,9 +764,9 @@ the existing turn pipeline. The only new branch is inside
 
 | Step | Image (model supports) | Image (not) / File |
 |---|---|---|
-| Download | `image.get` → bytes + mediaType | `file.get` / `image.get` → bytes + name |
-| Save | `ctx.attachments.saveImage` → ref | — (not injected) |
-| Content | `[text, {type:'image', attachment}]` | `[text note]` |
+| Download | message-resource (image) → bytes + mediaType | message-resource (file) → bytes + name |
+| Save | `ctx.attachments.saveImage` → ref | write `cwd/.dsh_feishu/attachments/<appId>/<messageId>/<key>.<ext>` (host seam) |
+| Content | `[text, {type:'image', attachment}]` | `[text note with the saved path]` |
 | Card | none (streaming card already opens) | `📎 File received` receipt card |
 | Failure | card + text notice, turn still runs text-only | same |
 
@@ -752,7 +775,7 @@ markdown card (like the approval/question notices), posted before
 `beginTurn` so it never interferes with the streaming card.
 
 **Failure modes**:
-- `image.get` / `file.get` download fails (scope missing, key expired):
+- message-resource download fails (scope missing, key expired):
   log loudly, post a `⚠️ Could not download` text notice, and run the turn
   text-only — a broken attachment must never wedge the chat.
 - `ctx.attachments` absent (attachment-local not mounted): feature-detect
@@ -760,6 +783,8 @@ markdown card (like the approval/question notices), posted before
   with a loud log, matching the "hide the row, don't fail" seam rule.
 - `saveImage` rejects bytes (unsupported format, over limits): loud log +
   text notice; turn continues without the image block.
+- File save to the workspace fails (cwd unwritable, path collision): loud
+  log, receipt card still posted, turn continues with the name-only note.
 - Group message without mention: the existing mention gate drops it before
   any download — no attachment handling for ignored messages.
 - Stale/unknown `image_key` at download time: same as download failure.
@@ -770,8 +795,11 @@ markdown card (like the approval/question notices), posted before
 - [ ] `image` message + text-only model → degrades to a `📎 File received`
       receipt + name note; turn completes (no UNSUPPORTED_CONTENT error)
       (unit + integration tested)
-- [ ] `file` message → receipt card posted, agent's message carries the
-      file-name note (unit + integration tested)
+- [ ] `file` message → bytes saved under `cwd/.dsh_feishu/attachments/<appId>/<messageId>/`, receipt card
+      posted, agent's message carries the REAL saved path (unit + integration
+      tested)
+- [ ] The saved file is readable by the agent's tools (integration test
+      asserts the file exists on disk at the noted path)
 - [ ] Group messages still gated by the mention gate (no attachment handling
       for ignored messages)
 - [ ] Download failure → loud notice, turn continues text-only (unit-tested)

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -65,6 +65,29 @@ import { turnTitle } from './cards/StreamingCardController.js';
 
 export { turnTitle } from './cards/StreamingCardController.js';
 
+/** Sniff a file extension (no dot) from leading bytes, for inbound files —
+ *  Feishu file events carry no original name, so the surface derives a
+ *  usable extension from the content. Unknown content → `bin`. */
+export function sniffExtension(data: Uint8Array): string {
+  const head = data.slice(0, 8);
+  const startsWith = (bytes: readonly number[]): boolean => bytes.every((b, i) => head[i] === b);
+  const text = new TextDecoder().decode(head);
+  if (startsWith([0x25, 0x50, 0x44, 0x46])) return 'pdf'; // %PDF
+  if (startsWith([0x50, 0x4b, 0x03, 0x04]) || startsWith([0x50, 0x4b, 0x05, 0x06])) return 'zip';
+  if (startsWith([0x89, 0x50, 0x4e, 0x47])) return 'png';
+  if (startsWith([0xff, 0xd8, 0xff])) return 'jpg';
+  if (text.startsWith('GIF8')) return 'gif';
+  if (startsWith([0x52, 0x49, 0x46, 0x46]) && text.slice(8, 12) === 'WEBP') return 'webp';
+  if (text.startsWith('{"') || text.startsWith('[{')) return 'json';
+  if (text.startsWith('<?xml')) return 'xml';
+  // Plain text (no control bytes in the head) → txt.
+  const printable = [...head].every(
+    (b) => b === 0x09 || b === 0x0a || b === 0x0d || (b >= 0x20 && b <= 0x7e),
+  );
+  if (printable) return 'txt';
+  return 'bin';
+}
+
 /** Minimal logger surface the bridge needs. */
 export interface BridgeLogger {
   info(message: string): void;
@@ -317,6 +340,29 @@ export interface BridgeOptions {
         name?: string;
       }) => Promise<ImageAttachmentRefLike>)
     | undefined;
+  /**
+   * Inbound-file seam: persist one downloaded file under the chat's working
+   * directory at `<cwd>/.dsh_feishu/attachments/<appId>/<messageId>/<key>.<ext>`
+   * so the agent can read it with its workspace tools. Bucketed per app +
+   * message (botmux layout) so concurrent chats never collide. Implemented
+   * by the host (index.ts) where fs access lives; the bridge only names the
+   * file. Absent, files degrade to a name-only note (the receipt card still
+   * posts).
+   */
+  readonly saveInboundFile?: (input: {
+    /** The chat whose working directory holds the file. */
+    chatId: string;
+    /** The Feishu app id the surface runs as (bucket segment). */
+    appId: string;
+    /** The owning message id (bucket segment). */
+    messageId: string;
+    /** The normalized attachment (key + optional name). */
+    attachment: InboundAttachment;
+    /** The downloaded bytes. */
+    data: Uint8Array;
+    /** A sniffed extension (pdf/zip/txt/json/bin…), no leading dot. */
+    extension: string;
+  }) => Promise<{ path: string }>;
   /**
    * Permission-preset service (`ctx.permissionPresets`, mounted by
    * dsh-base): `/permission` renders a preset picker from it and applies
@@ -1274,10 +1320,10 @@ export class Bridge {
     // covers transport-level JSON without the field (defensive only).
     for (const attachment of message.attachments ?? []) {
       if (attachment.kind === 'image') {
-        const block = await this.inboundImage(message.chatId, attachment, blocks);
+        const block = await this.inboundImage(message, attachment, blocks);
         if (block !== undefined) blocks.push(block);
       } else {
-        await this.inboundFile(message.chatId, attachment, blocks);
+        await this.inboundFile(message, attachment, blocks);
       }
     }
     if (blocks.length === 0) blocks.push({ type: 'text', text: message.text });
@@ -1292,24 +1338,27 @@ export class Bridge {
    *  or model not image-capable) the file path appends its note to `blocks`
    *  — the message is never left content-less. */
   private async inboundImage(
-    chatId: string,
+    message: FeishuMessage,
     attachment: InboundAttachment,
     blocks: ContentBlock[],
   ): Promise<ContentBlock | undefined> {
     const saveImage = this.options.getSaveImage?.();
-    const imageCapable = await this.supportsImageInput(chatId);
+    const imageCapable = await this.supportsImageInput(message.chatId);
     if (saveImage === undefined || !imageCapable) {
       // Attachment service not mounted, or the model cannot see images:
       // degrade to the file path (receipt + name note) instead of dropping
       // the message or erroring the turn (seam rule).
       this.options.logger.warn(
-        `inbound image ${attachment.key}: ${saveImage === undefined ? 'attachment service absent' : `model does not support image input (${this.currentModelSelection(chatId) ?? 'unknown'})`}, treating as a file notice`,
+        `inbound image ${attachment.key}: ${saveImage === undefined ? 'attachment service absent' : `model does not support image input (${this.currentModelSelection(message.chatId) ?? 'unknown'})`}, treating as a file notice`,
       );
-      await this.inboundFile(chatId, attachment, blocks);
+      await this.inboundFile(message, attachment, blocks);
       return undefined;
     }
     try {
-      const downloaded = await this.options.transport.downloadImage(attachment.key);
+      const downloaded = await this.options.transport.downloadImage(
+        message.messageId,
+        attachment.key,
+      );
       const saved = await saveImage({
         data: downloaded.data,
         mediaType: downloaded.mediaType,
@@ -1326,33 +1375,64 @@ export class Bridge {
         `inbound image ${attachment.key} could not be processed: ${String(error)}`,
       );
       await this.options.transport.sendText(
-        chatId,
+        message.chatId,
         '⚠️ An image you sent could not be read — sending as text only.',
       );
       return undefined;
     }
   }
 
-  /** Post the file-receipt card and append a file-name note to `blocks`.
-   *  Failures notice loudly and still let the turn run text-only. */
+  /** Download + persist one inbound file under the chat's working directory,
+   *  post the receipt card, and append a note with the REAL saved path to
+   *  `blocks` (the agent reads the file with its workspace tools). Failures
+   *  notice loudly and still let the turn run text-only. */
   private async inboundFile(
-    chatId: string,
+    message: FeishuMessage,
     attachment: InboundAttachment,
     blocks: ContentBlock[],
   ): Promise<void> {
     const name = attachment.name ?? attachment.key;
+    let savedPath: string | undefined;
     try {
-      await this.options.transport.downloadFile(attachment.key);
-      this.options.logger.debug(`inbound file ${attachment.key}: ${name} downloaded (${chatId})`);
+      const data = await this.options.transport.downloadFile(message.messageId, attachment.key);
+      this.options.logger.debug(
+        `inbound file ${attachment.key}: ${data.length} bytes downloaded (${message.chatId})`,
+      );
+      const save = this.options.saveInboundFile;
+      if (save !== undefined) {
+        const extension = sniffExtension(data);
+        const saved = await save({
+          chatId: message.chatId,
+          appId: this.options.appId ?? 'unknown',
+          messageId: message.messageId,
+          attachment,
+          data,
+          extension,
+        });
+        savedPath = saved.path;
+        this.options.logger.debug(
+          `inbound file ${attachment.key}: saved to ${saved.path} (${message.chatId})`,
+        );
+      } else {
+        this.options.logger.warn(
+          `inbound file ${attachment.key}: save seam absent, name-only note (${message.chatId})`,
+        );
+      }
     } catch (error: unknown) {
       this.options.logger.warn(`inbound file ${attachment.key} download failed: ${String(error)}`);
     }
     try {
-      await this.options.transport.sendCard(chatId, buildInboundFileCard(name));
+      await this.options.transport.sendCard(message.chatId, buildInboundFileCard(name, savedPath));
     } catch (error: unknown) {
       this.options.logger.warn(`file receipt card failed: ${String(error)}`);
     }
-    blocks.push({ type: 'text', text: `[user sent a file: ${name}]` });
+    blocks.push({
+      type: 'text',
+      text:
+        savedPath === undefined
+          ? `[user sent a file: ${name}]`
+          : `[user sent a file: ${name} — saved at ${savedPath}. You can read it with your file tools.]`,
+    });
   }
 
   /**

--- a/src/cards/render.ts
+++ b/src/cards/render.ts
@@ -906,15 +906,24 @@ export function buildPanelNoticeCard(options: {
 
 /**
  * The inbound-file receipt card: posted when a user sends a file message.
- * The agent cannot read arbitrary file bytes, so the surface acknowledges
- * the file (name) as a standalone card and tells the agent the file exists
- * by name — there is no downloadable URL for a Feishu `file_key`.
+ * The file bytes are saved under the chat's working directory
+ * (`<cwd>/.dsh_feishu/attachments/…`) and the card shows the path so the
+ * user knows where it landed; the agent receives the path too and reads the
+ * file with its workspace tools.
  */
-export function buildInboundFileCard(name: string): CardJson {
+export function buildInboundFileCard(name: string, savedPath?: string): CardJson {
   return {
     config: { wide_screen_mode: true },
     header: { title: { tag: 'plain_text', content: '📎 File received' }, template: 'blue' },
-    elements: [{ tag: 'markdown', content: `**${name}**\n\nTell me what to do with it.` }],
+    elements: [
+      {
+        tag: 'markdown',
+        content:
+          savedPath === undefined
+            ? `**${name}**\n\nTell me what to do with it.`
+            : `**${name}**\n\nSaved to \`${savedPath}\` — tell me what to do with it.`,
+      },
+    ],
   };
 }
 

--- a/src/feishu/types.ts
+++ b/src/feishu/types.ts
@@ -255,18 +255,26 @@ export interface FeishuTransport {
   /** Recall (delete) a previously sent message. Fire-and-forget-safe: never throws. */
   deleteMessage(messageId: string): Promise<void>;
   /**
-   * Download an inbound image message's bytes (`im.v1.image.get`, keyed by
-   * the normalized `image_key`). Resolves with the raw bytes and the
-   * platform-declared media type; throws when the key is unknown/stale or
-   * the scope is missing.
+   * Download an inbound image message's bytes. User-sent images are only
+   * reachable through the message-resource endpoint
+   * (`im.v1.messageResource.get` — `/messages/{message_id}/resources/{image_key}?type=image`);
+   * `im.v1.image.get` can only fetch bot-uploaded images. Resolves with the
+   * raw bytes and a media type; throws when the key is unknown/stale or the
+   * scope is missing.
+   * @param messageId - the owning message's id (the resource endpoint needs it).
+   * @param key - the normalized `image_key`.
    */
-  downloadImage(key: string): Promise<{ data: Uint8Array; mediaType: string }>;
+  downloadImage(messageId: string, key: string): Promise<{ data: Uint8Array; mediaType: string }>;
   /**
-   * Download an inbound file message's bytes (`im.v1.file.get`, keyed by the
-   * normalized `file_key`). Resolves with the raw bytes; throws when the key
-   * is unknown/stale or the scope is missing.
+   * Download an inbound file message's bytes. User-sent files are only
+   * reachable through the message-resource endpoint
+   * (`im.v1.messageResource.get` — `/messages/{message_id}/resources/{file_key}?type=file`);
+   * `im.v1.file.get` can only fetch bot-uploaded files. Resolves with the
+   * raw bytes; throws when the key is unknown/stale or the scope is missing.
+   * @param messageId - the owning message's id (the resource endpoint needs it).
+   * @param key - the normalized `file_key`.
    */
-  downloadFile(key: string): Promise<Uint8Array>;
+  downloadFile(messageId: string, key: string): Promise<Uint8Array>;
   /**
    * Membership counts for a chat, or `undefined` when unknown/unavailable.
    * Used for the 1-person-1-bot solo relaxation of the group mention gate.

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@
  * approvals, and questions land in later iterations.
  */
 
-import { readdirSync, readFileSync } from 'node:fs';
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { Context } from '@deepseek-ai/cordis';
@@ -532,6 +532,23 @@ export function apply(ctx: Context, config: Config, deps: ApplyDeps = {}): void 
         | undefined;
       if (attachments === undefined) return undefined;
       return (input) => attachments.saveImage(input);
+    },
+    // Inbound-file seam: persist one downloaded file under the chat's
+    // working directory at `.dsh_feishu/attachments/<appId>/<messageId>/<key>.<ext>`
+    // (hidden subdirectory; bucketed per app + message, botmux layout, so
+    // concurrent chats and apps never collide). The name derives from the
+    // resource key + sniffed extension — Feishu file events carry no
+    // original name. Files are kept permanently.
+    saveInboundFile: async ({ chatId, appId, messageId, attachment, data, extension }) => {
+      const cwd = sessionMap.cwdFor(chatId) ?? config.defaultCwd ?? process.cwd();
+      const safeAppId = appId.replace(/[^a-zA-Z0-9_-]/g, '_');
+      const safeMessageId = messageId.replace(/[^a-zA-Z0-9_-]/g, '_');
+      const safeKey = attachment.key.replace(/[^a-zA-Z0-9_-]/g, '_');
+      const dir = join(cwd, '.dsh_feishu', 'attachments', safeAppId, safeMessageId);
+      mkdirSync(dir, { recursive: true });
+      const path = join(dir, `${safeKey}.${extension}`);
+      writeFileSync(path, data);
+      return { path };
     },
     // Feature-detect the two stateful web-command services (both mounted by
     // dsh-base); absent, the /permission and /plan wrappers degrade.

--- a/src/memory-transport.ts
+++ b/src/memory-transport.ts
@@ -188,7 +188,10 @@ export class MemoryTransport implements FeishuTransport {
   }
 
   /** Resolve an inbound image's bytes from the seeded attachment map. */
-  async downloadImage(key: string): Promise<{ data: Uint8Array; mediaType: string }> {
+  async downloadImage(
+    _messageId: string,
+    key: string,
+  ): Promise<{ data: Uint8Array; mediaType: string }> {
     const seeded = this.seededAttachments.get(key);
     if (seeded === undefined) {
       throw new Error(`memory transport: no seeded image for key ${key}`);
@@ -197,7 +200,7 @@ export class MemoryTransport implements FeishuTransport {
   }
 
   /** Resolve an inbound file's bytes from the seeded attachment map. */
-  async downloadFile(key: string): Promise<Uint8Array> {
+  async downloadFile(_messageId: string, key: string): Promise<Uint8Array> {
     const seeded = this.seededAttachments.get(key);
     if (seeded === undefined) {
       throw new Error(`memory transport: no seeded file for key ${key}`);

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -453,32 +453,59 @@ export class LarkTransport implements FeishuTransport {
    * media type is derived from the message event. Throws on unknown/stale
    * keys or a missing `im:resource` scope.
    */
-  async downloadImage(key: string): Promise<{ data: Uint8Array; mediaType: string }> {
-    this.logger?.debug(`transport downloadImage ${key}`);
-    // im.v1.image.get streams the resource; the SDK resolves the response
-    // body as a Buffer for binary resources.
-    const response = (await this.client.im.v1.image.get({
-      path: { image_key: key },
-    })) as unknown as { file?: Buffer; data?: { image?: Buffer } };
-    const bytes = response.file ?? response.data?.image;
-    if (bytes === undefined) {
-      throw new FeishuApiError('im.v1.image.get', -1, 'response carried no image bytes');
-    }
-    // The image resource API does not echo the media type; the message
-    // content declares it, so callers pass it through. Default to png when
-    // unknown — saveImage re-detects the real format from bytes.
-    return { data: new Uint8Array(bytes), mediaType: 'image/png' };
+  /**
+   * Download an inbound image message's bytes via the message-resource
+   * endpoint (`/messages/{message_id}/resources/{image_key}?type=image`).
+   * User-sent images are only reachable here — `im.v1.image.get` can only
+   * fetch bot-uploaded images. Routed through the raw client request (not
+   * the generated `messageResource.get`, which sends `{}` as a GET body and
+   * trips gateway 411s — botmux lesson).
+   * @param messageId - the owning message's id.
+   * @param key - the normalized `image_key`.
+   */
+  async downloadImage(
+    messageId: string,
+    key: string,
+  ): Promise<{ data: Uint8Array; mediaType: string }> {
+    this.logger?.debug(`transport downloadImage ${key} (message ${messageId})`);
+    const bytes = await this.downloadMessageResource(messageId, key, 'image');
+    // The resource endpoint does not echo the media type; default to png —
+    // saveImage re-detects the real format from the bytes.
+    return { data: bytes, mediaType: 'image/png' };
   }
 
-  /** Download an inbound file message's bytes (`im.v1.file.get`). */
-  async downloadFile(key: string): Promise<Uint8Array> {
-    this.logger?.debug(`transport downloadFile ${key}`);
-    const response = (await this.client.im.v1.file.get({
-      path: { file_key: key },
-    })) as unknown as { file?: Buffer; data?: { file?: Buffer } };
-    const bytes = response.file ?? response.data?.file;
+  /**
+   * Download an inbound file message's bytes via the message-resource
+   * endpoint (`/messages/{message_id}/resources/{file_key}?type=file`).
+   * User-sent files are only reachable here — `im.v1.file.get` can only
+   * fetch bot-uploaded files.
+   * @param messageId - the owning message's id.
+   * @param key - the normalized `file_key`.
+   */
+  async downloadFile(messageId: string, key: string): Promise<Uint8Array> {
+    this.logger?.debug(`transport downloadFile ${key} (message ${messageId})`);
+    return this.downloadMessageResource(messageId, key, 'file');
+  }
+
+  /** GET one message resource (`im.v1.messageResource.get`) as bytes. */
+  private async downloadMessageResource(
+    messageId: string,
+    key: string,
+    type: 'image' | 'file',
+  ): Promise<Uint8Array> {
+    const response = await this.client.request<{ file?: Buffer }>({
+      method: 'GET',
+      url: `/open-apis/im/v1/messages/${encodeURIComponent(messageId)}/resources/${encodeURIComponent(key)}`,
+      params: { type },
+      responseType: 'arraybuffer',
+    });
+    const bytes = response?.file;
     if (bytes === undefined) {
-      throw new FeishuApiError('im.v1.file.get', -1, 'response carried no file bytes');
+      throw new FeishuApiError(
+        `im.v1.messageResource.get (${type})`,
+        -1,
+        'response carried no resource bytes',
+      );
     }
     return new Uint8Array(bytes);
   }

--- a/tests/bridge.spec.ts
+++ b/tests/bridge.spec.ts
@@ -22,6 +22,7 @@ import {
   type PermissionPresetService,
   type PlanModeService,
   type SessionListRow,
+  sniffExtension,
   turnTitle,
 } from '../src/bridge.js';
 import { SESSION_SELECT_MAX } from '../src/cards/session-list.js';
@@ -109,11 +110,14 @@ class RecordingTransport implements FeishuTransport {
    *  success/failure per scenario). */
   downloadImageImpl?: (key: string) => Promise<{ data: Uint8Array; mediaType: string }>;
   downloadFileImpl?: (key: string) => Promise<Uint8Array>;
-  async downloadImage(key: string): Promise<{ data: Uint8Array; mediaType: string }> {
+  async downloadImage(
+    _messageId: string,
+    key: string,
+  ): Promise<{ data: Uint8Array; mediaType: string }> {
     if (this.downloadImageImpl === undefined) throw new Error(`no downloadImage for ${key}`);
     return this.downloadImageImpl(key);
   }
-  async downloadFile(key: string): Promise<Uint8Array> {
+  async downloadFile(_messageId: string, key: string): Promise<Uint8Array> {
     if (this.downloadFileImpl === undefined) throw new Error(`no downloadFile for ${key}`);
     return this.downloadFileImpl(key);
   }
@@ -234,6 +238,7 @@ function makeHarness(
     sessionTitle?: NonNullable<BridgeOptions['sessionTitle']>;
     getWorkspaceRegistry?: NonNullable<BridgeOptions['getWorkspaceRegistry']>;
     getSaveImage?: NonNullable<BridgeOptions['getSaveImage']>;
+    saveInboundFile?: NonNullable<BridgeOptions['saveInboundFile']>;
   } = {},
 ): Harness {
   const transport = new RecordingTransport();
@@ -285,6 +290,7 @@ function makeHarness(
       ? { getWorkspaceRegistry: options.getWorkspaceRegistry }
       : {}),
     ...(options.getSaveImage !== undefined ? { getSaveImage: options.getSaveImage } : {}),
+    ...(options.saveInboundFile !== undefined ? { saveInboundFile: options.saveInboundFile } : {}),
     // Tests default the working-directory gate OFF (production defaults it
     // ON); the gate's own tests enable it explicitly.
     requireWorkingDir: options.requireWorkingDir ?? false,
@@ -377,6 +383,25 @@ describe('Bridge', () => {
     expect(h.transport.sentCards).toHaveLength(1);
   });
 
+  describe('sniffExtension', () => {
+    const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+    it('detects common binary formats from magic bytes', () => {
+      expect(sniffExtension(enc('%PDF-1.7'))).toBe('pdf');
+      expect(sniffExtension(new Uint8Array([0x50, 0x4b, 0x03, 0x04]))).toBe('zip');
+      expect(sniffExtension(enc('{"a":1}'))).toBe('json');
+      expect(sniffExtension(enc('<?xml version="1.0"?>'))).toBe('xml');
+      expect(sniffExtension(new Uint8Array([0x89, 0x50, 0x4e, 0x47]))).toBe('png');
+      expect(sniffExtension(new Uint8Array([0xff, 0xd8, 0xff, 0xe0]))).toBe('jpg');
+      expect(sniffExtension(enc('GIF89a'))).toBe('gif');
+    });
+
+    it('classifies printable text as txt and unknown binary as bin', () => {
+      expect(sniffExtension(enc('hello world\n'))).toBe('txt');
+      expect(sniffExtension(new Uint8Array([0x00, 0x01, 0xff, 0xfe]))).toBe('bin');
+    });
+  });
+
   describe('inbound attachments', () => {
     const pngBytes = new Uint8Array([137, 80, 78, 71]);
 
@@ -426,8 +451,13 @@ describe('Bridge', () => {
       expect(h.transport.sentCards).toHaveLength(1);
     });
 
-    it('posts a file receipt card and names the file to the agent', async () => {
-      const h = makeHarness();
+    it('posts a file receipt card and names the saved path to the agent', async () => {
+      const h = makeHarness({
+        saveInboundFile: async ({ data }) => {
+          expect(data).toEqual(new Uint8Array([1, 2, 3]));
+          return { path: '/work/.dsh_feishu/attachments/file-1.bin' };
+        },
+      });
       h.transport.downloadFileImpl = async () => new Uint8Array([1, 2, 3]);
       await h.bridge.handleMessage(
         message({
@@ -435,9 +465,27 @@ describe('Bridge', () => {
           attachments: [{ kind: 'file', key: 'file-1', name: 'notes.txt' }],
         }),
       );
-      // Receipt card + streaming card.
+      // Receipt card + streaming card; receipt shows the saved path.
       expect(h.transport.sentCards).toHaveLength(2);
       expect(h.transport.sentCards[0]?.header?.title.content).toBe('📎 File received');
+      expect(JSON.stringify(h.transport.sentCards[0]?.elements)).toContain('.dsh_feishu');
+      const followups = h.agentStore.followups.get('feishu-session-1');
+      const blocks = followups?.[0]?.content as unknown[];
+      expect(blocks?.[0]).toEqual({
+        type: 'text',
+        text: '[user sent a file: notes.txt — saved at /work/.dsh_feishu/attachments/file-1.bin. You can read it with your file tools.]',
+      });
+    });
+
+    it('falls back to a name-only note when the save seam is absent', async () => {
+      const h = makeHarness(); // no saveInboundFile
+      h.transport.downloadFileImpl = async () => new Uint8Array([1, 2, 3]);
+      await h.bridge.handleMessage(
+        message({
+          text: '',
+          attachments: [{ kind: 'file', key: 'file-1', name: 'notes.txt' }],
+        }),
+      );
       const followups = h.agentStore.followups.get('feishu-session-1');
       const blocks = followups?.[0]?.content as unknown[];
       expect(blocks?.[0]).toEqual({ type: 'text', text: '[user sent a file: notes.txt]' });

--- a/tests/cards/InteractionCardController.spec.ts
+++ b/tests/cards/InteractionCardController.spec.ts
@@ -49,10 +49,13 @@ class RecordingTransport implements FeishuTransport {
     this.updatedCards.push(card);
   }
   async deleteMessage(_messageId: string): Promise<void> {}
-  async downloadImage(_key: string): Promise<{ data: Uint8Array; mediaType: string }> {
+  async downloadImage(
+    _messageId: string,
+    _key: string,
+  ): Promise<{ data: Uint8Array; mediaType: string }> {
     throw new Error('downloadImage not implemented in this fake');
   }
-  async downloadFile(_key: string): Promise<Uint8Array> {
+  async downloadFile(_messageId: string, _key: string): Promise<Uint8Array> {
     throw new Error('downloadFile not implemented in this fake');
   }
 }

--- a/tests/cards/StreamingCardController.spec.ts
+++ b/tests/cards/StreamingCardController.spec.ts
@@ -69,10 +69,13 @@ class RecordingTransport implements FeishuTransport {
     this.updatedCards.push(card);
   }
   async deleteMessage(_messageId: string): Promise<void> {}
-  async downloadImage(_key: string): Promise<{ data: Uint8Array; mediaType: string }> {
+  async downloadImage(
+    _messageId: string,
+    _key: string,
+  ): Promise<{ data: Uint8Array; mediaType: string }> {
     throw new Error('downloadImage not implemented in this fake');
   }
-  async downloadFile(_key: string): Promise<Uint8Array> {
+  async downloadFile(_messageId: string, _key: string): Promise<Uint8Array> {
     throw new Error('downloadFile not implemented in this fake');
   }
 }

--- a/tests/cards/streaming.spec.ts
+++ b/tests/cards/streaming.spec.ts
@@ -63,10 +63,13 @@ class RecordingTransport implements FeishuTransport {
     this.updated.push(card);
   }
   async deleteMessage(_messageId: string): Promise<void> {}
-  async downloadImage(_key: string): Promise<{ data: Uint8Array; mediaType: string }> {
+  async downloadImage(
+    _messageId: string,
+    _key: string,
+  ): Promise<{ data: Uint8Array; mediaType: string }> {
     throw new Error('downloadImage not implemented in this fake');
   }
-  async downloadFile(_key: string): Promise<Uint8Array> {
+  async downloadFile(_messageId: string, _key: string): Promise<Uint8Array> {
     throw new Error('downloadFile not implemented in this fake');
   }
 }

--- a/tests/commands-surface.spec.ts
+++ b/tests/commands-surface.spec.ts
@@ -50,10 +50,13 @@ class FakeTransport implements FeishuTransport {
   }
   async updateCard(_messageId: string, _card: CardJson): Promise<void> {}
   async deleteMessage(_messageId: string): Promise<void> {}
-  async downloadImage(_key: string): Promise<{ data: Uint8Array; mediaType: string }> {
+  async downloadImage(
+    _messageId: string,
+    _key: string,
+  ): Promise<{ data: Uint8Array; mediaType: string }> {
     throw new Error('downloadImage not implemented in this fake');
   }
-  async downloadFile(_key: string): Promise<Uint8Array> {
+  async downloadFile(_messageId: string, _key: string): Promise<Uint8Array> {
     throw new Error('downloadFile not implemented in this fake');
   }
 }

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -68,10 +68,13 @@ class FakeTransport implements FeishuTransport {
   }
   async updateCard(_messageId: string, _card: CardJson): Promise<void> {}
   async deleteMessage(_messageId: string): Promise<void> {}
-  async downloadImage(_key: string): Promise<{ data: Uint8Array; mediaType: string }> {
+  async downloadImage(
+    _messageId: string,
+    _key: string,
+  ): Promise<{ data: Uint8Array; mediaType: string }> {
     throw new Error('downloadImage not implemented in this fake');
   }
-  async downloadFile(_key: string): Promise<Uint8Array> {
+  async downloadFile(_messageId: string, _key: string): Promise<Uint8Array> {
     throw new Error('downloadFile not implemented in this fake');
   }
 }

--- a/tests/integration/inbound-attachments.spec.ts
+++ b/tests/integration/inbound-attachments.spec.ts
@@ -86,8 +86,9 @@ function sendMessage(
   chatId: string,
   text: string,
   attachments?: readonly { kind: 'image' | 'file'; key: string; name?: string }[],
+  fixedMessageId?: string,
 ): void {
-  const messageId = `om-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const messageId = fixedMessageId ?? `om-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   writeFileSync(
     join(INBOX_DIR, `${messageId}.json`),
     JSON.stringify({
@@ -132,6 +133,7 @@ describe.skipIf(!integrationReady)('integration > inbound-attachments', () => {
   let mock: MockLlmServer | undefined;
   let child: ReturnType<typeof spawn> | undefined;
   let stdout = '';
+  let stderr = '';
   let bridgeReady = false;
 
   async function stopChild(): Promise<void> {
@@ -196,7 +198,9 @@ describe.skipIf(!integrationReady)('integration > inbound-attachments', () => {
       stdout += chunk.toString();
       if (stdout.includes('[feishu] bridge ready')) bridgeReady = true;
     });
-    child.stderr?.on('data', (_chunk: Buffer) => {});
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
     await waitFor('the bridge to report ready', () => bridgeReady, 30_000);
     const chatId = `oc_att_${Date.now()}`;
     await pinWorkingDir(chatId);
@@ -245,21 +249,40 @@ describe.skipIf(!integrationReady)('integration > inbound-attachments', () => {
     );
   }, 150_000);
 
-  it('an inbound file message posts a receipt card and names the file to the agent', async () => {
+  it('an inbound file message saves the file to the workspace and names its path to the agent', async () => {
+    // A tiny text file: sniffed as .txt, saved under the chat's cwd in the
+    // appId/messageId bucket (botmux layout). Seeded BEFORE boot — the
+    // memory transport reads the attachment dir once at process start.
+    const content = 'hello from the inbound file\n';
+    seedAttachment('file-1', new TextEncoder().encode(content));
     const { chatId } = await boot();
-    seedAttachment('file-1', new Uint8Array([1, 2, 3]));
-    sendMessage(chatId, '', [{ kind: 'file', key: 'file-1', name: 'notes.txt' }]);
+    sendMessage(chatId, '', [{ kind: 'file', key: 'file-1' }], 'om-saved-file-1');
     await waitFor(
       'the file receipt card',
       () => cardMarkdowns('📎 File received').length > 0,
       30_000,
     );
-    // The agent's user message names the file.
+    // The bytes are on disk at <cwd>/.dsh_feishu/attachments/<appId>/<messageId>/file-1.txt.
+    const savedFile = join(
+      INT_CWD,
+      '.dsh_feishu',
+      'attachments',
+      'cli_mock_app',
+      'om-saved-file-1',
+      'file-1.txt',
+    );
+    try {
+      await waitFor('the saved attachment file on disk', () => existsSync(savedFile), 10_000);
+    } catch (error) {
+      throw new Error(`${String(error)}\n--- dsh stderr ---\n${stderr}`);
+    }
+    expect(readFileSync(savedFile, 'utf8')).toBe(content);
+    // The agent's user message carries the REAL saved path.
     await waitFor(
-      'the file name in the agent turn',
+      'the saved path in the agent turn',
       () => {
         const b = agentLastBody() as { messages?: unknown[] } | undefined;
-        return JSON.stringify(b?.messages ?? []).includes('notes.txt');
+        return JSON.stringify(b?.messages ?? []).includes(savedFile);
       },
       90_000,
     );

--- a/tests/memory-transport.spec.ts
+++ b/tests/memory-transport.spec.ts
@@ -139,7 +139,7 @@ describe('MemoryTransport', () => {
         dir: SCRATCH,
         attachments: new Map([['img-1', { data: bytes, mediaType: 'image/jpeg' }]]),
       });
-      const result = await transport.downloadImage('img-1');
+      const result = await transport.downloadImage('om_x', 'img-1');
       expect(result.data).toEqual(bytes);
       expect(result.mediaType).toBe('image/jpeg');
     });
@@ -149,12 +149,12 @@ describe('MemoryTransport', () => {
         dir: SCRATCH,
         attachments: new Map([['img-1', { data: bytes }]]),
       });
-      expect((await transport.downloadImage('img-1')).mediaType).toBe('image/png');
+      expect((await transport.downloadImage('om_x', 'img-1')).mediaType).toBe('image/png');
     });
 
     it('downloadImage throws for an unknown key', async () => {
       const transport = new MemoryTransport({ dir: SCRATCH });
-      await expect(transport.downloadImage('nope')).rejects.toThrow(/no seeded image/);
+      await expect(transport.downloadImage('om_x', 'nope')).rejects.toThrow(/no seeded image/);
     });
 
     it('downloadFile resolves seeded bytes and throws for an unknown key', async () => {
@@ -162,8 +162,8 @@ describe('MemoryTransport', () => {
         dir: SCRATCH,
         attachments: new Map([['file-1', { data: bytes }]]),
       });
-      expect(await transport.downloadFile('file-1')).toEqual(bytes);
-      await expect(transport.downloadFile('nope')).rejects.toThrow(/no seeded file/);
+      expect(await transport.downloadFile('om_x', 'file-1')).toEqual(bytes);
+      await expect(transport.downloadFile('om_x', 'nope')).rejects.toThrow(/no seeded file/);
     });
   });
 });


### PR DESCRIPTION
## What

- **Downloads move to the message-resource endpoint** (`im.v1.messageResource.get` — `/messages/{message_id}/resources/{key}?type=file|image`). `im.v1.file.get`/`im.v1.image.get` can only fetch bot-uploaded files/images, so user-sent attachments MUST use the message-resource API. Routed through the raw client request because the generated SDK method sends `{}` as a GET body and trips gateway 411s (botmux lesson).
- **Files are saved to the workspace** at `<cwd>/.dsh_feishu/attachments/<appId>/<messageId>/<key>.<ext>` — hidden subdirectory, bucketed per app + message (botmux `attachment-path.ts` layout) so concurrent chats/apps never collide.
- **Name = key + magic-bytes-sniffed extension** (pdf/zip/json/xml/png/jpg/gif/webp/txt/bin) — Feishu file events carry no original file name.
- **The agent gets the REAL path** (user message note + receipt card), so it reads the file with its workspace tools (bash/read under the fs sandbox).
- A missing save seam or download/save failure still posts the receipt and runs the turn text-only — an attachment never wedges the chat.

## Why

Follow-up to #15: user-sent files were acknowledged by name only and never reached the agent. The message-resource endpoint is the platform-correct download path for user-sent resources (confirmed against the Feishu docs — `file.get`/`image.get` are bot-upload-only), and botmux's raw-request route avoids the SDK GET-body 411.

## Docs

- `docs/ux-specification.md` → Part: inbound-attachments (message-resource downloads, appId/messageId bucket, sniffed names)
- `docs/features.md` (+ zh): file row → saved to workspace, agent reads by path
- `CHANGELOG.md` [Unreleased] entry updated

## Verification

- `pnpm run gates` all green (lint, typecheck, build, 520 tests incl. FEISHU_INT_REQUIRED=1 integration)
- `scripts/check-acceptance.mjs` all mechanical items pass
- Unit: `sniffExtension` (pdf/zip/json/xml/png/jpg/gif/txt/bin), bridge file-save note with real path + seam-absent fallback, memory-transport two-arg downloads
- Integration (real dsh process): file bytes land on disk at `<cwd>/.dsh_feishu/attachments/cli_mock_app/<messageId>/file-1.txt`, the real path appears in the agent turn, receipt card posted