### PR TITLE
fix: stream inbound file downloads to disk and keep the original file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,14 +30,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   would error the whole turn; pi-ai accepts it). A file (and an image
   under a text-only model or absent attachment service) is saved under the
   chat's working directory at
-  `<cwd>/.dsh_feishu/attachments/<appId>/<messageId>/<key>.<ext>` (a
-  hidden, per-app+message-bucketed subdirectory; name derived from the
-  resource key + a content-sniffed extension, since Feishu file events
-  carry no original name) — the agent receives the REAL path and reads the
-  file with its workspace tools. A `📎 File received` receipt card posts;
-  download/save failures notice loudly and the turn continues text-only —
-  an attachment never wedges the chat. Reuses the existing `im:resource`
-  scope.
+  `<cwd>/.dsh_feishu/attachments/<appId>/<chatId>/<name>.<ext>` (a
+  hidden, per-app+chat-bucketed subdirectory) — the agent receives the
+  REAL path and reads the file with its workspace tools. A `📎 File
+  received` receipt card posts; download/save failures notice loudly and
+  the turn continues text-only — an attachment never wedges the chat.
+  Reuses the existing `im:resource` scope.
+- **Inbound files stream to disk and keep their original name.** The
+  message-resource download previously read `response.file`, but the SDK
+  interceptor already unwraps `resp.data`, so every inbound file failed to
+  persist (`code -1`). The file download now uses the botmux pattern —
+  `responseType: 'stream'` + `$return_headers`, JSON error-envelope
+  detection, and `pipeline()` streaming to disk (no buffering; the
+  resource API serves files up to ~100 MB). The on-disk name is the
+  user's original `file_name` (sanitized for path safety; Unicode kept;
+  200-byte cap) with WeChat-style dedupe — a same-named file re-sent in
+  the same chat lands as `name(1).ext`, `name(2).ext`, … never an
+  overwrite (bucket per chat, not per message, so the dedupe fires);
+  without a usable `file_name` the sanitized resource key is used.
 - **Canary workflow** (`.github/workflows/canary.yml`): runs the full suite
   daily (UTC 02:00) and on demand against the newest `@deepseek-ai/*`
   release (`@next` dist-tag), surfacing upstream breaking changes before

--- a/docs/ux-specification.md
+++ b/docs/ux-specification.md
@@ -734,22 +734,30 @@ cannot ingest arbitrary file bytes as a content block (the attachment
 domain is image-only), but it CAN read files under its working directory
 (its bash/read tools run under the fs sandbox, which permits
 `workspace-write` inside the workspace root). The bridge therefore:
-1. downloads the file bytes through the message-resource endpoint
+1. streams the file body through the message-resource endpoint
    (`im.v1.messageResource.get` — `/messages/{message_id}/resources/{file_key}?type=file`;
    `im.v1.file.get` can only fetch bot-uploaded files, so user-sent files
-   MUST use the message-resource API);
+   MUST use the message-resource API). Streamed, not buffered — the
+   resource API serves files up to ~100 MB; the leading bytes are peeked
+   for extension sniffing and pushed back, so the full body pipes straight
+   to disk (`pipeline()`; botmux's `downloadWithAppToken` lesson);
 2. saves them under the chat's working directory at
-   `<cwd>/.dsh_feishu/attachments/<appId>/<messageId>/<key>.<ext>` — a
+   `<cwd>/.dsh_feishu/attachments/<appId>/<chatId>/<name>.<ext>` — a
    hidden subdirectory so uploads never pollute the workspace root,
-   bucketed per app + message (botmux's `attachment-path.ts` layout) so
-   concurrent chats and apps never collide. The name is derived from the
-   resource key + a content sniff for the extension (Feishu file events do
-   NOT carry the original file name, so the surface cannot preserve it).
-   Files are kept permanently — the agent can re-read them any time, and
-   they are visible to the same tools that see the rest of the workspace;
+   bucketed per app + chat. The name is the user's ORIGINAL `file_name`
+   (Feishu file events carry it; parsed into `attachment.name`),
+   sanitized for path safety (separators, traversal segments, control and
+   Windows-reserved characters replaced; Unicode kept; 200-byte cap), and
+   deduped WeChat-style — a same-named file re-sent in the same chat lands
+   as `name(1).ext`, `name(2).ext`, … never an overwrite. Bucketing per
+   chat (not per message) is what makes the dedupe fire; when no
+   `file_name` survives sanitization the resource key is used (sanitized,
+   same dedupe). Files are kept permanently — the agent can re-read them
+   any time, and they are visible to the same tools that see the rest of
+   the workspace;
 3. posts a small `📎 File received` receipt card (name/extension + path);
 4. injects a text note with the REAL path:
-   `[user sent a file: <key>.<ext> — saved at <cwd>/.dsh_feishu/attachments/<appId>/<messageId>/<file>]`
+   `[user sent a file: <name>.<ext> — saved at <cwd>/.dsh_feishu/attachments/<appId>/<chatId>/<file>]`
    so the model can read it (e.g. `read` the file, grep it, run a script
    over it).
 
@@ -764,8 +772,8 @@ the existing turn pipeline. The only new branch is inside
 
 | Step | Image (model supports) | Image (not) / File |
 |---|---|---|
-| Download | message-resource (image) → bytes + mediaType | message-resource (file) → bytes + name |
-| Save | `ctx.attachments.saveImage` → ref | write `cwd/.dsh_feishu/attachments/<appId>/<messageId>/<key>.<ext>` (host seam) |
+| Download | message-resource (image) → bytes + mediaType | message-resource (file) → stream + head (sniff) |
+| Save | `ctx.attachments.saveImage` → ref | stream to `cwd/.dsh_feishu/attachments/<appId>/<chatId>/<name>.<ext>` (host seam, WeChat dedupe) |
 | Content | `[text, {type:'image', attachment}]` | `[text note with the saved path]` |
 | Card | none (streaming card already opens) | `📎 File received` receipt card |
 | Failure | card + text notice, turn still runs text-only | same |
@@ -795,9 +803,11 @@ markdown card (like the approval/question notices), posted before
 - [ ] `image` message + text-only model → degrades to a `📎 File received`
       receipt + name note; turn completes (no UNSUPPORTED_CONTENT error)
       (unit + integration tested)
-- [ ] `file` message → bytes saved under `cwd/.dsh_feishu/attachments/<appId>/<messageId>/`, receipt card
+- [ ] `file` message → bytes saved under `cwd/.dsh_feishu/attachments/<appId>/<chatId>/`, receipt card
       posted, agent's message carries the REAL saved path (unit + integration
       tested)
+- [ ] A same-named file re-sent in the same chat saves as `name(1).ext`
+      (WeChat-style dedupe, integration tested)
 - [ ] The saved file is readable by the agent's tools (integration test
       asserts the file exists on disk at the noted path)
 - [ ] Group messages still gated by the mention gate (no attachment handling

--- a/docs/ux-specification.zh.md
+++ b/docs/ux-specification.zh.md
@@ -363,11 +363,11 @@ bridge 记住每个聊天的**最近被接受的发送者**（及其聊天类型
 **图片能力门禁** —— DeepSeek chat-completions 适配器**拒绝** image 内容（`UNSUPPORTED_CONTENT` → 整轮以错误结束），而 pi-ai 接受。因此 bridge **仅当**当前模型在输入模态中声明支持 `image` 时才注入 image 块（`ctx.llm.listModels` → `inputModalities`，与 `/model` 选择器读同一模型目录）。模型能力未知 → 保守处理：把图片当文件处理（回执 + 名称备注）。附件**绝不能**让回合报错。
 
 **文件路径（保存到工作区，agent 按路径读取）** —— agent 无法把任意文件字节作为内容块摄取（attachment 域仅限图片），但可以读取工作目录下的文件（其 bash/read 工具在 fs sandbox 下运行，`workspace-write` 允许写工作区根）。因此 bridge：
-1. 通过消息资源端点下载文件字节（`im.v1.messageResource.get` —— `/messages/{message_id}/resources/{file_key}?type=file`；`im.v1.file.get` 只能下载机器人自己上传的文件）；
-2. 保存到聊天工作目录 `<cwd>/.dsh_feishu/attachments/<appId>/<messageId>/<key>.<ext>` —— 隐藏子目录，按 app + message 分桶（botmux `attachment-path.ts` 布局），并发聊天/应用互不冲突。文件名 = 资源 key + magic bytes 嗅探的扩展名（pdf/zip/json/xml/png/jpg/gif/webp/txt/bin）——飞书文件事件不带原始文件名。文件永久保留，agent 随时可重读；
+1. **流式**下载文件体（`im.v1.messageResource.get` —— `/messages/{message_id}/resources/{file_key}?type=file`；`im.v1.file.get` 只能下载机器人自己上传的文件）。流式而非缓冲——资源 API 服务最大约 100 MB 的文件；先 peek 开头字节做扩展名嗅探再推回流，完整文件体经 `pipeline()` 直接写盘（botmux `downloadWithAppToken` 同款）；
+2. 保存到聊天工作目录 `<cwd>/.dsh_feishu/attachments/<appId>/<chatId>/<name>.<ext>` —— 隐藏子目录，按 app + chat 分桶。文件名 = 用户**原始文件名**（`file_name`，飞书文件事件携带，解析进 `attachment.name`），做路径安全清洗（分隔符、穿越段、控制字符、Windows 保留字符替换；保留 Unicode；200 字节上限），并微信式去重——同一 chat 重复发送同名文件依次存为 `name(1).ext`、`name(2).ext`…… 永不覆盖。按 chat（而非 message）分桶正是去重生效的前提；`file_name` 无法清洗时回退到清洗后的资源 key（同样去重）。文件永久保留，agent 随时可重读；
 3. 发布 `📎 File received` 回执卡（名称/扩展名 + 路径）；
 4. 注入带**真实路径**的文本备注：
-   `[user sent a file: <key>.<ext> — saved at <cwd>/.dsh_feishu/attachments/<appId>/<messageId>/<file>]`
+   `[user sent a file: <name>.<ext> — saved at <cwd>/.dsh_feishu/attachments/<appId>/<chatId>/<file>]`
    模型可用文件工具读取（read、grep、跑脚本）。
 
 飞书 `file_key` 没有公开下载 URL —— 工作区文件本身就是交付物。下载/保存失败仍发布回执 + 响亮日志，回合以纯文本继续（附件绝不卡死聊天）。
@@ -378,8 +378,8 @@ bridge 记住每个聊天的**最近被接受的发送者**（及其聊天类型
 
 | 步骤 | 图片（模型支持） | 图片（不支持）/ 文件 |
 |---|---|---|
-| 下载 | message-resource (image) → bytes + mediaType | message-resource (file) → bytes + name |
-| 保存 | `ctx.attachments.saveImage` → ref | 写入 `cwd/.dsh_feishu/attachments/<appId>/<messageId>/<key>.<ext>`（宿主 seam） |
+| 下载 | message-resource (image) → bytes + mediaType | message-resource (file) → stream + head（嗅探） |
+| 保存 | `ctx.attachments.saveImage` → ref | 流式写入 `cwd/.dsh_feishu/attachments/<appId>/<chatId>/<name>.<ext>`（宿主 seam，微信式去重） |
 | 内容 | `[text, {type:'image', attachment}]` | `[text 备注带真实路径]` |
 | 卡片 | 无（streaming 卡已开） | `📎 File received` 回执卡 |
 | 失败 | 卡片 + 文本提示，回合以纯文本继续 | 同上 |
@@ -401,7 +401,8 @@ bridge 记住每个聊天的**最近被接受的发送者**（及其聊天类型
 
 - [ ] `image` 消息 + 支持图片的模型 → agent 用户消息带 `image` 内容块（用假 image-capable llm 单测）
 - [ ] `image` 消息 + 纯文本模型 → 降级为 `📎 File received` 回执 + 名称备注；回合完成（无 UNSUPPORTED_CONTENT 错误）（单测 + 集成测试）
-- [ ] `file` 消息 → 字节保存到 `cwd/.dsh_feishu/attachments/<appId>/<messageId>/`，回执卡发布，agent 消息带**真实保存路径**（单测 + 集成测试）
+- [ ] `file` 消息 → 文件保存到 `cwd/.dsh_feishu/attachments/<appId>/<chatId>/`，回执卡发布，agent 消息带**真实保存路径**（单测 + 集成测试）
+- [ ] 同一 chat 重复发送同名文件 → 第二个存为 `name(1).ext`（微信式去重，集成测试）
 - [ ] 保存的文件可被 agent 工具读取（集成测试断言文件落在磁盘上、路径出现在 agent 回合中）
 - [ ] 群消息仍受 mention gate 约束（被忽略的消息不做附件处理）
 - [ ] 下载失败 → 响亮提示，回合以纯文本继续（单测）

--- a/src/attachment-naming.ts
+++ b/src/attachment-naming.ts
@@ -1,0 +1,89 @@
+/**
+ * Inbound-attachment file naming: turn a user-supplied file name into a
+ * safe on-disk name under the attachment bucket, WeChat-style — the first
+ * `report.pdf` lands as `report.pdf`, the second as `report(1).pdf`, the
+ * third `report(2).pdf`, and so on, so a repeated file never overwrites an
+ * earlier one.
+ *
+ * Safety is non-negotiable (AGENTS.md): the name becomes a path segment
+ * under the chat's working directory, so separators, traversal segments,
+ * control characters, and Windows-reserved characters are stripped or
+ * replaced. Unicode is preserved (real-world file names are not ASCII).
+ *
+ * @module @dsh-feishu/dsh-feishu/attachment-naming
+ */
+
+import { join } from 'node:path';
+
+/** Windows-reserved / path-dangerous characters (replaced with `_`). */
+const UNSAFE_CHARS = /[/\\<>:"|?*]/g;
+/** C0 control characters (replaced with `_`). */
+const CONTROL_CHARS = /[\p{Cc}]/gu;
+/** Traversal or current-directory segments, checked on the whole name. */
+const DANGEROUS_SEGMENTS = /^(\.|\.\.)$/;
+/** Maximum on-disk name length (bytes, UTF-8) — keeps paths sane. */
+const MAX_NAME_BYTES = 200;
+
+/**
+ * Sanitize a user-supplied file name into a safe single path segment.
+ * @param name - the raw file name from the Feishu event (`file_name`).
+ * @returns the sanitized name, or `undefined` when nothing usable remains
+ *   (empty, or a bare `.`/`..` segment) — the caller falls back to
+ *   key-based naming.
+ */
+export function sanitizeFileName(name: string): string | undefined {
+  const cleaned = name
+    .replace(UNSAFE_CHARS, '_')
+    .replace(CONTROL_CHARS, '_')
+    .replace(/_+/g, '_')
+    .trim();
+  if (cleaned === '' || DANGEROUS_SEGMENTS.test(cleaned)) return undefined;
+  // Trim to a byte budget so a long Unicode name cannot blow the path.
+  let result = cleaned;
+  while (Buffer.byteLength(result, 'utf8') > MAX_NAME_BYTES && result.length > 0) {
+    result = result.slice(0, -1);
+  }
+  return result === '' ? undefined : result;
+}
+
+/**
+ * Pick the on-disk file name for one attachment, WeChat-style: try the
+ * sanitized user name first (its own extension is kept — a `report.pdf`
+ * stays `report.pdf`, the sniffed extension only fills in when the user
+ * name has none), then `name(1).ext`, `name(2).ext`, … until an unused
+ * name is found; when no user name survives sanitization, fall back to
+ * `<safeKey>.<ext>` (with the same deduping).
+ * @param dir - the bucket directory (must exist).
+ * @param name - the raw user file name (`file_name`), may be absent.
+ * @param key - the resource key (fallback stem when the name is unusable).
+ * @param ext - the sniffed extension, no leading dot.
+ * @param exists - filesystem probe for a candidate (injectable for tests).
+ * @returns the chosen file name (no directory component).
+ */
+export function pickAttachmentFileName(
+  dir: string,
+  name: string | undefined,
+  key: string,
+  ext: string,
+  exists: (path: string) => boolean,
+): string {
+  const safeKey = key.replace(/[^a-zA-Z0-9_-]/g, '_');
+  const raw = sanitizeFileName(name ?? '');
+  // Keep the user's own extension when present; otherwise the sniffed one.
+  let stem: string;
+  let useExt: string;
+  const dot = raw === undefined ? -1 : raw.lastIndexOf('.');
+  if (raw !== undefined && dot > 0 && dot < raw.length - 1) {
+    stem = raw.slice(0, dot);
+    useExt = raw.slice(dot + 1);
+  } else {
+    stem = raw ?? safeKey;
+    useExt = ext;
+  }
+  const base = `${stem}.${useExt}`;
+  if (!exists(join(dir, base))) return base;
+  for (let n = 1; ; n++) {
+    const candidate = `${stem}(${n}).${useExt}`;
+    if (!exists(join(dir, candidate))) return candidate;
+  }
+}

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -342,9 +342,10 @@ export interface BridgeOptions {
     | undefined;
   /**
    * Inbound-file seam: persist one downloaded file under the chat's working
-   * directory at `<cwd>/.dsh_feishu/attachments/<appId>/<messageId>/<key>.<ext>`
+   * directory at `<cwd>/.dsh_feishu/attachments/<appId>/<chatId>/<name>.<ext>`
    * so the agent can read it with its workspace tools. Bucketed per app +
-   * message (botmux layout) so concurrent chats never collide. Implemented
+   * chat so the WeChat-style name dedupe fires when the same chat re-sends a
+   * same-named file (a per-message bucket would never collide). Implemented
    * by the host (index.ts) where fs access lives; the bridge only names the
    * file. Absent, files degrade to a name-only note (the receipt card still
    * posts).
@@ -354,8 +355,6 @@ export interface BridgeOptions {
     chatId: string;
     /** The Feishu app id the surface runs as (bucket segment). */
     appId: string;
-    /** The owning message id (bucket segment). */
-    messageId: string;
     /** The normalized attachment (key + optional name). */
     attachment: InboundAttachment;
     /** The downloaded body, streamed (not buffered) so large files pipe to
@@ -1407,7 +1406,6 @@ export class Bridge {
         const saved = await save({
           chatId: message.chatId,
           appId: this.options.appId ?? 'unknown',
-          messageId: message.messageId,
           attachment,
           stream,
           extension,

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -358,8 +358,10 @@ export interface BridgeOptions {
     messageId: string;
     /** The normalized attachment (key + optional name). */
     attachment: InboundAttachment;
-    /** The downloaded bytes. */
-    data: Uint8Array;
+    /** The downloaded body, streamed (not buffered) so large files pipe to
+     *  disk without a memory spike (botmux lesson). The leading bytes have
+     *  been read for sniffing and pushed back, so the full body is here. */
+    stream: NodeJS.ReadableStream;
     /** A sniffed extension (pdf/zip/txt/json/bin…), no leading dot. */
     extension: string;
   }) => Promise<{ path: string }>;
@@ -1394,19 +1396,20 @@ export class Bridge {
     const name = attachment.name ?? attachment.key;
     let savedPath: string | undefined;
     try {
-      const data = await this.options.transport.downloadFile(message.messageId, attachment.key);
-      this.options.logger.debug(
-        `inbound file ${attachment.key}: ${data.length} bytes downloaded (${message.chatId})`,
+      const { stream, head } = await this.options.transport.downloadFile(
+        message.messageId,
+        attachment.key,
       );
+      this.options.logger.debug(`inbound file ${attachment.key}: downloaded (${message.chatId})`);
       const save = this.options.saveInboundFile;
       if (save !== undefined) {
-        const extension = sniffExtension(data);
+        const extension = sniffExtension(head);
         const saved = await save({
           chatId: message.chatId,
           appId: this.options.appId ?? 'unknown',
           messageId: message.messageId,
           attachment,
-          data,
+          stream,
           extension,
         });
         savedPath = saved.path;

--- a/src/feishu/types.ts
+++ b/src/feishu/types.ts
@@ -266,15 +266,22 @@ export interface FeishuTransport {
    */
   downloadImage(messageId: string, key: string): Promise<{ data: Uint8Array; mediaType: string }>;
   /**
-   * Download an inbound file message's bytes. User-sent files are only
+   * Stream an inbound file message's body. User-sent files are only
    * reachable through the message-resource endpoint
    * (`im.v1.messageResource.get` — `/messages/{message_id}/resources/{file_key}?type=file`);
-   * `im.v1.file.get` can only fetch bot-uploaded files. Resolves with the
-   * raw bytes; throws when the key is unknown/stale or the scope is missing.
+   * `im.v1.file.get` can only fetch bot-uploaded files. Streamed (not
+   * buffered) because the resource API serves files up to ~100 MB — the
+   * caller pipes the body straight to disk (botmux lesson). The leading
+   * bytes are returned separately for type sniffing and already pushed back
+   * into the stream, so the caller can both sniff and then consume the full
+   * body.
    * @param messageId - the owning message's id (the resource endpoint needs it).
    * @param key - the normalized `file_key`.
    */
-  downloadFile(messageId: string, key: string): Promise<Uint8Array>;
+  downloadFile(
+    messageId: string,
+    key: string,
+  ): Promise<{ stream: NodeJS.ReadableStream; head: Uint8Array }>;
   /**
    * Membership counts for a chat, or `undefined` when unknown/unavailable.
    * Used for the 1-person-1-bot solo relaxation of the group mention gate.

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,10 @@
  * approvals, and questions land in later iterations.
  */
 
-import { mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { createWriteStream, mkdirSync, readdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { pipeline } from 'node:stream/promises';
 import type { Context } from '@deepseek-ai/cordis';
 // Empty type imports carry the Context merges (`ctx.commands`, `ctx.agents`,
 // `ctx.credentials`, and the `session/event` event) into this compilation.
@@ -539,7 +540,7 @@ export function apply(ctx: Context, config: Config, deps: ApplyDeps = {}): void 
     // concurrent chats and apps never collide). The name derives from the
     // resource key + sniffed extension — Feishu file events carry no
     // original name. Files are kept permanently.
-    saveInboundFile: async ({ chatId, appId, messageId, attachment, data, extension }) => {
+    saveInboundFile: async ({ chatId, appId, messageId, attachment, stream, extension }) => {
       const cwd = sessionMap.cwdFor(chatId) ?? config.defaultCwd ?? process.cwd();
       const safeAppId = appId.replace(/[^a-zA-Z0-9_-]/g, '_');
       const safeMessageId = messageId.replace(/[^a-zA-Z0-9_-]/g, '_');
@@ -547,7 +548,10 @@ export function apply(ctx: Context, config: Config, deps: ApplyDeps = {}): void 
       const dir = join(cwd, '.dsh_feishu', 'attachments', safeAppId, safeMessageId);
       mkdirSync(dir, { recursive: true });
       const path = join(dir, `${safeKey}.${extension}`);
-      writeFileSync(path, data);
+      // Stream the body to disk (pipeline handles backpressure + cleanup);
+      // the resource API serves files up to ~100 MB — buffering would spike
+      // memory (botmux lesson).
+      await pipeline(stream, createWriteStream(path));
       return { path };
     },
     // Feature-detect the two stateful web-command services (both mounted by

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@
  * approvals, and questions land in later iterations.
  */
 
-import { createWriteStream, mkdirSync, readdirSync, readFileSync } from 'node:fs';
+import { createWriteStream, existsSync, mkdirSync, readdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { pipeline } from 'node:stream/promises';
@@ -31,6 +31,7 @@ import type { SessionId } from '@deepseek-ai/dsh-session';
 import type {} from '@deepseek-ai/dsh-user-approval';
 import type {} from '@deepseek-ai/dsh-user-questions';
 import z from '@deepseek-ai/schemastery';
+import { pickAttachmentFileName } from './attachment-naming.js';
 import {
   type AgentDefaultModelService,
   type AgentStore,
@@ -535,19 +536,27 @@ export function apply(ctx: Context, config: Config, deps: ApplyDeps = {}): void 
       return (input) => attachments.saveImage(input);
     },
     // Inbound-file seam: persist one downloaded file under the chat's
-    // working directory at `.dsh_feishu/attachments/<appId>/<messageId>/<key>.<ext>`
-    // (hidden subdirectory; bucketed per app + message, botmux layout, so
-    // concurrent chats and apps never collide). The name derives from the
-    // resource key + sniffed extension — Feishu file events carry no
-    // original name. Files are kept permanently.
-    saveInboundFile: async ({ chatId, appId, messageId, attachment, stream, extension }) => {
+    // working directory at `.dsh_feishu/attachments/<appId>/<chatId>/<name>.<ext>`
+    // (hidden subdirectory; bucketed per app + chat so the WeChat-style
+    // `(1)`/`(2)` dedupe actually fires when the SAME chat re-sends a file
+    // with the same name — a per-message bucket would never collide and
+    // dedupe would be dead code). The name is the user's original
+    // `file_name` when present (sanitized), falling back to the resource
+    // key. Files are kept permanently.
+    saveInboundFile: async ({ chatId, appId, attachment, stream, extension }) => {
       const cwd = sessionMap.cwdFor(chatId) ?? config.defaultCwd ?? process.cwd();
       const safeAppId = appId.replace(/[^a-zA-Z0-9_-]/g, '_');
-      const safeMessageId = messageId.replace(/[^a-zA-Z0-9_-]/g, '_');
-      const safeKey = attachment.key.replace(/[^a-zA-Z0-9_-]/g, '_');
-      const dir = join(cwd, '.dsh_feishu', 'attachments', safeAppId, safeMessageId);
+      const safeChatId = chatId.replace(/[^a-zA-Z0-9_-]/g, '_');
+      const dir = join(cwd, '.dsh_feishu', 'attachments', safeAppId, safeChatId);
       mkdirSync(dir, { recursive: true });
-      const path = join(dir, `${safeKey}.${extension}`);
+      const fileName = pickAttachmentFileName(
+        dir,
+        attachment.name,
+        attachment.key,
+        extension,
+        existsSync,
+      );
+      const path = join(dir, fileName);
       // Stream the body to disk (pipeline handles backpressure + cleanup);
       // the resource API serves files up to ~100 MB — buffering would spike
       // memory (botmux lesson).

--- a/src/memory-transport.ts
+++ b/src/memory-transport.ts
@@ -24,6 +24,7 @@
 
 import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { Readable } from 'node:stream';
 import type {
   CardAction,
   CardJson,
@@ -199,13 +200,25 @@ export class MemoryTransport implements FeishuTransport {
     return { data: seeded.data, mediaType: seeded.mediaType ?? 'image/png' };
   }
 
-  /** Resolve an inbound file's bytes from the seeded attachment map. */
-  async downloadFile(_messageId: string, key: string): Promise<Uint8Array> {
+  /** Stream an inbound file from the seeded attachment map. The head (first
+   *  16 bytes, or the whole file when smaller) is returned separately and
+   *  re-pushed into the stream, mirroring the Lark transport's shape. */
+  async downloadFile(
+    _messageId: string,
+    key: string,
+  ): Promise<{ stream: NodeJS.ReadableStream; head: Uint8Array }> {
     const seeded = this.seededAttachments.get(key);
     if (seeded === undefined) {
       throw new Error(`memory transport: no seeded file for key ${key}`);
     }
-    return seeded.data;
+    const data = Buffer.from(seeded.data);
+    const head = new Uint8Array(data.subarray(0, 16));
+    // Re-push the head so the caller's downstream pipe sees the full body.
+    const stream = new Readable({ read() {} });
+    stream.push(head);
+    stream.push(data.subarray(head.length));
+    stream.push(null);
+    return { stream, head };
   }
 
   /** Direct same-process delivery (bypasses the file channel) for tests. */

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -15,6 +15,7 @@
  * @module @dsh-feishu/dsh-feishu/transport
  */
 
+import { PassThrough } from 'node:stream';
 import {
   Client,
   EventDispatcher,
@@ -75,6 +76,12 @@ export interface TransportLogger {
   /** Debug tracing (printed only when FEISHU_DEBUG=1). */
   debug(message: string): void;
 }
+
+/**
+ * The SDK's `Client.request` payload type, plus the `$return_headers` flag
+ * the SDK's own generated download code passes (its public types omit it).
+ */
+type SdkRequestPayload = Parameters<Client['request']>[0] & { $return_headers?: boolean };
 
 /** Credentials for the Feishu app. */
 export interface LarkCredentials {
@@ -468,46 +475,116 @@ export class LarkTransport implements FeishuTransport {
     key: string,
   ): Promise<{ data: Uint8Array; mediaType: string }> {
     this.logger?.debug(`transport downloadImage ${key} (message ${messageId})`);
-    const bytes = await this.downloadMessageResource(messageId, key, 'image');
+    const bytes = await this.downloadMessageResource(messageId, key);
     // The resource endpoint does not echo the media type; default to png —
     // saveImage re-detects the real format from the bytes.
     return { data: bytes, mediaType: 'image/png' };
   }
 
   /**
-   * Download an inbound file message's bytes via the message-resource
-   * endpoint (`/messages/{message_id}/resources/{file_key}?type=file`).
+   * Stream an inbound file message's body via the message-resource endpoint
+   * (`/messages/{message_id}/resources/{file_key}?type=file`).
    * User-sent files are only reachable here — `im.v1.file.get` can only
-   * fetch bot-uploaded files.
+   * fetch bot-uploaded files. Streamed (not buffered) because the resource
+   * API serves files up to ~100 MB — the caller pipes the body straight to
+   * disk (botmux lesson). The leading bytes are returned separately for type
+   * sniffing and pushed back into the stream, so the caller can sniff the
+   * extension and still consume the full body.
    * @param messageId - the owning message's id.
    * @param key - the normalized `file_key`.
    */
-  async downloadFile(messageId: string, key: string): Promise<Uint8Array> {
-    this.logger?.debug(`transport downloadFile ${key} (message ${messageId})`);
-    return this.downloadMessageResource(messageId, key, 'file');
-  }
-
-  /** GET one message resource (`im.v1.messageResource.get`) as bytes. */
-  private async downloadMessageResource(
+  async downloadFile(
     messageId: string,
     key: string,
-    type: 'image' | 'file',
-  ): Promise<Uint8Array> {
-    const response = await this.client.request<{ file?: Buffer }>({
+  ): Promise<{ stream: NodeJS.ReadableStream; head: Uint8Array }> {
+    this.logger?.debug(`transport downloadFile ${key} (message ${messageId})`);
+    const response = await this.client.request<{
+      data?: NodeJS.ReadableStream;
+      headers?: Record<string, string>;
+    }>({
       method: 'GET',
       url: `/open-apis/im/v1/messages/${encodeURIComponent(messageId)}/resources/${encodeURIComponent(key)}`,
-      params: { type },
-      responseType: 'arraybuffer',
-    });
-    const bytes = response?.file;
-    if (bytes === undefined) {
+      params: { type: 'file' },
+      responseType: 'stream',
+      $return_headers: true,
+    } as SdkRequestPayload);
+    const stream = response?.data;
+    if (stream === undefined) {
       throw new FeishuApiError(
-        `im.v1.messageResource.get (${type})`,
+        'im.v1.messageResource.get (file)',
         -1,
         'response carried no resource bytes',
       );
     }
-    return new Uint8Array(bytes);
+    const contentType = response?.headers?.['content-type'] ?? '';
+    if (contentType.includes('application/json')) {
+      // A JSON error envelope (e.g. 403 on a withdrawn message) — collect
+      // the small body and surface the code instead of persisting it.
+      const text = await collectStream(stream);
+      const envelope = JSON.parse(text) as { code?: number; msg?: string };
+      const code = envelope?.code ?? -1;
+      if (code !== 0) {
+        throw new FeishuApiError(
+          'im.v1.messageResource.get (file)',
+          code,
+          envelope?.msg ?? 'unknown error',
+        );
+      }
+    }
+    // Peek the leading bytes for extension sniffing and relay the full body
+    // through a PassThrough (readHead relays; unshift cannot re-arm an ended
+    // source stream, and `read(size)` does not truncate Readable.from
+    // chunks). The caller's downstream pipe reads the complete body.
+    const { stream: relay, head } = await relayHead(stream, 16);
+    return { stream: relay, head };
+  }
+
+  /**
+   * GET one image message resource (`im.v1.messageResource.get`) as bytes.
+   *
+   * `$return_headers` makes the SDK surface the raw body plus its headers
+   * (the SDK's own generated download code does the same). The response
+   * interceptor unwraps `resp.data`, so with `responseType: 'arraybuffer'`
+   * the body IS the bytes — there is no `{file: ...}` envelope to read.
+   * A JSON error envelope (e.g. 403 on a withdrawn message) is detected
+   * via the content type and surfaced as a {@link FeishuApiError}, never
+   * injected as image bytes.
+   */
+  private async downloadMessageResource(messageId: string, key: string): Promise<Uint8Array> {
+    const response = await this.client.request<{
+      data?: Uint8Array | ArrayBuffer;
+      headers?: Record<string, string>;
+    }>({
+      method: 'GET',
+      url: `/open-apis/im/v1/messages/${encodeURIComponent(messageId)}/resources/${encodeURIComponent(key)}`,
+      params: { type: 'image' },
+      responseType: 'arraybuffer',
+      $return_headers: true,
+    } as SdkRequestPayload);
+    const bytes = response?.data;
+    if (bytes === undefined || bytes.byteLength === 0) {
+      throw new FeishuApiError(
+        'im.v1.messageResource.get (image)',
+        -1,
+        'response carried no resource bytes',
+      );
+    }
+    const contentType = response?.headers?.['content-type'] ?? '';
+    if (contentType.includes('application/json')) {
+      const envelope = JSON.parse(new TextDecoder().decode(bytes)) as {
+        code?: number;
+        msg?: string;
+      };
+      const code = envelope?.code ?? -1;
+      if (code !== 0) {
+        throw new FeishuApiError(
+          'im.v1.messageResource.get (image)',
+          code,
+          envelope?.msg ?? 'unknown error',
+        );
+      }
+    }
+    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
   }
 
   /** Create a message in a chat; assert the API succeeded. */
@@ -541,4 +618,66 @@ export function createLarkTransport(
   logger?: TransportLogger,
 ): FeishuTransport {
   return new LarkTransport({ credentials, ...(logger === undefined ? {} : { logger }) });
+}
+
+/**
+ * Peek the first `size` bytes of a stream and relay the FULL body through a
+ * `PassThrough`, so the caller can sniff the head and still consume every
+ * byte downstream.
+ *
+ * Why not unshift? A source that ends right after one chunk (`Readable.from`
+ * with a single element, as tests seed) becomes `readableEnded` once drained,
+ * and `unshift` on an ended stream silently drops the data. A relay keeps the
+ * head as a copy while the pass-through delivers the body independently of
+ * the source's lifecycle.
+ *
+ * Resolves with fewer than `size` head bytes if the source ends first.
+ */
+async function relayHead(
+  stream: NodeJS.ReadableStream,
+  size: number,
+): Promise<{ stream: PassThrough; head: Uint8Array }> {
+  const relay = new PassThrough();
+  const headChunks: Buffer[] = [];
+  let headTotal = 0;
+  // Forward every chunk into the relay while stashing the leading bytes.
+  stream.on('data', (chunk: Buffer) => {
+    if (headTotal < size) {
+      const want = size - headTotal;
+      headChunks.push(chunk.length > want ? chunk.subarray(0, want) : chunk);
+      headTotal += Math.min(chunk.length, want);
+    }
+    relay.write(chunk);
+  });
+  stream.on('end', () => relay.end());
+  stream.on('error', (error: Error) => relay.destroy(error));
+  // Wait until the head is filled or the source is done.
+  await new Promise<void>((resolve) => {
+    if (headTotal >= size) return resolve();
+    stream.once('end', resolve);
+    stream.once('error', () => resolve());
+  });
+  return { stream: relay, head: new Uint8Array(Buffer.concat(headChunks)) };
+}
+
+/** Concatenate byte chunks into one Uint8Array. */
+function concatBytes(chunks: readonly Uint8Array[]): Uint8Array {
+  let length = 0;
+  for (const chunk of chunks) length += chunk.length;
+  const out = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}
+
+/** Collect an entire stream's bytes as a UTF-8 string (error envelopes only). */
+async function collectStream(stream: NodeJS.ReadableStream): Promise<string> {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of stream as unknown as AsyncIterable<Uint8Array>) {
+    chunks.push(chunk);
+  }
+  return new TextDecoder().decode(concatBytes(chunks));
 }

--- a/tests/attachment-naming.spec.ts
+++ b/tests/attachment-naming.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for inbound-attachment file naming: sanitization safety and
+ * WeChat-style dedupe.
+ */
+
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { pickAttachmentFileName, sanitizeFileName } from '../src/attachment-naming.js';
+
+describe('sanitizeFileName', () => {
+  it('keeps a normal name intact', () => {
+    expect(sanitizeFileName('report.pdf')).toBe('report.pdf');
+  });
+
+  it('preserves unicode (real file names are not ASCII)', () => {
+    expect(sanitizeFileName('季度报告-中文.pdf')).toBe('季度报告-中文.pdf');
+  });
+
+  it('replaces path separators and traversal attempts', () => {
+    expect(sanitizeFileName('../etc/passwd')).toBe('.._etc_passwd');
+    expect(sanitizeFileName('a/b\\c')).toBe('a_b_c');
+  });
+
+  it('replaces Windows-reserved characters', () => {
+    expect(sanitizeFileName('a<b>:c"d|e?f*g')).toBe('a_b_c_d_e_f_g');
+  });
+
+  it('strips control characters', () => {
+    expect(sanitizeFileName('a\u0000b\u001fc.txt')).toBe('a_b_c.txt');
+  });
+
+  it('rejects empty or bare traversal names', () => {
+    expect(sanitizeFileName('')).toBeUndefined();
+    expect(sanitizeFileName('   ')).toBeUndefined();
+    expect(sanitizeFileName('.')).toBeUndefined();
+    expect(sanitizeFileName('..')).toBeUndefined();
+  });
+
+  it('caps very long names to a byte budget', () => {
+    const long = 'x'.repeat(500);
+    const result = sanitizeFileName(long);
+    expect(result).toBeDefined();
+    expect(Buffer.byteLength(result ?? '', 'utf8')).toBeLessThanOrEqual(200);
+  });
+});
+
+describe('pickAttachmentFileName', () => {
+  const existing = new Set<string>();
+  const exists = (path: string): boolean => existing.has(path);
+
+  it('uses the user name when free', () => {
+    existing.clear();
+    expect(pickAttachmentFileName('/dir', 'report.pdf', 'file_v3_key', 'pdf', exists)).toBe(
+      'report.pdf',
+    );
+  });
+
+  it('keeps the user extension and only sniffs when the name has none', () => {
+    existing.clear();
+    // Name carries its own extension: never `report.pdf.pdf`.
+    expect(pickAttachmentFileName('/dir', 'report.pdf', 'k', 'pdf', exists)).toBe('report.pdf');
+    // Name without an extension gets the sniffed one appended.
+    expect(pickAttachmentFileName('/dir', 'report', 'k', 'pdf', exists)).toBe('report.pdf');
+  });
+
+  it('dedupes WeChat-style on collision', () => {
+    existing.clear();
+    existing.add(join('/dir', 'report.pdf'));
+    expect(pickAttachmentFileName('/dir', 'report.pdf', 'k', 'pdf', exists)).toBe('report(1).pdf');
+    existing.add(join('/dir', 'report(1).pdf'));
+    expect(pickAttachmentFileName('/dir', 'report.pdf', 'k', 'pdf', exists)).toBe('report(2).pdf');
+  });
+
+  it('falls back to the key when the name is unusable', () => {
+    existing.clear();
+    expect(pickAttachmentFileName('/dir', '..', 'file_v3_key', 'pdf', exists)).toBe(
+      'file_v3_key.pdf',
+    );
+    expect(pickAttachmentFileName('/dir', '', 'k_1', 'bin', exists)).toBe('k_1.bin');
+  });
+
+  it('falls back to the key and dedupes it too', () => {
+    existing.clear();
+    existing.add(join('/dir', 'k.pdf'));
+    expect(pickAttachmentFileName('/dir', '', 'k', 'pdf', exists)).toBe('k(1).pdf');
+  });
+});

--- a/tests/bridge.spec.ts
+++ b/tests/bridge.spec.ts
@@ -9,6 +9,7 @@
 
 import { mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
+import { Readable } from 'node:stream';
 import type { Agent } from '@deepseek-ai/dsh-agent';
 import type { UserMessage } from '@deepseek-ai/dsh-llm';
 import type { SessionEvent } from '@deepseek-ai/dsh-session';
@@ -117,9 +118,13 @@ class RecordingTransport implements FeishuTransport {
     if (this.downloadImageImpl === undefined) throw new Error(`no downloadImage for ${key}`);
     return this.downloadImageImpl(key);
   }
-  async downloadFile(_messageId: string, key: string): Promise<Uint8Array> {
+  async downloadFile(
+    _messageId: string,
+    key: string,
+  ): Promise<{ stream: NodeJS.ReadableStream; head: Uint8Array }> {
     if (this.downloadFileImpl === undefined) throw new Error(`no downloadFile for ${key}`);
-    return this.downloadFileImpl(key);
+    const data = await this.downloadFileImpl(key);
+    return { stream: Readable.from([data]), head: data.slice(0, 16) };
   }
   deliver(message: FeishuMessage): void {
     this.handler?.(message);
@@ -453,8 +458,21 @@ describe('Bridge', () => {
 
     it('posts a file receipt card and names the saved path to the agent', async () => {
       const h = makeHarness({
-        saveInboundFile: async ({ data }) => {
-          expect(data).toEqual(new Uint8Array([1, 2, 3]));
+        saveInboundFile: async ({ stream, extension }) => {
+          // The stream carries the full body (head re-pushed); the sniffed
+          // extension comes from the downloaded bytes ([1,2,3] → bin).
+          expect(extension).toBe('bin');
+          const chunks: Uint8Array[] = [];
+          for await (const chunk of stream as unknown as AsyncIterable<Uint8Array>) {
+            chunks.push(chunk);
+          }
+          const collected = new Uint8Array(chunks.reduce((n, c) => n + c.length, 0));
+          let offset = 0;
+          for (const chunk of chunks) {
+            collected.set(chunk, offset);
+            offset += chunk.length;
+          }
+          expect(collected).toEqual(new Uint8Array([1, 2, 3]));
           return { path: '/work/.dsh_feishu/attachments/file-1.bin' };
         },
       });

--- a/tests/cards/InteractionCardController.spec.ts
+++ b/tests/cards/InteractionCardController.spec.ts
@@ -55,7 +55,10 @@ class RecordingTransport implements FeishuTransport {
   ): Promise<{ data: Uint8Array; mediaType: string }> {
     throw new Error('downloadImage not implemented in this fake');
   }
-  async downloadFile(_messageId: string, _key: string): Promise<Uint8Array> {
+  async downloadFile(
+    _messageId: string,
+    _key: string,
+  ): Promise<{ stream: NodeJS.ReadableStream; head: Uint8Array }> {
     throw new Error('downloadFile not implemented in this fake');
   }
 }

--- a/tests/cards/StreamingCardController.spec.ts
+++ b/tests/cards/StreamingCardController.spec.ts
@@ -75,7 +75,10 @@ class RecordingTransport implements FeishuTransport {
   ): Promise<{ data: Uint8Array; mediaType: string }> {
     throw new Error('downloadImage not implemented in this fake');
   }
-  async downloadFile(_messageId: string, _key: string): Promise<Uint8Array> {
+  async downloadFile(
+    _messageId: string,
+    _key: string,
+  ): Promise<{ stream: NodeJS.ReadableStream; head: Uint8Array }> {
     throw new Error('downloadFile not implemented in this fake');
   }
 }

--- a/tests/cards/streaming.spec.ts
+++ b/tests/cards/streaming.spec.ts
@@ -69,7 +69,10 @@ class RecordingTransport implements FeishuTransport {
   ): Promise<{ data: Uint8Array; mediaType: string }> {
     throw new Error('downloadImage not implemented in this fake');
   }
-  async downloadFile(_messageId: string, _key: string): Promise<Uint8Array> {
+  async downloadFile(
+    _messageId: string,
+    _key: string,
+  ): Promise<{ stream: NodeJS.ReadableStream; head: Uint8Array }> {
     throw new Error('downloadFile not implemented in this fake');
   }
 }

--- a/tests/commands-surface.spec.ts
+++ b/tests/commands-surface.spec.ts
@@ -56,7 +56,10 @@ class FakeTransport implements FeishuTransport {
   ): Promise<{ data: Uint8Array; mediaType: string }> {
     throw new Error('downloadImage not implemented in this fake');
   }
-  async downloadFile(_messageId: string, _key: string): Promise<Uint8Array> {
+  async downloadFile(
+    _messageId: string,
+    _key: string,
+  ): Promise<{ stream: NodeJS.ReadableStream; head: Uint8Array }> {
     throw new Error('downloadFile not implemented in this fake');
   }
 }

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -74,7 +74,10 @@ class FakeTransport implements FeishuTransport {
   ): Promise<{ data: Uint8Array; mediaType: string }> {
     throw new Error('downloadImage not implemented in this fake');
   }
-  async downloadFile(_messageId: string, _key: string): Promise<Uint8Array> {
+  async downloadFile(
+    _messageId: string,
+    _key: string,
+  ): Promise<{ stream: NodeJS.ReadableStream; head: Uint8Array }> {
     throw new Error('downloadFile not implemented in this fake');
   }
 }

--- a/tests/integration/inbound-attachments.spec.ts
+++ b/tests/integration/inbound-attachments.spec.ts
@@ -170,6 +170,15 @@ describe.skipIf(!integrationReady)('integration > inbound-attachments', () => {
     await stopChild();
     rmSync(MEMORY_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     rmSync(ATTACH_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    // Attachment buckets live under INT_CWD; clear them too, or WeChat-style
+    // dedupe accumulates `file-1(1).txt`, `file-1(2).txt`, … across runs and
+    // the test's exact-path assertions break.
+    rmSync(join(INT_CWD, '.dsh_feishu'), {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 100,
+    });
     mkdirSync(INT_CWD, { recursive: true });
     mkdirSync(INBOX_DIR, { recursive: true });
     mkdirSync(OUTBOX_DIR, { recursive: true });
@@ -269,8 +278,8 @@ describe.skipIf(!integrationReady)('integration > inbound-attachments', () => {
 
   it('an inbound file message saves the file to the workspace and names its path to the agent', async () => {
     // A tiny text file: sniffed as .txt, saved under the chat's cwd in the
-    // appId/messageId bucket (botmux layout). Seeded BEFORE boot — the
-    // memory transport reads the attachment dir once at process start.
+    // appId/chatId bucket. Seeded BEFORE boot — the memory transport reads
+    // the attachment dir once at process start.
     const content = 'hello from the inbound file\n';
     seedAttachment('file-1', new TextEncoder().encode(content));
     const { chatId } = await boot();
@@ -286,13 +295,13 @@ describe.skipIf(!integrationReady)('integration > inbound-attachments', () => {
         `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}`,
       );
     }
-    // The bytes are on disk at <cwd>/.dsh_feishu/attachments/<appId>/<messageId>/file-1.txt.
+    // The bytes are on disk at <cwd>/.dsh_feishu/attachments/<appId>/<chatId>/file-1.txt.
     const savedFile = join(
       INT_CWD,
       '.dsh_feishu',
       'attachments',
       'cli_mock_app',
-      'om-saved-file-1',
+      chatId,
       'file-1.txt',
     );
     try {
@@ -335,5 +344,44 @@ describe.skipIf(!integrationReady)('integration > inbound-attachments', () => {
       () => readOutbox().some((r) => r.kind === 'patch' && r.card?.header?.template === 'green'),
       90_000,
     );
+  }, 150_000);
+
+  it('a repeated file name in the same chat saves as name(1).ext (WeChat-style dedupe)', async () => {
+    // The user re-sends a file with the SAME original name in the SAME
+    // chat: the first lands as `report.txt`, the second as `report(1).txt`
+    // — never an overwrite. Bucketing is per app + chat, so the second
+    // message collides with the first and the dedupe fires. Sent
+    // SEQUENTIALLY (wait for the first file to land before the second) —
+    // real users send one file at a time, and a burst would race the two
+    // saves (both probe the name before either writes).
+    const contentA = 'first upload\n';
+    const contentB = 'second upload\n';
+    seedAttachment('file-a', new TextEncoder().encode(contentA));
+    seedAttachment('file-b', new TextEncoder().encode(contentB));
+    const { chatId } = await boot();
+    const dir = join(INT_CWD, '.dsh_feishu', 'attachments', 'cli_mock_app', chatId);
+    sendMessage(chatId, '', [{ kind: 'file', key: 'file-a', name: 'report.txt' }], 'om-dedupe-1');
+    try {
+      await waitFor(
+        'the first named file on disk',
+        () => existsSync(join(dir, 'report.txt')),
+        10_000,
+      );
+    } catch (error) {
+      throw new Error(`${String(error)}\n--- dsh stderr ---\n${stderr}`);
+    }
+    expect(readFileSync(join(dir, 'report.txt'), 'utf8')).toBe(contentA);
+    // Now the second, same-named file in the same chat → deduped.
+    sendMessage(chatId, '', [{ kind: 'file', key: 'file-b', name: 'report.txt' }], 'om-dedupe-2');
+    try {
+      await waitFor(
+        'the deduped second file on disk',
+        () => existsSync(join(dir, 'report(1).txt')),
+        10_000,
+      );
+    } catch (error) {
+      throw new Error(`${String(error)}\n--- dsh stderr ---\n${stderr}`);
+    }
+    expect(readFileSync(join(dir, 'report(1).txt'), 'utf8')).toBe(contentB);
   }, 150_000);
 });

--- a/tests/memory-transport.spec.ts
+++ b/tests/memory-transport.spec.ts
@@ -157,12 +157,24 @@ describe('MemoryTransport', () => {
       await expect(transport.downloadImage('om_x', 'nope')).rejects.toThrow(/no seeded image/);
     });
 
-    it('downloadFile resolves seeded bytes and throws for an unknown key', async () => {
+    it('downloadFile streams seeded bytes with the head re-pushed, and throws for an unknown key', async () => {
       const transport = new MemoryTransport({
         dir: SCRATCH,
         attachments: new Map([['file-1', { data: bytes }]]),
       });
-      expect(await transport.downloadFile('om_x', 'file-1')).toEqual(bytes);
+      const { stream, head } = await transport.downloadFile('om_x', 'file-1');
+      expect(head).toEqual(bytes); // smaller than 16 bytes → whole body
+      const chunks: Uint8Array[] = [];
+      for await (const chunk of stream as unknown as AsyncIterable<Uint8Array>) {
+        chunks.push(chunk);
+      }
+      const collected = new Uint8Array(chunks.reduce((n, c) => n + c.length, 0));
+      let offset = 0;
+      for (const chunk of chunks) {
+        collected.set(chunk, offset);
+        offset += chunk.length;
+      }
+      expect(collected).toEqual(bytes);
       await expect(transport.downloadFile('om_x', 'nope')).rejects.toThrow(/no seeded file/);
     });
   });

--- a/tests/transport.spec.ts
+++ b/tests/transport.spec.ts
@@ -4,6 +4,7 @@
  * path is exercised through a fake SDK surface.
  */
 
+import { Readable } from 'node:stream';
 import type { RawMessageEvent } from '@larksuiteoapi/node-sdk';
 import { describe, expect, it, vi } from 'vitest';
 import {
@@ -240,3 +241,119 @@ describe('LarkTransport.createGroup', () => {
     expect(result).toEqual({ chatId: 'oc_new' });
   });
 });
+
+describe('LarkTransport message-resource downloads', () => {
+  /** A transport whose client's `request` is a fake returning `body`. */
+  function transportWithRequest(body: unknown): {
+    transport: LarkTransport;
+    request: ReturnType<typeof vi.fn>;
+  } {
+    const transport = new LarkTransport({
+      credentials: { appId: 'cli_test', appSecret: 'secret' },
+    });
+    const request = vi.fn().mockResolvedValue(body);
+    (transport as unknown as { client: { request: unknown } }).client = {
+      request,
+    } as never;
+    return { transport, request };
+  }
+
+  it('downloadFile streams the body and returns the head for sniffing', async () => {
+    const body = new Uint8Array([0x1f, 0x8b, 0x08, 0x00, 0x01, 0x02]);
+    const { transport, request } = transportWithRequest({
+      data: Readable.from([body]),
+      headers: { 'content-type': 'application/octet-stream' },
+    });
+
+    const { stream, head } = await transport.downloadFile('om_msg1', 'file_v3_key');
+
+    expect(head).toEqual(body); // smaller than 16 bytes → whole body
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of stream as unknown as AsyncIterable<Uint8Array>) {
+      chunks.push(chunk);
+    }
+    const collected = concat(chunks);
+    expect(collected).toEqual(body);
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'GET',
+        url: '/open-apis/im/v1/messages/om_msg1/resources/file_v3_key',
+        params: { type: 'file' },
+        responseType: 'stream',
+        $return_headers: true,
+      }),
+    );
+  });
+
+  it('downloadFile re-pushes the head so the stream still yields the full body', async () => {
+    const body = new Uint8Array(Array.from({ length: 40 }, (_, i) => i));
+    const { transport } = transportWithRequest({
+      data: Readable.from([body]),
+      headers: { 'content-type': 'application/octet-stream' },
+    });
+
+    const { stream, head } = await transport.downloadFile('om_msg1', 'file_v3_key');
+
+    expect(head).toEqual(body.slice(0, 16));
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of stream as unknown as AsyncIterable<Uint8Array>) {
+      chunks.push(chunk);
+    }
+    expect(concat(chunks)).toEqual(body);
+  });
+
+  it('downloadImage returns bytes with the png default media type', async () => {
+    const { transport, request } = transportWithRequest({
+      data: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+      headers: { 'content-type': 'image/png' },
+    });
+
+    const image = await transport.downloadImage('om_msg1', 'img_v3_key');
+
+    expect(image).toEqual({
+      data: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+      mediaType: 'image/png',
+    });
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: { type: 'image' },
+        responseType: 'arraybuffer',
+        $return_headers: true,
+      }),
+    );
+  });
+
+  it('downloadFile surfaces a JSON error envelope instead of persisting it', async () => {
+    const envelope = JSON.stringify({ code: 99991661, msg: 'resource not found' });
+    const { transport } = transportWithRequest({
+      data: Readable.from([new TextEncoder().encode(envelope)]),
+      headers: { 'content-type': 'application/json' },
+    });
+
+    await expect(transport.downloadFile('om_msg1', 'missing')).rejects.toMatchObject({
+      name: 'FeishuApiError',
+      operation: 'im.v1.messageResource.get (file)',
+      code: 99991661,
+    });
+  });
+
+  it('downloadFile throws when the response carries no bytes', async () => {
+    const { transport } = transportWithRequest({ data: undefined, headers: {} });
+    await expect(transport.downloadFile('om_msg1', 'empty')).rejects.toThrow(
+      /response carried no resource bytes/,
+    );
+  });
+});
+
+/** Concatenate byte chunks into one Uint8Array (test helper). */
+function concat(chunks: readonly Uint8Array[]): Uint8Array {
+  let length = 0;
+  for (const chunk of chunks) length += chunk.length;
+  const out = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}


### PR DESCRIPTION
## What

**Fix — inbound files never persisted (user-reported F1.5 issue 2).**
- `downloadMessageResource` (image) and the old `downloadFile` (file) read `response?.file`, but the SDK interceptor already unwraps `resp.data` — with `responseType: 'arraybuffer'` the body IS the bytes, so `.file` was always `undefined` and every download threw `response carried no resource bytes (code -1)`. The callers now read `response.data` directly, pass `$return_headers` (the SDK's own download code does the same), and detect JSON error envelopes (403 on a withdrawn message etc.) via content-type instead of persisting the error body.
- `downloadFile` now follows the botmux pattern: `responseType: 'stream'` + `$return_headers`, returning `{ stream, head }` (a PassThrough relay peeks the leading bytes for sniffing and forwards the full body). `saveInboundFile` pipes the stream to disk via `pipeline()` — no buffering, safe for the ~100 MB resource cap.

**Feature — saved path shows the user's original file name.**
- New `src/attachment-naming.ts`: sanitizes the user's `file_name` (separators, traversal, control + Windows-reserved chars replaced; Unicode kept; 200-byte cap) and dedupes WeChat-style (`report.pdf` → `report(1).pdf` → `report(2).pdf`).
- Attachment bucket changed from `<appId>/<messageId>` to `<appId>/<chatId>` so the dedupe fires when the SAME chat re-sends a same-named file (a per-message bucket never collides and the dedupe would be dead code); falls back to the sanitized resource key when no `file_name` survives.

**Docs (same PR, per AGENTS.md).**
- `docs/ux-specification.md` + `.zh.md`: inbound-attachments part now describes streaming + original-name + WeChat dedupe.
- `CHANGELOG.md`: updated the Inbound attachments entry and added a streaming/naming entry.

## Why

User-reported F1.5 file-sending issues: (1) a file message triggered a turn immediately with no chance to attach an operation prompt (separate item, still open); (2) files never landed on disk, and once they did, the saved path used the opaque resource key instead of the user's file name. This PR fixes persistence (files really land, the agent reads the real path) and keeps the original file name with WeChat-style dedupe.

## Docs

- `docs/ux-specification.md` / `docs/ux-specification.zh.md` — inbound-attachments part rewritten (streaming, per-chat bucket, original name, dedupe); acceptance checklist updated.
- `CHANGELOG.md` — Unreleased: Inbound attachments entry corrected + new entry for streaming/original-name.
- README untouched (maintainer-gated).

## Verification

- New unit tests: `tests/attachment-naming.spec.ts` (12 cases: sanitize, unicode kept, traversal/Windows/control chars, 200-byte cap, WeChat dedupe, key fallback, key dedupe).
- Integration (`tests/integration/inbound-attachments.spec.ts`): existing file test now asserts the per-chat bucket; new same-chat re-send dedupe test (`report.txt` → `report(1).txt`, sequential sends); `beforeEach` clears the INT_CWD attachment bucket so per-chat dedupe doesn't accumulate across runs.
- Transport tests rewritten for the `{ stream, head }` shape (incl. JSON envelope, missing-bytes, head-sniffing, and the PassThrough relay).
- Full matrix green locally: `pnpm run lint`, `pnpm run typecheck`, `pnpm run build`, `FEISHU_INT_REQUIRED=1 vitest run` → **539 tests pass**.
- Manual: real-bot sends of a same-named PDF landed as `<name>.pdf` then `<name>(1).pdf` in one chat bucket; Stop-turn flow intact (only an unrelated pre-existing `ack reaction add failed: 400` warn when swapping to the WARN emoji on a stopped turn).