### PR TITLE
feat: bare attachment messages wait for the user's instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,21 +21,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Inbound attachments.** `image` and `file` messages are no longer
-  ignored. An image is downloaded through the message-resource endpoint
-  (`im.v1.messageResource.get` — `im.v1.image.get` can only fetch
-  bot-uploaded images), committed through the host's attachment service,
-  and injected as an `image` content block of the agent's user message —
-  but ONLY when the chat's current model advertises image input (the
-  DeepSeek adapter rejects image content with `UNSUPPORTED_CONTENT`, which
-  would error the whole turn; pi-ai accepts it). A file (and an image
-  under a text-only model or absent attachment service) is saved under the
-  chat's working directory at
-  `<cwd>/.dsh_feishu/attachments/<appId>/<chatId>/<name>.<ext>` (a
-  hidden, per-app+chat-bucketed subdirectory) — the agent receives the
-  REAL path and reads the file with its workspace tools. A `📎 File
-  received` receipt card posts; download/save failures notice loudly and
-  the turn continues text-only — an attachment never wedges the chat.
-  Reuses the existing `im:resource` scope.
+  ignored. Every attachment (image or file) is downloaded through the
+  message-resource endpoint (`im.v1.messageResource.get` — `im.v1.image.get`
+  can only fetch bot-uploaded images; `type=file` covers files and video)
+  and saved under the chat's working directory at
+  `<cwd>/.dsh_feishu/attachments/<appId>/<chatId>/<name>.<ext>` (a hidden,
+  per-app+chat-bucketed subdirectory) — the agent receives the REAL path
+  and reads the file with its workspace tools. A `📎 File received` receipt
+  card posts; download/save failures notice loudly and never wedge the
+  chat. Reuses the existing `im:resource` scope. (Feishu images are plain
+  files to the agent — there is no image content block / visual-input path.)
+- **Bare attachment messages wait for the user's instruction
+  (inbound-wait-instruction).** A file/image message without text no longer
+  starts a turn by itself: the bytes land in the workspace, a NEW receipt
+  card posts for each file (kept in chat history, showing the running count
+  `📎 已收到 N 个文件`), and the agent waits. The next text message drains
+  the pending list into its turn — every pending file's saved path is
+  injected before the text, in arrival order, then the list clears. In
+  groups, bare attachment messages bypass the mention gate (Feishu sends
+  them without an input box, so an @ is physically impossible), but the
+  follow-up TEXT instruction still requires an @ — the agent never acts
+  without an accepted instruction.
 - **Inbound files stream to disk and keep their original name.** The
   message-resource download previously read `response.file`, but the SDK
   interceptor already unwraps `resp.data`, so every inbound file failed to

--- a/docs/features.md
+++ b/docs/features.md
@@ -17,7 +17,7 @@ Feature list and TODO tracker for dsh-feishu. ✅ = shipped, 📋 = planned
 | Allowlists | `allowedChats` / `allowedUsers` gate who can talk to the bot | Env/config-driven, applied to messages and card actions | ✅ |
 | Session-log export | `/export` sends the chat's session log as a downloadable file message | File message with markdown transcript | ✅ |
 | Diagnostics | `/feishu-status` shows a diagnostic card (connection state, sessions, last inbound) | Read-only status card, usable mid-turn | ✅ |
-| Inbound attachments | Images/files the user sends are no longer ignored: images are injected into the agent (image-capable models) or receipt-noted, files become receipt cards | Image → agent processes it (model supports images) / 📎 receipt; file → saved to workspace, agent reads by path | ✅ |
+| Inbound attachments | Images/files the user sends are saved to the workspace as plain files and the agent reads them by path; a bare file/image message registers as pending — a receipt card posts and the agent waits for your instruction | 📎 File received receipt (counts pending files); follow-up text makes the agent work on them | ✅ |
 | Outbound files/images | Agent-produced images/files send as native Feishu image/file messages | Tap to view original / download | 📋 |
 | Session hard delete | Remove a session from the active list (archive + hide, restorable from the archived list) | Session-detail card Delete + confirm view | 📋 |
 | Agent preset selection | Pick an agent preset (e.g. PTC mode) when choosing a working directory | Mode dropdown on the `/repo` / `/cd` picker card; preset binds to the new session | 📋 |
@@ -29,3 +29,4 @@ Feature list and TODO tracker for dsh-feishu. ✅ = shipped, 📋 = planned
 | Session stats line | Durable per-session usage: turns, steps, LLM/tool time, TTFT, tok/s, cache hit, tokens | One small line at the card bottom, refreshed per turn; details in `/status` | 📋 |
 | Context occupancy | Current session's context-window usage | Percent on the card bottom, refreshed per turn; details (used/capacity, breakdown) in `/status` | 📋 |
 | session-rename-archive | Session rename/archive via dsh sessionTitle + workspaceRegistry (web-visible) | — | 📋 |
+| inbound-wait-instruction | Bare file/image messages register as pending — a receipt card posts and the agent waits for the user's instruction before working | 📎 File received receipt (counts pending files); follow-up text drains them into one turn | ✅ |

--- a/docs/features.zh.md
+++ b/docs/features.zh.md
@@ -17,7 +17,7 @@ dsh-feishu 的功能列表与 TODO 追踪表。✅ = 已实现，📋 = 计划�
 | 白名单 | `allowedChats` / `allowedUsers` 控制谁能与 bot 对话 | 环境变量/配置驱动，作用于消息与卡片动作 | ✅ |
 | 会话日志导出 | `/export` 把聊天的会话日志作为可下载文件消息发送 | 带 markdown 转录的文件消息 | ✅ |
 | 诊断 | `/feishu-status` 显示诊断卡（连接状态、会话数、最后入站） | 只读状态卡，运行中可用 | ✅ |
-| 入站附件 | 用户发来的图片/文件不再被忽略：图片注入 agent（支持图片的模型）或回执通知，文件保存到工作区由 agent 按路径读取 | 图片 → agent 处理（模型支持图片）/ 📎 回执；文件 → 保存到工作区，agent 读路径 | ✅ |
+| 入站附件 | 用户发来的图片/文件保存到工作区作为普通文件，agent 按路径读取；裸文件/图片消息登记为 pending——发回执卡并等你的指令 | 📎 File received 回执（计数 pending 文件）；补发文字让 agent 处理 | ✅ |
 | 出站文件/图片 | agent 产出的图片/文件以飞书原生 image/file 消息发送 | 点开看原图/下载 | 📋 |
 | 会话删除 | 从活跃列表删除会话（归档 + 隐藏，可从归档列表恢复） | 会话详情卡 Delete + 确认视图 | 📋 |
 | agent 预设选择 | 选择工作目录时一并选 agent 预设（如 PTC mode） | `/repo` / `/cd` 选择卡加 Mode 下拉；预设绑定新会话 | 📋 |
@@ -29,3 +29,4 @@ dsh-feishu 的功能列表与 TODO 追踪表。✅ = 已实现，📋 = 计划�
 | 会话统计行 | 持久化的会话用量：轮数、步数、LLM/工具时长、TTFT、tok/s、缓存命中、token | 卡底部一行小字，随 turn 刷新；详情在 `/status` | 📋 |
 | 上下文占用 | 当前会话的上下文窗口占用 | 卡底部百分比，随 turn 刷新；详情（used/capacity、分布）在 `/status` | 📋 |
 | session-rename-archive | Session rename/archive via dsh sessionTitle + workspaceRegistry (web-visible) | — | 📋 |
+| inbound-wait-instruction | 裸文件/图片消息登记为 pending——发回执卡并等用户指令后才开始工作 | 📎 File received 回执（计数 pending 文件）；补发文字把它们带进一个 turn | ✅ |

--- a/docs/ux-specification.md
+++ b/docs/ux-specification.md
@@ -707,27 +707,17 @@ arrive in a p2p chat or a group (mention gate applies exactly as for text).
 (`{kind:'image'|'file'; key: string; name?: string}`). Unknown types stay
 ignored. A mixed message is not a Feishu concept — each message is one type.
 
-**Image path (agent sees the image)** — the transport downloads the image
-bytes through the message-resource endpoint (`im.v1.messageResource.get` —
-`/messages/{message_id}/resources/{image_key}?type=image`; `im.v1.image.get`
-can only fetch bot-uploaded images, so user-sent images MUST use the
-message-resource API; needs the existing `im:resource` scope), then the
-bridge saves them through the host's attachment store (`ctx.attachments`
-— `dsh-attachment-local` is part of the dsh-base bundle, so the seam is
-REALLY mounted, unlike `apiProxy`) and injects
-`{type:'image', attachment}` as a content block of the agent's user message
-(the reference is `packages/host/apiproxy/src/api-proxy.ts` →
-`durablePromptContent`: `saveImages(bytes) → refs → {type:'image'}` blocks).
-The turn then runs normally; the model can describe/read the image.
-
-**Image capability gate** — the DeepSeek chat-completions adapter REJECTS
-image content (`UNSUPPORTED_CONTENT` → the whole turn ends in error), while
-pi-ai accepts it. The bridge therefore injects an `image` block ONLY when
-the chat's current model advertises `image` in its input modalities
-(`ctx.llm.listModels` → `inputModalities`, via the same model directory the
-`/model` picker reads). Unknown model capability → conservative: treat the
-image as a file (receipt + name note). A turn must never error because of
-an attachment.
+**Unified attachment path (every attachment is a file)** — a Feishu image
+is a plain file to the agent: it is downloaded through the message-resource
+endpoint (`im.v1.messageResource.get` — `/messages/{message_id}/resources/{image_key}?type=image`;
+`im.v1.image.get` can only fetch bot-uploaded images, so user-sent images
+MUST use the message-resource API; needs the existing `im:resource` scope),
+then saved into the same attachment bucket as files and read by path with
+the agent's workspace tools. There is NO image content block / visual-input
+path — a bare image message registers as pending like a bare file
+(inbound-wait-instruction part), and the agent reads the saved file. This
+mirrors the decision that the DSH web paste-image-into-inputbox capability
+has no meaningful Feishu equivalent.
 
 **File path (save to the workspace, agent reads by path)** — the agent
 cannot ingest arbitrary file bytes as a content block (the attachment
@@ -770,13 +760,13 @@ chat).
 the existing turn pipeline. The only new branch is inside
 `deliverTurn` (build the content blocks before `createUserMessage`):
 
-| Step | Image (model supports) | Image (not) / File |
-|---|---|---|
-| Download | message-resource (image) → bytes + mediaType | message-resource (file) → stream + head (sniff) |
-| Save | `ctx.attachments.saveImage` → ref | stream to `cwd/.dsh_feishu/attachments/<appId>/<chatId>/<name>.<ext>` (host seam, WeChat dedupe) |
-| Content | `[text, {type:'image', attachment}]` | `[text note with the saved path]` |
-| Card | none (streaming card already opens) | `📎 File received` receipt card |
-| Failure | card + text notice, turn still runs text-only | same |
+| Step | Attachment (image / file unified) |
+|---|---|
+| Download | image → message-resource (image) → bytes; file → message-resource (file) → stream + head (sniff) |
+| Save | unified stream/bytes to `cwd/.dsh_feishu/attachments/<appId>/<chatId>/<name>.<ext>` (host seam, WeChat dedupe) |
+| Content | `[text note with the saved path]` (no image content block) |
+| Card | `📎 File received` receipt card |
+| Failure | degraded receipt + loud log; turn / follow-up unaffected |
 
 **Card/panel shape** — no new panel views. The receipt card is a plain
 markdown card (like the approval/question notices), posted before
@@ -784,36 +774,165 @@ markdown card (like the approval/question notices), posted before
 
 **Failure modes**:
 - message-resource download fails (scope missing, key expired):
-  log loudly, post a `⚠️ Could not download` text notice, and run the turn
-  text-only — a broken attachment must never wedge the chat.
-- `ctx.attachments` absent (attachment-local not mounted): feature-detect
-  and degrade — images fall back to the file path (receipt + text note)
-  with a loud log, matching the "hide the row, don't fail" seam rule.
-- `saveImage` rejects bytes (unsupported format, over limits): loud log +
-  text notice; turn continues without the image block.
+  log loudly, post a degraded receipt (no path), and — for a bare attachment
+  message — nothing registers (the follow-up text still works normally); a
+  broken attachment never wedges the chat.
 - File save to the workspace fails (cwd unwritable, path collision): loud
-  log, receipt card still posted, turn continues with the name-only note.
-- Group message without mention: the existing mention gate drops it before
-  any download — no attachment handling for ignored messages.
-- Stale/unknown `image_key` at download time: same as download failure.
+  log, receipt card still posted, pending entry is name-only.
+- Group bare attachment without mention: bypasses the gate (registers
+  pending — see the inbound-wait-instruction part); group TEXT still gated.
+- Stale/unknown `image_key`/`file_key` at download time: same as download
+  failure.
 
 **Acceptance checklist**:
-- [ ] `image` message + image-capable model → agent's user message carries an
-      `image` content block (unit-tested via a fake image-capable llm)
-- [ ] `image` message + text-only model → degrades to a `📎 File received`
-      receipt + name note; turn completes (no UNSUPPORTED_CONTENT error)
-      (unit + integration tested)
-- [ ] `file` message → bytes saved under `cwd/.dsh_feishu/attachments/<appId>/<chatId>/`, receipt card
-      posted, agent's message carries the REAL saved path (unit + integration
-      tested)
+- [ ] `image` message → bytes saved under
+      `cwd/.dsh_feishu/attachments/<appId>/<chatId>/`, receipt card posted,
+      agent's message carries the REAL saved path (unit + integration tested)
+- [ ] `file` message → bytes saved under
+      `cwd/.dsh_feishu/attachments/<appId>/<chatId>/`, receipt card posted,
+      agent's message carries the REAL saved path (unit + integration tested)
 - [ ] A same-named file re-sent in the same chat saves as `name(1).ext`
       (WeChat-style dedupe, integration tested)
 - [ ] The saved file is readable by the agent's tools (integration test
       asserts the file exists on disk at the noted path)
-- [ ] Group messages still gated by the mention gate (no attachment handling
-      for ignored messages)
-- [ ] Download failure → loud notice, turn continues text-only (unit-tested)
-- [ ] `attachments` service absent → image degrades to the file path, loud log
+- [ ] No image content block is ever injected (a Feishu image is a plain
+      file to the agent) — regression
+- [ ] Download failure → degraded receipt, nothing registers, no wedge
       (unit-tested)
 - [ ] `im:resource` scope reused — manifest unchanged, feishu-setup.md
       description updated
+
+## Part: inbound-wait-instruction
+
+> Bare attachment messages (file OR image — every attachment is a plain
+> file to the agent) no longer start a turn by themselves: the bytes land in
+> the workspace, a receipt card posts, and the agent waits for the user's
+> follow-up instruction (text, or a mention in a group) before it does any
+> work. The follow-up message carries every pending attachment into the
+> SAME turn, in order.
+
+### Intended behavior
+
+**Trigger** — an inbound message whose `text` is empty AND that carries at
+least one attachment (a bare `file` or `image` message; `video` and
+rich-text `post` support land in the sibling inbound-rich-text feature and
+reuse this pending path). Such a message is *registered* (pending) instead
+of delivered: the attachment is downloaded and saved to the workspace
+exactly as today, a NEW receipt card posts (the previous ones are kept —
+each file gets its own card, traceable in chat history), and NO turn starts.
+
+The pending set is a per-chat list, not a single slot: consecutive bare
+attachment messages APPEND (`📎 已收到 N 个文件` on each new card), so the
+user can send several files and then one instruction to analyze them all.
+
+**How the follow-up works** — the NEXT inbound message in the same chat that
+carries text drains the pending list: the saved-path notes are injected into
+that turn's user content BEFORE the text, the list is cleared, and the turn
+runs normally. Only the first text message after pending files fires —
+later messages see an empty list. A new bare attachment message arriving
+while a turn is already running simply appends to the list (the running turn
+is unaffected).
+
+**Group mention gate** — attachment messages cannot carry a mention (Feishu
+sends a file/image without an input box, so `@bot` is physically
+impossible), so the mention gate would otherwise dead-lock group usage: an
+un-@ file would be dropped before it could ever become pending. Bare
+attachment messages therefore BYPASS the mention gate and always register
+(pending only — no work happens, so the gate's safety purpose is preserved:
+the agent still never does anything until a gated text instruction follows).
+The follow-up TEXT message still passes the normal gate (group text must
+@ the bot, or solo-group
+relaxation applies) — pending files are only drained by an instruction the
+gate would have accepted anyway. p2p chats are unaffected (no gate).
+
+**Feishu message model — one bubble, one message_type** — Feishu messages
+are single-type: `text`, `image`, `file`, `video`, or `post` (rich text).
+There is no "text + file in one bubble" — a user pasting text and attaching
+a file sends two separate messages (which this feature handles naturally:
+the file registers, the text drains). The `post` type is the one multi-
+element bubble: its content is a 2-D array of inline elements
+(`[[{tag:'text'},{tag:'img'},...],[...]]`) that CAN mix text and
+attachments (image / media-video / file) in ONE message with an ORDER
+that matters ("look at the picture, then read this" vs the reverse). post
+support is the sibling inbound-rich-text feature (PR-A); this part's pending
+path is what a text-less post's attachments will drain into.
+
+**States & transitions** — one authoritative per-chat object,
+`pendingInbound`:
+
+| From | Event | To | Side effects |
+|---|---|---|---|
+| — | bare attachment message (p2p / solo / any group) | pending list non-empty | download+save each attachment; NEW receipt card (`📎 已收到 N 个文件`); NO turn |
+| pending non-empty | text message, gate passed | pending drained, turn runs | inject saved paths in order before text; clear list; normal turn |
+| pending non-empty | another bare attachment message | pending grows | append; another NEW card (count N+1); still no turn |
+| pending non-empty | slash command | unchanged (command handles it; list stays) | command runs normally |
+| pending empty | text message | (no change) | normal turn, no injection |
+| — | message fails download/save | not registered | loud log + degraded receipt (existing behavior); never wedges |
+| — | working-directory gate refuses the follow-up text | pending stays | existing refusal notice; user re-sends instruction after /cd |
+
+The pending object is NOT persisted across restarts — a restart drops it
+(the files remain on disk; the user re-sends an instruction and, because
+the list is empty, the files are not re-attached — acceptable: the paths
+are visible in the kept receipt cards, and the agent can be pointed at
+them by path).
+
+**Concurrency** — the message channel delivers a burst without awaiting
+(`drainInbox` calls the handler back-to-back), so `registerPending` appends
+its placeholders to the chat's pending list SYNCHRONOUSLY before any await,
+and later mutates them in place. Two concurrent bare-attachment messages
+each see the other's entries — a read-then-set around an await would
+silently drop one of them.
+
+**Card/panel shape** — the existing `buildInboundFileCard` gains a count:
+the markdown body shows `📎 已收到 N 个文件` when more than one file is
+pending (count 1 for a single file), listing the just-added file + its
+path. The card still shows the saved path and the "send an instruction"
+hint. NO action buttons (a button was considered and rejected: it makes
+the interaction ambiguous — "do I type or tap?"; the single mental model
+is "type the instruction"). Each file posts its OWN card — the previous
+cards stay in chat history. No panel views.
+
+**Failure modes**:
+- Download/save fails for a bare attachment: existing loud-degrade path
+  (receipt posts with a notice, nothing registers, no turn) — a broken
+  attachment never wedges the chat.
+- Follow-up text refused by the working-directory gate: pending list is
+  kept (the user fixes /cd and re-sends); the refusal notice explains.
+- Group follow-up text not @-ing the bot: existing gate drops it, pending
+  stays — the user must @ the bot to trigger.
+- Mid-turn new bare attachment message: appends to pending; the running
+  turn is unaffected (no double delivery).
+- (PR-A, inbound-rich-text) post parse fails: falls back to a text-only
+  notice; `md` absent: element-array serialization is the fallback.
+
+**Acceptance checklist**:
+- [ ] Bare file message → file on disk, NEW receipt card, NO turn (mock LLM
+      receives nothing) — unit + integration
+- [ ] Bare image message → image on disk (sniffed extension), NEW receipt
+      card, NO turn — unit + integration
+- [ ] Two bare attachment messages → two files on disk, two cards
+      (count 1, 2), still no turn — integration
+- [ ] Follow-up text message → ONE turn whose user content carries BOTH
+      saved paths in order, then the list clears — integration
+- [ ] Follow-up in a group must @ the bot; un-@ text keeps the list —
+      integration
+- [ ] Bare attachment in a group WITHOUT @ registers (bypasses the gate) —
+      integration
+- [ ] Slash command while pending → command runs, list untouched — unit
+- [ ] Failed download → degraded receipt, nothing registers, no wedge — unit
+- [ ] No image content block is ever injected (a Feishu image is a plain
+      file to the agent) — regression
+
+### Reference
+
+- botmux has NO wait-for-instruction mechanism (files immediately trigger
+  processing) — this part is dsh-feishu's own UX, added because a file
+  message otherwise starts a turn before the user can say what to do with
+  it (user-reported F1.5 issue 1).
+- The mention-gate bypass mirrors the reality that Feishu file messages
+  cannot carry a mention (no input box) — the gate still protects the
+  actual work (gated text instruction required).
+- `im.v1.messageResource.get`: `type=file` covers files, audio, AND video —
+  the pending download path reuses the existing file seam for all of them.
+- post / video support is the sibling PR-A (inbound-rich-text), which drains
+  into this pending path.

--- a/docs/ux-specification.zh.md
+++ b/docs/ux-specification.zh.md
@@ -358,9 +358,7 @@ bridge 记住每个聊天的**最近被接受的发送者**（及其聊天类型
 
 `FeishuMessage` 增加可选 `attachments` 数组（`{kind:'image'|'file'; key: string; name?: string}`）。未知类型继续忽略。每条消息只有一种类型（飞书不支持混合消息）。
 
-**图片路径（agent 看到图片）** —— transport 通过**消息资源端点**下载图片字节（`im.v1.messageResource.get` —— `/messages/{message_id}/resources/{image_key}?type=image`；`im.v1.image.get` 只能下载机器人自己上传的图片，所以用户发的图片必须走 message-resource API；复用现有 `im:resource` scope），bridge 再通过宿主附件服务保存（`ctx.attachments` —— `dsh-attachment-local` 是 dsh-base bundle 的一部分，seam 真实装载，不同于 `apiProxy`），并注入 `{type:'image', attachment}` 内容块到 agent 的用户消息（参考 `packages/host/apiproxy/src/api-proxy.ts` → `durablePromptContent`：`saveImages(bytes) → refs → {type:'image'}` 块）。回合正常进行，模型可以描述/读取图片。
-
-**图片能力门禁** —— DeepSeek chat-completions 适配器**拒绝** image 内容（`UNSUPPORTED_CONTENT` → 整轮以错误结束），而 pi-ai 接受。因此 bridge **仅当**当前模型在输入模态中声明支持 `image` 时才注入 image 块（`ctx.llm.listModels` → `inputModalities`，与 `/model` 选择器读同一模型目录）。模型能力未知 → 保守处理：把图片当文件处理（回执 + 名称备注）。附件**绝不能**让回合报错。
+**统一附件路径（所有附件都是文件）** —— 飞书图片对 agent 就是普通文件：transport 通过**消息资源端点**下载图片字节（`im.v1.messageResource.get` —— `/messages/{message_id}/resources/{image_key}?type=image`；`im.v1.image.get` 只能下载机器人自己上传的图片，所以用户发的图片必须走 message-resource API；复用现有 `im:resource` scope），然后与文件一样保存进同一附件目录、由 agent 按路径读取。**没有 image 内容块 / 视觉输入路径**——裸图片消息像裸文件一样登记为 pending（见 inbound-wait-instruction part），agent 读取已保存的文件。这对应了"DSH Web 把图片粘贴进输入框"的能力在飞书场景没有意义这一决定。
 
 **文件路径（保存到工作区，agent 按路径读取）** —— agent 无法把任意文件字节作为内容块摄取（attachment 域仅限图片），但可以读取工作目录下的文件（其 bash/read 工具在 fs sandbox 下运行，`workspace-write` 允许写工作区根）。因此 bridge：
 1. **流式**下载文件体（`im.v1.messageResource.get` —— `/messages/{message_id}/resources/{file_key}?type=file`；`im.v1.file.get` 只能下载机器人自己上传的文件）。流式而非缓冲——资源 API 服务最大约 100 MB 的文件；先 peek 开头字节做扩展名嗅探再推回流，完整文件体经 `pipeline()` 直接写盘（botmux `downloadWithAppToken` 同款）；
@@ -376,13 +374,13 @@ bridge 记住每个聊天的**最近被接受的发送者**（及其聊天类型
 
 本特性**没有新状态机**：喂入现有 turn 管道。唯一新分支在 `deliverTurn`（构建内容块时）：
 
-| 步骤 | 图片（模型支持） | 图片（不支持）/ 文件 |
-|---|---|---|
-| 下载 | message-resource (image) → bytes + mediaType | message-resource (file) → stream + head（嗅探） |
-| 保存 | `ctx.attachments.saveImage` → ref | 流式写入 `cwd/.dsh_feishu/attachments/<appId>/<chatId>/<name>.<ext>`（宿主 seam，微信式去重） |
-| 内容 | `[text, {type:'image', attachment}]` | `[text 备注带真实路径]` |
-| 卡片 | 无（streaming 卡已开） | `📎 File received` 回执卡 |
-| 失败 | 卡片 + 文本提示，回合以纯文本继续 | 同上 |
+| 步骤 | 附件（image / file 统一） |
+|---|---|
+| 下载 | image → message-resource (image) → bytes；file → message-resource (file) → stream + head（嗅探） |
+| 保存 | 统一流式/字节写入 `cwd/.dsh_feishu/attachments/<appId>/<chatId>/<name>.<ext>`（宿主 seam，微信式去重） |
+| 内容 | `[text 备注带真实路径]`（无 image 内容块） |
+| 卡片 | `📎 File received` 回执卡 |
+| 失败 | 降级回执 + 响亮日志，回合/后续文字不受影响 |
 
 ### 卡片/面板形态
 
@@ -390,20 +388,87 @@ bridge 记住每个聊天的**最近被接受的发送者**（及其聊天类型
 
 ### 失败模式
 
-- message-resource 下载失败（scope 缺失、key 过期）：响亮日志 + `⚠️ Could not download` 文本提示，回合以纯文本继续——坏附件绝不卡死聊天。
-- `ctx.attachments` 缺失（attachment-local 未装载）：feature-detect 并降级——图片回退到文件路径（回执 + 文本备注）+ 响亮日志，符合 "hide the row, don't fail" seam 规则。
-- `saveImage` 拒绝字节（格式不支持、超限）：响亮日志 + 文本提示；回合继续、无 image 块。
-- 文件保存到工作区失败（cwd 不可写、路径冲突）：响亮日志，回执卡照发，回合以仅名称备注继续。
-- 群消息未 @：现有 mention gate 在下载前丢弃——被忽略的消息不做附件处理。
+- message-resource 下载失败（scope 缺失、key 过期）：响亮日志 + 降级回执（无路径）——裸附件消息不登记任何东西，后续文字仍正常工作；坏附件绝不卡死聊天。
+- 文件保存到工作区失败（cwd 不可写、路径冲突）：响亮日志，回执卡照发，pending 条目仅名称。
+- 群裸附件未 @：豁免 gate（登记 pending——见 inbound-wait-instruction part）；群**文字**仍受 gate 约束。
 - 下载时 key 过期/未知：同下载失败。
 
 ### 验收清单
 
-- [ ] `image` 消息 + 支持图片的模型 → agent 用户消息带 `image` 内容块（用假 image-capable llm 单测）
-- [ ] `image` 消息 + 纯文本模型 → 降级为 `📎 File received` 回执 + 名称备注；回合完成（无 UNSUPPORTED_CONTENT 错误）（单测 + 集成测试）
+- [ ] `image` 消息 → 图片保存到 `cwd/.dsh_feishu/attachments/<appId>/<chatId>/`，回执卡发布，agent 消息带**真实保存路径**（单测 + 集成测试）
 - [ ] `file` 消息 → 文件保存到 `cwd/.dsh_feishu/attachments/<appId>/<chatId>/`，回执卡发布，agent 消息带**真实保存路径**（单测 + 集成测试）
 - [ ] 同一 chat 重复发送同名文件 → 第二个存为 `name(1).ext`（微信式去重，集成测试）
 - [ ] 保存的文件可被 agent 工具读取（集成测试断言文件落在磁盘上、路径出现在 agent 回合中）
-- [ ] 群消息仍受 mention gate 约束（被忽略的消息不做附件处理）
-- [ ] 下载失败 → 响亮提示，回合以纯文本继续（单测）
-- [ ] `attachments` 服务缺失 → 图片降级到文件路径，响亮日志（单测）
+- [ ] 从不注入 image 内容块（飞书图片对 agent 是普通文件）——回归
+- [ ] 下载失败 → 降级回执，不登记任何东西，不卡死（单测）
+
+## Part: inbound-wait-instruction
+
+> 裸附件消息（文件或图片——所有附件对 agent 都是普通文件）不再自行触发
+> turn：字节落到工作区、回执卡发布、agent 等用户补指令（文字，或在群里
+> @）才开始工作。下一条文字消息把全部 pending 附件**按顺序**带进同一个
+> turn。
+
+### 预期行为
+
+**触发** —— `text` 为空且至少带一个附件的入站消息（裸 `file`/`image` 消息；
+`video` 与富文本 `post` 支持在兄弟特性 inbound-rich-text 中落地并复用本
+pending 路径）。此类消息**登记**（pending）而非投递：附件照常下载并保存到
+工作区，每份文件发一张**新**回执卡（旧卡保留——每份文件在聊天记录中可追溯），
+**不启动 turn**。
+
+pending 集是 per-chat 列表而非单槽：连续裸附件消息**追加**（每张新卡显示
+`📎 已收到 N 个文件`），用户可先发多份文件再发一条指令一起分析。
+
+**跟进机制** —— 同 chat 下一条带文字的消息排空 pending 列表：把每条
+saved-path 备注**按到达顺序**注入该 turn 的用户内容（在文字之前），清空列表，
+正常跑 turn。只有 pending 之后第一条文字消息会触发——后续消息看到空列表。
+turn 运行中到达的新裸附件消息只追加（不影响正在跑的 turn）。
+
+**群 mention gate** —— 附件消息无法带 @（飞书发文件/图片没有输入框，
+`@bot` 物理上不可能），否则 gate 会让群文件永远进不了 pending。因此裸附件
+消息**绕过** mention gate 直接登记（仅 pending、不干活——gate 的安全目的仍
+保留：agent 在收到一条通过 gate 的文字指令前不会做任何事）。跟进**文字**消息
+仍走正常 gate（群文字必须 @ bot，或 solo 群豁免）。p2p 无 gate。
+
+**并发** —— 消息通道批量投递不 await（`drainInbox` 逐个调用 handler），所以
+`registerPending` 在任何 await 之前**同步**把占位条目追加进该 chat 的 pending
+列表，之后原地更新。两条并发裸附件消息彼此都能看到对方的条目——围绕 await
+的"先读后写"会静默丢文件。
+
+**卡片/面板形态** —— `buildInboundFileCard` 增加计数：多于一份文件时 markdown
+正文显示 `📎 已收到 N 个文件`（单份为 1），列出刚到的文件 + 路径。卡片仍显示
+保存路径和"发送指令"提示。**无操作按钮**（曾考虑过「▶ 开始处理」按钮并否决：
+它让交互变得含糊——"该打字还是点按钮？"；唯一心智模型是"发文字指令"）。
+每份文件发自己的卡——旧卡留在聊天记录。无面板视图。
+
+**失败模式**：
+- 裸附件下载/保存失败：现有响亮降级路径（回执带提示、不登记、不触发 turn）——
+  坏附件绝不卡死聊天。
+- 跟进文字被 working-directory gate 拒绝：pending 保留（用户修好 /cd 重发）。
+- 群跟进文字未 @ bot：现有 gate 丢弃，pending 保留——用户必须 @ 触发。
+- turn 运行中新裸附件消息：追加 pending；运行中的 turn 不受影响（不会重复投递）。
+- （PR-A inbound-rich-text）post 解析失败：回退纯文本提示；`md` 缺失时用元素
+  数组序列化兜底。
+
+**验收清单**：
+- [ ] 裸文件消息 → 文件落盘、新回执卡、无 turn（mock LLM 未收到任何请求）——单测 + 集成
+- [ ] 裸图片消息 → 图片落盘（嗅探扩展名）、新回执卡、无 turn——单测 + 集成
+- [ ] 两条裸附件消息 → 两份文件落盘、两张卡（计数 1、2）、仍无 turn——集成
+- [ ] 跟进文字消息 → 一个 turn 的用户内容按顺序带**两条** saved-path，然后列表清空——集成
+- [ ] 群里跟进必须 @ bot；未 @ 文字保留列表——集成
+- [ ] 群裸附件未 @ 也登记（绕过 gate）——集成
+- [ ] pending 期间发斜杠命令 → 命令正常运行、列表不动——单测
+- [ ] 下载失败 → 降级回执、不登记、不卡死——单测
+- [ ] 从不注入 image 内容块（飞书图片对 agent 是普通文件）——回归
+
+### Reference
+
+- botmux 没有 wait-for-instruction 机制（文件立即触发处理）——本 part 是
+  dsh-feishu 自己的 UX，因文件消息会在用户说出用途前就启动 turn 而新增
+  （用户实测 F1.5 问题 1）。
+- mention-gate 绕过对应现实：飞书附件消息无法带 @（无输入框）——gate 仍保护
+  实际工作（必须通过 gate 的文字指令）。
+- `im.v1.messageResource.get`：`type=file` 覆盖文件、音频和视频——pending
+  下载路径对它们全部复用现有 file seam。
+- post / video 支持是兄弟 PR（inbound-rich-text），它们排空进本 pending 路径。

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -14,6 +14,7 @@
  * @module @dsh-feishu/dsh-feishu/bridge
  */
 
+import { Readable } from 'node:stream';
 import type { Agent } from '@deepseek-ai/dsh-agent';
 import { type ContentBlock, createUserMessage } from '@deepseek-ai/dsh-llm';
 import type { SessionEvent } from '@deepseek-ai/dsh-session';
@@ -56,6 +57,17 @@ import { buildSessionExport, type SessionExportEvent } from './session-export.js
 import type { SessionMap } from './session-map.js';
 
 export type { PanelInputCommand, PanelView } from './panel/types.js';
+
+/** One pending inbound attachment (inbound-wait-instruction): saved to the
+ *  workspace, awaiting the user's follow-up instruction. */
+export interface PendingInboundFile {
+  /** The attachment that was saved. */
+  attachment: InboundAttachment;
+  /** The display name (user file name or key). */
+  name: string;
+  /** The real on-disk path, or `undefined` when the save failed. */
+  savedPath: string | undefined;
+}
 
 import type { PanelView } from './panel/types.js';
 
@@ -226,21 +238,6 @@ export interface AskQuestionsAnswerLike {
   }[];
 }
 
-/**
- * Structural subset of the dsh `ImageAttachmentRef` (the value `saveImage`
- * resolves with): the agent's `image` content block carries it, so the
- * surface must pass it through verbatim. Type-only — no runtime dependency
- * on `@deepseek-ai/dsh-attachment`.
- */
-export interface ImageAttachmentRefLike {
-  readonly attachmentId: string;
-  readonly mediaType: string;
-  readonly bytes: number;
-  readonly width: number;
-  readonly height: number;
-  readonly name?: string;
-}
-
 /** Options for {@link Bridge}. */
 export interface BridgeOptions {
   readonly transport: FeishuTransport;
@@ -325,20 +322,6 @@ export interface BridgeOptions {
         archiveSession(sessionId: string): Promise<unknown>;
         readonly archivedSessionIds: readonly string[];
       }
-    | undefined;
-  /**
-   * Inbound-image seam (`ctx.attachments`, mounted by dsh-base's
-   * `dsh-attachment-local`): validate + durably commit one image so the
-   * agent's user message can carry an `image` content block. Resolved lazily
-   * (async-init service). Absent, inbound images degrade to the file path
-   * (receipt + name note) with a loud log — never a dropped message.
-   */
-  readonly getSaveImage?: () =>
-    | ((input: {
-        data: Uint8Array;
-        mediaType: string;
-        name?: string;
-      }) => Promise<ImageAttachmentRefLike>)
     | undefined;
   /**
    * Inbound-file seam: persist one downloaded file under the chat's working
@@ -469,6 +452,13 @@ export class Bridge {
   private readonly requesterOpenIds = new Map<string, string>();
   /** Chat type of the last accepted message per chat (`p2p` needs no @). */
   private readonly chatTypes = new Map<string, 'p2p' | 'group'>();
+  /**
+   * Pending inbound attachments per chat (inbound-wait-instruction): bare
+   * attachment messages (file/image/video — no text) register here instead
+   * of starting a turn. The next text message in the chat drains the list
+   * into its turn, in order. Not persisted across restarts.
+   */
+  private readonly pendingInbound = new Map<string, PendingInboundFile[]>();
 
   /**
    * The user to proactively @ for a chat: the last accepted sender, only in
@@ -676,6 +666,21 @@ export class Bridge {
         `message ${message.messageId} -> slash command /${slash.name} (chat ${message.chatId})`,
       );
       await this.handleCommand(message, slash);
+      return;
+    }
+    // Inbound-wait-instruction: a bare attachment message (no text) is
+    // registered as pending — every attachment (file OR image, both treated
+    // as plain files) lands on disk and a receipt card posts, but NO turn
+    // starts. The user's follow-up text message drains the pending list into
+    // its turn (the agent then works on the files). Attachment messages
+    // cannot carry a mention (Feishu sends them without an input box), so
+    // this is also where the mention gate is bypassed for groups — handled
+    // in shouldRespond.
+    if (text === '' && (message.attachments?.length ?? 0) > 0) {
+      this.options.logger.debug(
+        `message ${message.messageId} -> pending attachment (chat ${message.chatId})`,
+      );
+      await this.registerPending(message);
       return;
     }
     this.options.logger.debug(`message ${message.messageId} -> turn (chat ${message.chatId})`);
@@ -1167,31 +1172,6 @@ export class Bridge {
   }
 
   /**
-   * Whether the chat's current model can SEE images (advertises `image` in
-   * its input modalities). The DeepSeek adapter rejects image content
-   * (`UNSUPPORTED_CONTENT` ends the whole turn in error), so image blocks
-   * are only injected when this is true; unknown → false (conservative: the
-   * image degrades to a file receipt instead of breaking the turn).
-   * @param chatId - the chat whose model to probe.
-   * @returns true when the model advertises image input, false otherwise.
-   */
-  private async supportsImageInput(chatId: string): Promise<boolean> {
-    const selection = this.currentModelSelection(chatId);
-    const llm = this.options.llm;
-    if (selection === undefined || llm === undefined) return false;
-    const [provider, modelId] = selection.split('/');
-    if (provider === undefined || modelId === undefined) return false;
-    try {
-      const models = await llm.listModels(provider);
-      const model = models.find((m) => m.id === modelId);
-      return model?.inputModalities?.includes('image') ?? false;
-    } catch (error: unknown) {
-      this.options.logger.warn(`image-capability probe for ${selection} failed: ${String(error)}`);
-      return false;
-    }
-  }
-
-  /**
    * Load the model catalog for the /model picker: every registered provider
    * × its advisory model list (a failing provider catalog is skipped, loud
    * in the log). `undefined` when the llm service is absent.
@@ -1288,6 +1268,10 @@ export class Bridge {
     // turn starts — a broken attachment notices loudly but never wedges the
     // chat (the turn continues, text-only when the attachment failed).
     const content = await this.inboundContent(message);
+    // Inbound-wait-instruction: prepend any pending attachments (bare file
+    // messages that arrived earlier) so this text message's turn works on
+    // them too, in arrival order.
+    this.drainPending(message.chatId, content);
     // Two-stage ack stage 1 + the working card state + the card open (the
     // streaming controller's beginTurn; a failed reaction or card post must
     // never block the turn).
@@ -1319,68 +1303,15 @@ export class Bridge {
     if (message.text !== '') blocks.push({ type: 'text', text: message.text });
     // `attachments` is always present on normalized messages; the guard
     // covers transport-level JSON without the field (defensive only).
+    // Every attachment (image or file) is saved as a plain file under the
+    // chat's attachment bucket — a Feishu image is just a file to the agent
+    // (it reads it with its workspace tools; there is no image content block
+    // / visual-input path, per the unified-attachment decision).
     for (const attachment of message.attachments ?? []) {
-      if (attachment.kind === 'image') {
-        const block = await this.inboundImage(message, attachment, blocks);
-        if (block !== undefined) blocks.push(block);
-      } else {
-        await this.inboundFile(message, attachment, blocks);
-      }
+      await this.inboundFile(message, attachment, blocks);
     }
     if (blocks.length === 0) blocks.push({ type: 'text', text: message.text });
     return blocks;
-  }
-
-  /** Download + commit one inbound image; returns an `image` content block,
-   *  or `undefined` (with a loud notice) when the download/save fails. The
-   *  image is only injected when the chat's model supports image input — a
-   *  model that cannot see images (e.g. DeepSeek) would otherwise end the
-   *  whole turn in error (`UNSUPPORTED_CONTENT`). On degrade (service absent
-   *  or model not image-capable) the file path appends its note to `blocks`
-   *  — the message is never left content-less. */
-  private async inboundImage(
-    message: FeishuMessage,
-    attachment: InboundAttachment,
-    blocks: ContentBlock[],
-  ): Promise<ContentBlock | undefined> {
-    const saveImage = this.options.getSaveImage?.();
-    const imageCapable = await this.supportsImageInput(message.chatId);
-    if (saveImage === undefined || !imageCapable) {
-      // Attachment service not mounted, or the model cannot see images:
-      // degrade to the file path (receipt + name note) instead of dropping
-      // the message or erroring the turn (seam rule).
-      this.options.logger.warn(
-        `inbound image ${attachment.key}: ${saveImage === undefined ? 'attachment service absent' : `model does not support image input (${this.currentModelSelection(message.chatId) ?? 'unknown'})`}, treating as a file notice`,
-      );
-      await this.inboundFile(message, attachment, blocks);
-      return undefined;
-    }
-    try {
-      const downloaded = await this.options.transport.downloadImage(
-        message.messageId,
-        attachment.key,
-      );
-      const saved = await saveImage({
-        data: downloaded.data,
-        mediaType: downloaded.mediaType,
-      });
-      this.options.logger.debug(
-        `inbound image ${attachment.key} -> attachment ${saved.attachmentId} (${downloaded.data.length} bytes)`,
-      );
-      // The image block's `attachment` field is branded (`AttachmentId`) in
-      // the dsh types; the surface passes the saved ref through verbatim —
-      // the agent loop consumes it structurally.
-      return { type: 'image', attachment: saved } as ContentBlock;
-    } catch (error: unknown) {
-      this.options.logger.warn(
-        `inbound image ${attachment.key} could not be processed: ${String(error)}`,
-      );
-      await this.options.transport.sendText(
-        message.chatId,
-        '⚠️ An image you sent could not be read — sending as text only.',
-      );
-      return undefined;
-    }
   }
 
   /** Download + persist one inbound file under the chat's working directory,
@@ -1392,14 +1323,71 @@ export class Bridge {
     attachment: InboundAttachment,
     blocks: ContentBlock[],
   ): Promise<void> {
+    const pending = await this.saveInboundFileAttachment(message, attachment);
+    try {
+      await this.options.transport.sendCard(
+        message.chatId,
+        buildInboundFileCard(pending.name, pending.savedPath, 1),
+      );
+    } catch (error: unknown) {
+      this.options.logger.warn(`file receipt card failed: ${String(error)}`);
+    }
+    blocks.push({
+      type: 'text',
+      text:
+        pending.savedPath === undefined
+          ? `[user sent a file: ${pending.name}]`
+          : `[user sent a file: ${pending.name} — saved at ${pending.savedPath}. You can read it with your file tools.]`,
+    });
+  }
+
+  /**
+   * Download one inbound attachment and persist it under the chat's working
+   * directory. Files stream through the message-resource API; images are
+   * downloaded as bytes and re-wrapped as a stream, so BOTH land in the same
+   * attachment bucket as plain files (a Feishu image is just a file to the
+   * agent — it reads it with its workspace tools; there is no image content
+   * block / visual input path). Failures notice loudly and return an entry
+   * with no path (the message is never silently dropped, and a broken
+   * attachment never wedges the chat).
+   * @param message - the owning message.
+   * @param attachment - the attachment to download.
+   * @returns the pending entry (name + real path when the save succeeded).
+   */
+  private async saveInboundFileAttachment(
+    message: FeishuMessage,
+    attachment: InboundAttachment,
+  ): Promise<PendingInboundFile> {
     const name = attachment.name ?? attachment.key;
     let savedPath: string | undefined;
     try {
-      const { stream, head } = await this.options.transport.downloadFile(
-        message.messageId,
-        attachment.key,
-      );
-      this.options.logger.debug(`inbound file ${attachment.key}: downloaded (${message.chatId})`);
+      let stream: NodeJS.ReadableStream;
+      let head: Uint8Array;
+      if (attachment.kind === 'image') {
+        const downloaded = await this.options.transport.downloadImage(
+          message.messageId,
+          attachment.key,
+        );
+        const bytes = Buffer.from(downloaded.data);
+        head = new Uint8Array(bytes.subarray(0, 16));
+        // Re-push the head so the save seam's pipeline sees the full body.
+        const body = new Readable({ read() {} });
+        body.push(head);
+        body.push(bytes.subarray(head.length));
+        body.push(null);
+        stream = body;
+        this.options.logger.debug(
+          `inbound image ${attachment.key}: downloaded (${downloaded.data.length} bytes, ${message.chatId})`,
+        );
+      } else {
+        const downloaded = await this.options.transport.downloadFile(
+          message.messageId,
+          attachment.key,
+        );
+        stream = downloaded.stream;
+        head = downloaded.head;
+        this.options.logger.debug(`inbound file ${attachment.key}: downloaded (${message.chatId})`);
+      }
       const save = this.options.saveInboundFile;
       if (save !== undefined) {
         const extension = sniffExtension(head);
@@ -1422,18 +1410,78 @@ export class Bridge {
     } catch (error: unknown) {
       this.options.logger.warn(`inbound file ${attachment.key} download failed: ${String(error)}`);
     }
-    try {
-      await this.options.transport.sendCard(message.chatId, buildInboundFileCard(name, savedPath));
-    } catch (error: unknown) {
-      this.options.logger.warn(`file receipt card failed: ${String(error)}`);
+    return { attachment, name, savedPath };
+  }
+
+  /**
+   * Inbound-wait-instruction: register a bare attachment message (no text)
+   * as pending. Each attachment is downloaded and saved to the workspace; a
+   * NEW receipt card posts for each (the previous cards are kept — each file
+   * is traceable in chat history), showing the running count. NO turn starts;
+   * the user's follow-up text message drains the pending list into its turn.
+   * @param message - the bare attachment message.
+   */
+  private async registerPending(message: FeishuMessage): Promise<void> {
+    // Append this message's attachments to the chat's pending list
+    // SYNCHRONOUSLY, before any await: the message channel delivers a burst
+    // without awaiting (drainInbox calls the handler back-to-back), so two
+    // concurrent bare-file messages must each see the other's entries — a
+    // read-then-set around an await would silently drop one of them.
+    const pending = this.pendingInbound.get(message.chatId) ?? [];
+    const placeholders: PendingInboundFile[] = (message.attachments ?? []).map((attachment) => ({
+      attachment,
+      name: attachment.name ?? attachment.key,
+      savedPath: undefined,
+    }));
+    pending.push(...placeholders);
+    this.pendingInbound.set(message.chatId, pending);
+    for (let i = 0; i < placeholders.length; i += 1) {
+      const placeholder = placeholders[i];
+      if (placeholder === undefined) continue;
+      const saved = await this.saveInboundFileAttachment(message, placeholder.attachment);
+      // Mutate the already-registered entry in place (its position in the
+      // list is fixed; a re-set here would race concurrent appends).
+      placeholder.name = saved.name;
+      placeholder.savedPath = saved.savedPath;
+      const count = pending.length;
+      this.options.logger.debug(
+        `inbound pending ${placeholder.attachment.kind} ${placeholder.attachment.key}: ${saved.savedPath ?? 'no path'} (${count} pending, chat ${message.chatId})`,
+      );
+      try {
+        await this.options.transport.sendCard(
+          message.chatId,
+          buildInboundFileCard(saved.name, saved.savedPath, count),
+        );
+      } catch (error: unknown) {
+        this.options.logger.warn(`pending receipt card failed: ${String(error)}`);
+      }
     }
-    blocks.push({
+  }
+
+  /**
+   * Inbound-wait-instruction: drain the chat's pending attachments into the
+   * current turn — the saved-path notes are injected BEFORE the message's own
+   * content, in arrival order, and the list is cleared. Called by
+   * `deliverTurn` for every text message; no-op when nothing is pending.
+   * @param chatId - the chat.
+   * @param blocks - the content blocks being built for the turn; pending
+   *   notes are prepended in place.
+   */
+  private drainPending(chatId: string, blocks: ContentBlock[]): void {
+    const pending = this.pendingInbound.get(chatId);
+    if (pending === undefined || pending.length === 0) return;
+    this.pendingInbound.delete(chatId);
+    const notes: ContentBlock[] = pending.map((file) => ({
       type: 'text',
       text:
-        savedPath === undefined
-          ? `[user sent a file: ${name}]`
-          : `[user sent a file: ${name} — saved at ${savedPath}. You can read it with your file tools.]`,
-    });
+        file.savedPath === undefined
+          ? `[user sent a file: ${file.name}]`
+          : `[user sent a file: ${file.name} — saved at ${file.savedPath}. You can read it with your file tools.]`,
+    }));
+    this.options.logger.debug(
+      `inbound pending drained: ${pending.length} file(s) into turn (chat ${chatId})`,
+    );
+    blocks.unshift(...notes);
   }
 
   /**
@@ -1459,6 +1507,18 @@ export class Bridge {
     if (message.chatType === 'p2p') {
       this.options.logger.debug(
         `message ${message.messageId}: p2p chat -> respond (no mention gate)`,
+      );
+      return true;
+    }
+    // Inbound-wait-instruction: a bare attachment message (no text) bypasses
+    // the group mention gate. Feishu sends attachments without an input box,
+    // so an @ is physically impossible — gating it would dead-lock group file
+    // usage. Registration is pending-only (no work happens), and the follow-up
+    // TEXT instruction still passes the gate below, so the gate's safety
+    // purpose (the agent never acts without an accepted instruction) holds.
+    if (message.text === '' && (message.attachments?.length ?? 0) > 0) {
+      this.options.logger.debug(
+        `message ${message.messageId}: bare attachment -> register (mention gate bypassed)`,
       );
       return true;
     }

--- a/src/cards/render.ts
+++ b/src/cards/render.ts
@@ -905,13 +905,22 @@ export function buildPanelNoticeCard(options: {
 }
 
 /**
- * The inbound-file receipt card: posted when a user sends a file message.
- * The file bytes are saved under the chat's working directory
+ * The inbound-file receipt card: posted when a user sends a file message
+ * (or a bare attachment message registered as pending — inbound-wait-
+ * instruction). The file bytes are saved under the chat's working directory
  * (`<cwd>/.dsh_feishu/attachments/…`) and the card shows the path so the
  * user knows where it landed; the agent receives the path too and reads the
- * file with its workspace tools.
+ * file with its workspace tools. Each file posts its OWN card — the running
+ * `count` (1, 2, …) tells the user how many files are awaiting an
+ * instruction; the previous cards stay in chat history. NO action buttons:
+ * the single interaction model is "send an instruction".
+ * @param name - the file display name.
+ * @param savedPath - the real on-disk path, when the save succeeded.
+ * @param count - the number of files pending an instruction (1 for a single
+ *   file message; N for the N-th bare attachment awaiting follow-up).
  */
-export function buildInboundFileCard(name: string, savedPath?: string): CardJson {
+export function buildInboundFileCard(name: string, savedPath?: string, count = 1): CardJson {
+  const pendingLine = count > 1 ? `\n\n**${count} files awaiting your instruction.**` : '';
   return {
     config: { wide_screen_mode: true },
     header: { title: { tag: 'plain_text', content: '📎 File received' }, template: 'blue' },
@@ -920,8 +929,8 @@ export function buildInboundFileCard(name: string, savedPath?: string): CardJson
         tag: 'markdown',
         content:
           savedPath === undefined
-            ? `**${name}**\n\nTell me what to do with it.`
-            : `**${name}**\n\nSaved to \`${savedPath}\` — tell me what to do with it.`,
+            ? `**${name}**\n\nTell me what to do with it.${pendingLine}`
+            : `**${name}**\n\nSaved to \`${savedPath}\` — tell me what to do with it.${pendingLine}`,
       },
     ],
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -515,26 +515,6 @@ export function apply(ctx: Context, config: Config, deps: ApplyDeps = {}): void 
       const registry = ctx.get('workspaceRegistry');
       return registry === undefined ? undefined : (registry as WorkspaceRegistryLike);
     },
-    // Inbound-image seam: ctx.attachments (dsh-attachment-local, mounted by
-    // dsh-base) validates + durably commits one image. Resolved lazily —
-    // the service initializes asynchronously. Absent, images degrade to the
-    // file path (loud log) instead of dropping the message.
-    getSaveImage: () => {
-      const attachments = ctx.get('attachments') as
-        | {
-            saveImage(input: { data: Uint8Array; mediaType: string; name?: string }): Promise<{
-              attachmentId: string;
-              mediaType: string;
-              bytes: number;
-              width: number;
-              height: number;
-              name?: string;
-            }>;
-          }
-        | undefined;
-      if (attachments === undefined) return undefined;
-      return (input) => attachments.saveImage(input);
-    },
     // Inbound-file seam: persist one downloaded file under the chat's
     // working directory at `.dsh_feishu/attachments/<appId>/<chatId>/<name>.<ext>`
     // (hidden subdirectory; bucketed per app + chat so the WeChat-style

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -477,7 +477,7 @@ export class LarkTransport implements FeishuTransport {
     this.logger?.debug(`transport downloadImage ${key} (message ${messageId})`);
     const bytes = await this.downloadMessageResource(messageId, key);
     // The resource endpoint does not echo the media type; default to png —
-    // saveImage re-detects the real format from the bytes.
+    // the caller sniffs the real extension from the leading bytes.
     return { data: bytes, mediaType: 'image/png' };
   }
 

--- a/tests/bridge.spec.ts
+++ b/tests/bridge.spec.ts
@@ -242,7 +242,6 @@ function makeHarness(
     readSession?: NonNullable<BridgeOptions['readSession']>;
     sessionTitle?: NonNullable<BridgeOptions['sessionTitle']>;
     getWorkspaceRegistry?: NonNullable<BridgeOptions['getWorkspaceRegistry']>;
-    getSaveImage?: NonNullable<BridgeOptions['getSaveImage']>;
     saveInboundFile?: NonNullable<BridgeOptions['saveInboundFile']>;
   } = {},
 ): Harness {
@@ -294,7 +293,6 @@ function makeHarness(
     ...(options.getWorkspaceRegistry !== undefined
       ? { getWorkspaceRegistry: options.getWorkspaceRegistry }
       : {}),
-    ...(options.getSaveImage !== undefined ? { getSaveImage: options.getSaveImage } : {}),
     ...(options.saveInboundFile !== undefined ? { saveInboundFile: options.saveInboundFile } : {}),
     // Tests default the working-directory gate OFF (production defaults it
     // ON); the gate's own tests enable it explicitly.
@@ -410,35 +408,19 @@ describe('Bridge', () => {
   describe('inbound attachments', () => {
     const pngBytes = new Uint8Array([137, 80, 78, 71]);
 
-    /** An llm catalog where the current model advertises image input. */
-    const imageCapableLlm = (): LlmService => ({
-      listProviders: () => [{ id: 'pi-ai', name: 'pi-ai' }],
-      async listModels(provider: string) {
-        return [
-          { provider, id: 'pi-1.5-vision', name: 'pi vision', inputModalities: ['text', 'image'] },
-        ];
-      },
-    });
-    /** Point the default model at the image-capable entry. */
-    const imageCapableDefault = (): NonNullable<BridgeOptions['agentDefaultModel']> => ({
-      currentSelection: () => ({ provider: 'pi-ai', model: 'pi-1.5-vision' }),
-      saveSelection: async () => {},
-    });
-
-    it('injects an image message as an image content block', async () => {
-      const saved: unknown[] = [];
+    it('registers a bare image message as pending: saved as a file, receipt card, no image block, no turn until a follow-up', async () => {
       const h = makeHarness({
-        llm: imageCapableLlm(),
-        agentDefaultModel: imageCapableDefault(),
-        getSaveImage: () => (input: { data: Uint8Array; mediaType: string }) => {
-          saved.push(input);
-          return Promise.resolve({
-            attachmentId: 'att-1',
-            mediaType: input.mediaType,
-            bytes: input.data.length,
-            width: 1,
-            height: 1,
-          });
+        saveInboundFile: async ({ attachment, stream, extension }) => {
+          // Images land in the same attachment bucket as files; the sniffed
+          // extension comes from the PNG magic bytes (png).
+          expect(attachment.kind).toBe('image');
+          expect(extension).toBe('png');
+          const chunks: Uint8Array[] = [];
+          for await (const chunk of stream as unknown as AsyncIterable<Uint8Array>) {
+            chunks.push(chunk);
+          }
+          expect(chunks.reduce((n, c) => n + c.length, 0)).toBe(pngBytes.length);
+          return { path: '/work/.dsh_feishu/attachments/img-1.png' };
         },
       });
       h.transport.downloadImageImpl = async () => ({ data: pngBytes, mediaType: 'image/png' });
@@ -448,15 +430,37 @@ describe('Bridge', () => {
           attachments: [{ kind: 'image', key: 'img-1' }],
         }),
       );
-      const followups = h.agentStore.followups.get('feishu-session-1');
-      expect(saved).toEqual([{ data: pngBytes, mediaType: 'image/png' }]);
-      const blocks = followups?.[0]?.content as unknown[];
-      expect(blocks?.[0]).toMatchObject({ type: 'image' });
-      // No receipt card for images.
+      // Pending: receipt card posts, NO turn, NO image block injected.
       expect(h.transport.sentCards).toHaveLength(1);
+      expect(h.transport.sentCards[0]?.header?.title.content).toBe('📎 File received');
+      expect(h.agentStore.followups.get('feishu-session-1')).toBeUndefined();
+      // The follow-up text drains the image as a FILE note (no image block —
+      // Feishu images are plain files to the agent).
+      await h.bridge.handleMessage(message({ messageId: 'om_msg2', text: 'look at this' }));
+      const followups = h.agentStore.followups.get('feishu-session-1');
+      const blocks = followups?.[0]?.content as unknown[];
+      expect(JSON.stringify(blocks)).toContain('/work/.dsh_feishu/attachments/img-1.png');
+      expect(JSON.stringify(blocks)).not.toContain('"type":"image"');
     });
 
-    it('posts a file receipt card and names the saved path to the agent', async () => {
+    it('a failed image download registers nothing and never wedges the chat', async () => {
+      const h = makeHarness(); // downloadImageImpl left unset → throws
+      await h.bridge.handleMessage(
+        message({
+          text: '',
+          attachments: [{ kind: 'image', key: 'missing' }],
+        }),
+      );
+      // The degraded receipt card posts (no path), nothing registers, no turn.
+      expect(h.transport.sentCards).toHaveLength(1);
+      expect(h.transport.sentCards[0]?.header?.title.content).toBe('📎 File received');
+      expect(h.agentStore.followups.get('feishu-session-1')).toBeUndefined();
+      // A follow-up text message still works normally.
+      await h.bridge.handleMessage(message({ messageId: 'om_msg2', text: 'hi' }));
+      expect(h.agentStore.followups.get('feishu-session-1')).toHaveLength(1);
+    });
+
+    it('registers a bare file message as pending: receipt card, no turn until a follow-up instruction', async () => {
       const h = makeHarness({
         saveInboundFile: async ({ stream, extension }) => {
           // The stream carries the full body (head re-pushed); the sniffed
@@ -483,10 +487,13 @@ describe('Bridge', () => {
           attachments: [{ kind: 'file', key: 'file-1', name: 'notes.txt' }],
         }),
       );
-      // Receipt card + streaming card; receipt shows the saved path.
-      expect(h.transport.sentCards).toHaveLength(2);
+      // Pending: the receipt card posts but NO turn starts (no followup).
+      expect(h.transport.sentCards).toHaveLength(1);
       expect(h.transport.sentCards[0]?.header?.title.content).toBe('📎 File received');
       expect(JSON.stringify(h.transport.sentCards[0]?.elements)).toContain('.dsh_feishu');
+      expect(h.agentStore.followups.get('feishu-session-1')).toBeUndefined();
+      // The follow-up text drains the pending file into its turn.
+      await h.bridge.handleMessage(message({ messageId: 'om_msg2', text: 'read this file' }));
       const followups = h.agentStore.followups.get('feishu-session-1');
       const blocks = followups?.[0]?.content as unknown[];
       expect(blocks?.[0]).toEqual({
@@ -495,7 +502,7 @@ describe('Bridge', () => {
       });
     });
 
-    it('falls back to a name-only note when the save seam is absent', async () => {
+    it('falls back to a name-only pending entry when the save seam is absent, then drains it', async () => {
       const h = makeHarness(); // no saveInboundFile
       h.transport.downloadFileImpl = async () => new Uint8Array([1, 2, 3]);
       await h.bridge.handleMessage(
@@ -504,41 +511,87 @@ describe('Bridge', () => {
           attachments: [{ kind: 'file', key: 'file-1', name: 'notes.txt' }],
         }),
       );
+      expect(h.agentStore.followups.get('feishu-session-1')).toBeUndefined();
+      await h.bridge.handleMessage(message({ messageId: 'om_msg2', text: 'what is this' }));
       const followups = h.agentStore.followups.get('feishu-session-1');
       const blocks = followups?.[0]?.content as unknown[];
       expect(blocks?.[0]).toEqual({ type: 'text', text: '[user sent a file: notes.txt]' });
     });
 
-    it('a failed image download notices loudly and the turn continues text-only', async () => {
+    it('two bare file messages pending together drain into one follow-up turn, in order', async () => {
+      const paths = ['/work/.dsh_feishu/attachments/a.txt', '/work/.dsh_feishu/attachments/b.txt'];
       const h = makeHarness({
-        llm: imageCapableLlm(),
-        agentDefaultModel: imageCapableDefault(),
-        getSaveImage: () => (input: { data: Uint8Array; mediaType: string }) =>
+        saveInboundFile: async ({ attachment }) =>
           Promise.resolve({
-            attachmentId: 'att-1',
-            mediaType: input.mediaType,
-            bytes: input.data.length,
-            width: 1,
-            height: 1,
+            path: attachment.key === 'a' ? (paths[0] ?? '') : (paths[1] ?? ''),
           }),
       });
-      // downloadImageImpl left unset → throws.
+      h.transport.downloadFileImpl = async () => new Uint8Array([1, 2, 3]);
+      await h.bridge.handleMessage(
+        message({
+          messageId: 'om_file1',
+          text: '',
+          attachments: [{ kind: 'file', key: 'a', name: 'a.txt' }],
+        }),
+      );
+      await h.bridge.handleMessage(
+        message({
+          messageId: 'om_file2',
+          text: '',
+          attachments: [{ kind: 'file', key: 'b', name: 'b.txt' }],
+        }),
+      );
+      // Two receipt cards (each file its own card), no turn yet.
+      expect(h.transport.sentCards).toHaveLength(2);
+      expect(h.agentStore.followups.get('feishu-session-1')).toBeUndefined();
+      await h.bridge.handleMessage(message({ messageId: 'om_msg2', text: 'analyze both' }));
+      const followups = h.agentStore.followups.get('feishu-session-1');
+      const blocks = followups?.[0]?.content as unknown[];
+      expect(JSON.stringify(blocks)).toContain(paths[0] ?? '');
+      expect(JSON.stringify(blocks)).toContain(paths[1] ?? '');
+      // The list drained: a second text message does NOT re-inject.
+      await h.bridge.handleMessage(message({ messageId: 'om_msg3', text: 'anything else?' }));
+      expect(h.agentStore.followups.get('feishu-session-1')).toHaveLength(2);
+      const secondBlocks = h.agentStore.followups.get('feishu-session-1')?.[1]
+        ?.content as unknown[];
+      expect(JSON.stringify(secondBlocks)).not.toContain(paths[0] ?? '');
+    });
+
+    it('a bare file message in a group bypasses the mention gate (registers pending); the follow-up text must @ the bot', async () => {
+      const h = makeHarness({
+        saveInboundFile: async () =>
+          Promise.resolve({ path: '/work/.dsh_feishu/attachments/g.txt' }),
+      });
+      h.transport.downloadFileImpl = async () => new Uint8Array([1, 2, 3]);
+      h.transport.botOpenId = 'ou_bot';
+      // Group bare file, NO mention: registers (bypass).
       await h.bridge.handleMessage(
         message({
           text: '',
-          attachments: [{ kind: 'image', key: 'missing' }],
+          chatType: 'group',
+          mentions: [],
+          attachments: [{ kind: 'file', key: 'g', name: 'g.txt' }],
         }),
       );
-      expect(h.transport.sentTexts.some((t) => t.text.includes('could not be read'))).toBe(true);
-      // The turn still ran (text-only).
+      expect(h.transport.sentCards).toHaveLength(1);
+      expect(h.agentStore.followups.get('feishu-session-1')).toBeUndefined();
+      // Un-@ group text: the mention gate drops it, the file stays pending.
+      await h.bridge.handleMessage(
+        message({ messageId: 'om_msg2', text: 'look', chatType: 'group', mentions: [] }),
+      );
+      expect(h.agentStore.followups.get('feishu-session-1')).toBeUndefined();
+      // @-mentioned text drains it.
+      await h.bridge.handleMessage(
+        message({ messageId: 'om_msg3', text: 'look', chatType: 'group', mentions: ['ou_bot'] }),
+      );
       expect(h.agentStore.followups.get('feishu-session-1')).toHaveLength(1);
     });
 
-    it('degrades to the file path when the attachment service is absent', async () => {
-      const h = makeHarness({
-        llm: imageCapableLlm(),
-        agentDefaultModel: imageCapableDefault(),
-      }); // no getSaveImage
+    it('a bare image message without a save seam still registers a name-only pending entry', async () => {
+      // No saveInboundFile: the image download succeeds but nothing can
+      // persist it — the pending entry is name-only and the follow-up text
+      // still drains it (no image block, no wedge).
+      const h = makeHarness();
       h.transport.downloadImageImpl = async () => ({ data: pngBytes, mediaType: 'image/png' });
       await h.bridge.handleMessage(
         message({
@@ -546,42 +599,12 @@ describe('Bridge', () => {
           attachments: [{ kind: 'image', key: 'img-1' }],
         }),
       );
-      // Degraded: receipt card (file path) + file-name note; image NOT saved.
       expect(h.transport.sentCards[0]?.header?.title.content).toBe('📎 File received');
+      expect(h.agentStore.followups.get('feishu-session-1')).toBeUndefined();
+      await h.bridge.handleMessage(message({ messageId: 'om_msg2', text: 'look' }));
       const followups = h.agentStore.followups.get('feishu-session-1');
       const blocks = followups?.[0]?.content as unknown[];
       expect(JSON.stringify(blocks)).toContain('img-1');
-      expect(JSON.stringify(blocks)).not.toContain('"type":"image"');
-    });
-
-    it('degrades to the file path when the model cannot see images', async () => {
-      // FakeLlmService (DeepSeek, no image modality) + no capability → the
-      // image becomes a file receipt, never an injected image block.
-      const h = makeHarness({
-        llm: new FakeLlmService(),
-        agentDefaultModel: {
-          currentSelection: () => ({ provider: 'deepseek-official', model: 'deepseek-v4-flash' }),
-          saveSelection: async () => {},
-        },
-        getSaveImage: () => (input: { data: Uint8Array; mediaType: string }) =>
-          Promise.resolve({
-            attachmentId: 'att-1',
-            mediaType: input.mediaType,
-            bytes: input.data.length,
-            width: 1,
-            height: 1,
-          }),
-      });
-      h.transport.downloadImageImpl = async () => ({ data: pngBytes, mediaType: 'image/png' });
-      await h.bridge.handleMessage(
-        message({
-          text: '',
-          attachments: [{ kind: 'image', key: 'img-1' }],
-        }),
-      );
-      expect(h.transport.sentCards[0]?.header?.title.content).toBe('📎 File received');
-      const followups = h.agentStore.followups.get('feishu-session-1');
-      const blocks = followups?.[0]?.content as unknown[];
       expect(JSON.stringify(blocks)).not.toContain('"type":"image"');
     });
   });

--- a/tests/cards/render.spec.ts
+++ b/tests/cards/render.spec.ts
@@ -9,6 +9,7 @@ import {
   buildApprovalCard,
   buildApprovalDecidedCard,
   buildCard,
+  buildInboundFileCard,
   buildModelPickerCard,
   buildPanelCard,
   buildPermissionPickerCard,
@@ -932,5 +933,24 @@ describe('interaction cards (approvals/questions)', () => {
     const card = buildQuestionAnsweredCard('Which stack?', 'Rust');
     expect(card.elements.some((el) => el.tag === 'action')).toBe(false);
     expect(JSON.stringify(card.elements)).toContain('Answer: Rust');
+  });
+
+  it('inbound-file receipt card shows the saved path and the pending count', () => {
+    const card = buildInboundFileCard('report.pdf', '/work/attachments/report.pdf', 3);
+    expect(card.header?.title.content).toBe('📎 File received');
+    const content = JSON.stringify(card.elements);
+    expect(content).toContain('report.pdf');
+    expect(content).toContain('/work/attachments/report.pdf');
+    expect(content).toContain('**3 files awaiting your instruction.**');
+    // No action buttons — the interaction model is "send an instruction".
+    expect(card.elements.some((el) => el.tag === 'action')).toBe(false);
+  });
+
+  it('inbound-file receipt card defaults to count 1 and a name-only note without a path', () => {
+    const card = buildInboundFileCard('notes.txt');
+    const content = JSON.stringify(card.elements);
+    expect(content).toContain('notes.txt');
+    expect(content).not.toContain('awaiting your instruction');
+    expect(content).toContain('Tell me what to do with it.');
   });
 });

--- a/tests/integration/inbound-wait-instruction.spec.ts
+++ b/tests/integration/inbound-wait-instruction.spec.ts
@@ -1,12 +1,13 @@
 /**
- * Real-composition integration tests for inbound attachments (F1): a real
- * dsh process booted from the real profile, with only Feishu (memory
- * transport) and the LLM API (mock server) mocked. Asserts that an inbound
- * `image` message reaches the agent as an `image` content block, and an
- * inbound `file` message posts a receipt card + file-name note.
+ * Real-composition integration tests for the inbound wait-for-instruction
+ * feature: attachment-only messages (file / image / video / rich-text post)
+ * register as pending instead of starting a turn; the follow-up text message
+ * drains the pending list into ONE turn, in order. A real dsh process boots
+ * from the real profile with only Feishu (memory transport) and the LLM API
+ * (mock server) mocked.
  *
  * Self-skips when the environment lacks a prepared profile or the dsh CLI,
- * like the sibling real-composition suite (see docs/development.md →
+ * like the sibling real-composition suites (see docs/development.md →
  * "Integration test").
  */
 
@@ -21,11 +22,11 @@ import { type MockLlmServer, startMockLlmServer } from './mock-llm-server.js';
 const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
 const DSH_HOME = process.env.FEISHU_INT_DSH_HOME ?? join(REPO_ROOT, '_dev', 'dsh-home');
 const PROFILE_DIR = join(DSH_HOME, 'profiles', 'feishu-dev');
-const MEMORY_DIR = join(REPO_ROOT, '_dev', 'int-memory-attachments');
+const MEMORY_DIR = join(REPO_ROOT, '_dev', 'int-memory-wait-instruction');
 const INBOX_DIR = join(MEMORY_DIR, 'inbox');
 const OUTBOX_DIR = join(MEMORY_DIR, 'outbox');
-const ATTACH_DIR = join(REPO_ROOT, '_dev', 'int-attachments-seed');
-const INT_CWD = join(REPO_ROOT, '_dev', 'int-cwd-attachments');
+const ATTACH_DIR = join(REPO_ROOT, '_dev', 'int-attachments-wait-instruction');
+const INT_CWD = join(REPO_ROOT, '_dev', 'int-cwd-wait-instruction');
 
 function resolveDshBin(): string | undefined {
   if (process.env.DSH_BIN !== undefined && process.env.DSH_BIN !== '') return process.env.DSH_BIN;
@@ -80,13 +81,14 @@ if (integrationRequired && !integrationReady) {
   );
 }
 
-/** Drop one inbound message into the message channel. `attachments` is the
- *  normalized attachment list (the shape the bridge consumes). */
+/** Drop one inbound message into the message channel. */
 function sendMessage(
   chatId: string,
   text: string,
   attachments?: readonly { kind: 'image' | 'file'; key: string; name?: string }[],
   fixedMessageId?: string,
+  chatType: 'p2p' | 'group' = 'p2p',
+  mentions: readonly string[] = [],
 ): void {
   const messageId = fixedMessageId ?? `om-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   writeFileSync(
@@ -94,19 +96,18 @@ function sendMessage(
     JSON.stringify({
       messageId,
       chatId,
-      chatType: 'p2p',
+      chatType,
       senderOpenId: 'ou_mock',
       text,
       ...(attachments !== undefined ? { attachments } : {}),
-      mentions: [],
+      mentions,
       createdAt: Date.now(),
     }),
     'utf8',
   );
 }
 
-/** Seed downloadable bytes for an attachment key (`<key>.bin` +
- *  `<key>.mediaType`), consumed by the memory transport's download methods. */
+/** Seed downloadable bytes for an attachment key. */
 function seedAttachment(key: string, bytes: Uint8Array, mediaType?: string): void {
   writeFileSync(join(ATTACH_DIR, `${key}.bin`), bytes);
   if (mediaType !== undefined) {
@@ -114,12 +115,8 @@ function seedAttachment(key: string, bytes: Uint8Array, mediaType?: string): voi
   }
 }
 
-/** Pin the chat's working directory via /cd (the gate refuses turns until
- *  an explicit directory is chosen). */
+/** Pin the chat's working directory via /cd. */
 async function pinWorkingDir(chatId: string): Promise<void> {
-  // /cd is idempotent (setCwd + remint), so retry it if the confirmation
-  // does not arrive — the first /cd can be delayed by dsh cold-start on a
-  // slow CI runner (the bridge reports ready before every service settles).
   for (let attempt = 1; attempt <= 3; attempt += 1) {
     sendMessage(chatId, `/cd ${INT_CWD}`);
     try {
@@ -141,7 +138,7 @@ async function pinWorkingDir(chatId: string): Promise<void> {
   }
 }
 
-describe.skipIf(!integrationReady)('integration > inbound-attachments', () => {
+describe.skipIf(!integrationReady)('integration > inbound-wait-instruction', () => {
   let mock: MockLlmServer | undefined;
   let child: ReturnType<typeof spawn> | undefined;
   let stdout = '';
@@ -170,9 +167,6 @@ describe.skipIf(!integrationReady)('integration > inbound-attachments', () => {
     await stopChild();
     rmSync(MEMORY_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     rmSync(ATTACH_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
-    // Attachment buckets live under INT_CWD; clear them too, or WeChat-style
-    // dedupe accumulates `file-1(1).txt`, `file-1(2).txt`, … across runs and
-    // the test's exact-path assertions break.
     rmSync(join(INT_CWD, '.dsh_feishu'), {
       recursive: true,
       force: true,
@@ -186,6 +180,7 @@ describe.skipIf(!integrationReady)('integration > inbound-attachments', () => {
     mock = await startMockLlmServer();
     bridgeReady = false;
     stdout = '';
+    stderr = '';
   });
 
   afterEach(async () => {
@@ -208,10 +203,9 @@ describe.skipIf(!integrationReady)('integration > inbound-attachments', () => {
         FEISHU_TRANSPORT: 'memory',
         FEISHU_MEMORY_DIR: MEMORY_DIR,
         FEISHU_MEMORY_ATTACHMENTS: ATTACH_DIR,
+        FEISHU_MOCK_BOT_OPEN_ID: 'ou_bot',
         DEEPSEEK_API_KEY: 'mock_key',
         DEEPSEEK_BASE_URL: server.url,
-        // The memory transport serves attachment bytes from
-        // FEISHU_MEMORY_ATTACHMENTS (see the transport options).
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -223,7 +217,7 @@ describe.skipIf(!integrationReady)('integration > inbound-attachments', () => {
       stderr += chunk.toString();
     });
     await waitFor('the bridge to report ready', () => bridgeReady, 30_000);
-    const chatId = `oc_att_${Date.now()}`;
+    const chatId = `oc_wi_${Date.now()}`;
     await pinWorkingDir(chatId);
     return { chatId };
   }
@@ -233,7 +227,12 @@ describe.skipIf(!integrationReady)('integration > inbound-attachments', () => {
     return mock?.lastRequestBody();
   }
 
-  /** The markdown content of a receipt/notice card by header title. */
+  /** How many LLM completion requests the mock server has served. */
+  function llmRequestCount(): number {
+    return mock?.completionRequests() ?? 0;
+  }
+
+  /** The markdown content of receipt cards by header title. */
   function cardMarkdowns(title: string): string[] {
     return readOutbox()
       .filter(
@@ -246,14 +245,11 @@ describe.skipIf(!integrationReady)('integration > inbound-attachments', () => {
       );
   }
 
-  it('an inbound image message registers as pending and drains into the follow-up turn', async () => {
-    // Images are plain files to the agent (unified-attachment decision): a
-    // bare image message registers as pending — receipt card, no turn —
-    // and the follow-up text drains it as a file note with the REAL path.
-    const png = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82]);
-    seedAttachment('img-1', png, 'image/png');
+  it('a bare file message lands on disk, posts a receipt card, and does NOT start a turn', async () => {
+    const content = 'pending file body\n';
+    seedAttachment('pf-1', new TextEncoder().encode(content));
     const { chatId } = await boot();
-    sendMessage(chatId, '', [{ kind: 'image', key: 'img-1' }], 'om-img-1');
+    sendMessage(chatId, '', [{ kind: 'file', key: 'pf-1', name: 'pending.txt' }], 'om-pf-1');
     try {
       await waitFor('the receipt card', () => cardMarkdowns('📎 File received').length > 0, 30_000);
     } catch (error) {
@@ -261,108 +257,72 @@ describe.skipIf(!integrationReady)('integration > inbound-attachments', () => {
         `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}`,
       );
     }
-    // The image is on disk under the chat bucket (sniffed as png).
+    // The file is on disk under the chat bucket.
     const savedFile = join(
       INT_CWD,
       '.dsh_feishu',
       'attachments',
       'cli_mock_app',
       chatId,
-      'img-1.png',
+      'pending.txt',
     );
     try {
-      await waitFor('the saved image on disk', () => existsSync(savedFile), 10_000);
+      await waitFor('the saved file on disk', () => existsSync(savedFile), 10_000);
     } catch (error) {
       throw new Error(
         `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}`,
       );
     }
-    // The follow-up text drains the image as a file note (real path).
-    sendMessage(chatId, 'look at this', undefined, 'om-img-followup');
+    expect(readFileSync(savedFile, 'utf8')).toBe(content);
+    // Give the bridge a moment: a turn must NOT have started.
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+    expect(llmRequestCount()).toBe(0);
+  }, 150_000);
+
+  it('two bare files register both; one follow-up text drains both into a single turn', async () => {
+    const contentA = 'file A body\n';
+    const contentB = 'file B body\n';
+    seedAttachment('pf-a', new TextEncoder().encode(contentA));
+    seedAttachment('pf-b', new TextEncoder().encode(contentB));
+    const { chatId } = await boot();
+    const dir = join(INT_CWD, '.dsh_feishu', 'attachments', 'cli_mock_app', chatId);
+    sendMessage(chatId, '', [{ kind: 'file', key: 'pf-a', name: 'a.txt' }], 'om-pf-a');
+    sendMessage(chatId, '', [{ kind: 'file', key: 'pf-b', name: 'b.txt' }], 'om-pf-b');
     try {
       await waitFor(
-        'the saved path in the agent turn',
+        'the second receipt card',
+        () => cardMarkdowns('📎 File received').length >= 2,
+        30_000,
+      );
+    } catch (error) {
+      throw new Error(
+        `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}`,
+      );
+    }
+    await waitFor(
+      'both files on disk',
+      () => existsSync(join(dir, 'a.txt')) && existsSync(join(dir, 'b.txt')),
+      10_000,
+    );
+    expect(llmRequestCount()).toBe(0);
+    // The follow-up text drains BOTH pending files into one turn.
+    sendMessage(chatId, 'analyze these files', undefined, 'om-analyze');
+    try {
+      await waitFor(
+        'the agent turn to carry both saved paths',
         () => {
           const b = agentLastBody() as { messages?: unknown[] } | undefined;
-          return JSON.stringify(b?.messages ?? []).includes(savedFile);
+          const body = JSON.stringify(b?.messages ?? []);
+          return body.includes(join(dir, 'a.txt')) && body.includes(join(dir, 'b.txt'));
         },
         90_000,
       );
     } catch (error) {
       throw new Error(
-        `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}`,
+        `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}\n--- last body ---\n${JSON.stringify(agentLastBody())}`,
       );
     }
-  }, 150_000);
-
-  it('an inbound file message registers as pending and drains into the follow-up turn', async () => {
-    // A tiny text file: sniffed as .txt, saved under the chat's cwd in the
-    // appId/chatId bucket. Seeded BEFORE boot — the memory transport reads
-    // the attachment dir once at process start. The file registers as
-    // pending (receipt card, no turn); the follow-up text drains it.
-    const content = 'hello from the inbound file\n';
-    seedAttachment('file-1', new TextEncoder().encode(content));
-    const { chatId } = await boot();
-    sendMessage(chatId, '', [{ kind: 'file', key: 'file-1' }], 'om-saved-file-1');
-    try {
-      await waitFor(
-        'the file receipt card',
-        () => cardMarkdowns('📎 File received').length > 0,
-        30_000,
-      );
-    } catch (error) {
-      throw new Error(
-        `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}`,
-      );
-    }
-    // The bytes are on disk at <cwd>/.dsh_feishu/attachments/<appId>/<chatId>/file-1.txt.
-    const savedFile = join(
-      INT_CWD,
-      '.dsh_feishu',
-      'attachments',
-      'cli_mock_app',
-      chatId,
-      'file-1.txt',
-    );
-    try {
-      await waitFor('the saved attachment file on disk', () => existsSync(savedFile), 10_000);
-    } catch (error) {
-      throw new Error(`${String(error)}\n--- dsh stderr ---\n${stderr}`);
-    }
-    expect(readFileSync(savedFile, 'utf8')).toBe(content);
-    // The follow-up text drains the file; the agent's user message carries
-    // the REAL saved path.
-    sendMessage(chatId, 'what is this file', undefined, 'om-file-followup');
-    await waitFor(
-      'the saved path in the agent turn',
-      () => {
-        const b = agentLastBody() as { messages?: unknown[] } | undefined;
-        return JSON.stringify(b?.messages ?? []).includes(savedFile);
-      },
-      90_000,
-    );
-  }, 150_000);
-
-  it('an image whose key is missing registers a degraded receipt and never wedges the chat', async () => {
-    // The download fails (unknown key); the pending registration posts a
-    // degraded receipt (no path), registers nothing, and the chat stays
-    // usable — a follow-up text still turns normally.
-    const { chatId } = await boot();
-    sendMessage(chatId, '', [{ kind: 'image', key: 'missing' }], 'om-missing-img');
-    // Receipt card appears (degrade path)…
-    try {
-      await waitFor(
-        'the degraded file receipt card',
-        () => cardMarkdowns('📎 File received').length > 0,
-        30_000,
-      );
-    } catch (error) {
-      throw new Error(
-        `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}`,
-      );
-    }
-    // …a follow-up text still runs a turn (no wedge).
-    sendMessage(chatId, 'hello', undefined, 'om-after-missing');
+    // The turn completed (green final card).
     await waitFor(
       'the green final card patch',
       () => readOutbox().some((r) => r.kind === 'patch' && r.card?.header?.template === 'green'),
@@ -370,42 +330,33 @@ describe.skipIf(!integrationReady)('integration > inbound-attachments', () => {
     );
   }, 150_000);
 
-  it('a repeated file name in the same chat saves as name(1).ext (WeChat-style dedupe)', async () => {
-    // The user re-sends a file with the SAME original name in the SAME
-    // chat: the first lands as `report.txt`, the second as `report(1).txt`
-    // — never an overwrite. Bucketing is per app + chat, so the second
-    // message collides with the first and the dedupe fires. Sent
-    // SEQUENTIALLY (wait for the first file to land before the second) —
-    // real users send one file at a time, and a burst would race the two
-    // saves (both probe the name before either writes).
-    const contentA = 'first upload\n';
-    const contentB = 'second upload\n';
-    seedAttachment('file-a', new TextEncoder().encode(contentA));
-    seedAttachment('file-b', new TextEncoder().encode(contentB));
+  it('a bare attachment in a GROUP without a mention still registers, and the follow-up text must @ the bot', async () => {
+    const content = 'group pending file\n';
+    seedAttachment('pg-1', new TextEncoder().encode(content));
     const { chatId } = await boot();
-    const dir = join(INT_CWD, '.dsh_feishu', 'attachments', 'cli_mock_app', chatId);
-    sendMessage(chatId, '', [{ kind: 'file', key: 'file-a', name: 'report.txt' }], 'om-dedupe-1');
+    // Group bare file, NO mention: registers anyway (attachment messages
+    // cannot carry a mention in Feishu — no input box).
+    sendMessage(chatId, '', [{ kind: 'file', key: 'pg-1', name: 'group.txt' }], 'om-pg-1', 'group');
     try {
-      await waitFor(
-        'the first named file on disk',
-        () => existsSync(join(dir, 'report.txt')),
-        10_000,
-      );
+      await waitFor('the receipt card', () => cardMarkdowns('📎 File received').length > 0, 30_000);
     } catch (error) {
-      throw new Error(`${String(error)}\n--- dsh stderr ---\n${stderr}`);
+      throw new Error(
+        `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}`,
+      );
     }
-    expect(readFileSync(join(dir, 'report.txt'), 'utf8')).toBe(contentA);
-    // Now the second, same-named file in the same chat → deduped.
-    sendMessage(chatId, '', [{ kind: 'file', key: 'file-b', name: 'report.txt' }], 'om-dedupe-2');
+    expect(llmRequestCount()).toBe(0);
+    // Un-@ group text does NOT drain (mention gate) — the file stays pending.
+    sendMessage(chatId, 'look at this', undefined, 'om-noat', 'group');
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+    expect(llmRequestCount()).toBe(0);
+    // @-mentioned text drains it.
+    sendMessage(chatId, 'look at this', undefined, 'om-at', 'group', ['ou_bot']);
     try {
-      await waitFor(
-        'the deduped second file on disk',
-        () => existsSync(join(dir, 'report(1).txt')),
-        10_000,
-      );
+      await waitFor('the turn to start after the @ mention', () => llmRequestCount() > 0, 90_000);
     } catch (error) {
-      throw new Error(`${String(error)}\n--- dsh stderr ---\n${stderr}`);
+      throw new Error(
+        `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}`,
+      );
     }
-    expect(readFileSync(join(dir, 'report(1).txt'), 'utf8')).toBe(contentB);
   }, 150_000);
 });


### PR DESCRIPTION
## What

- **Wait-for-instruction.** A file/image message without text no longer starts a turn by itself: the bytes land in the workspace, a NEW receipt card posts for each file (previous cards stay in chat history, showing the running count `📎 已收到 N 个文件`), and the agent waits. The next text message drains the pending list into its turn — every pending file's saved path is injected before the text, in arrival order, then the list clears.
- **Unified attachments.** A Feishu image is a plain file to the agent: no image content block / visual-input path (the DSH-web paste-image capability has no Feishu equivalent). The `getSaveImage` / `ctx.attachments` seam and the image-capability gate are removed; images download, save into the same `<appId>/<chatId>` bucket, and are read by path like files.
- **Group mention gate.** Bare attachment messages bypass it (Feishu sends them without an input box, so an @ is physically impossible), but the follow-up TEXT instruction still requires an @ — the agent never acts without an accepted instruction.
- **Concurrency.** The pending list appends SYNCHRONOUSLY before any await: the message channel delivers a burst without awaiting, so two concurrent bare-attachment messages must each see the other's entries (a read-then-set around an await silently drops one).
- Receipt card gains the pending count; no action buttons (a button was considered and rejected — the single interaction model is "send an instruction").

## Why

User-reported F1.5 issue 1: sending a file triggered a turn immediately, with no chance to attach an operation prompt. This makes bare attachment messages wait for the user's instruction; multiple files pile up and drain into one turn. Also implements the user's decision that Feishu images are plain files (not injected into the LLM).

## Docs

- `docs/ux-specification.md` + `.zh.md`: new `inbound-wait-instruction` part; the `inbound-attachments` part rewritten for unified attachments + pending behavior.
- `docs/features.md` + `.zh.md`: Inbound attachments row updated; `inbound-wait-instruction` row flips to shipped.
- `CHANGELOG.md`: Added entries for unified inbound attachments and inbound-wait-instruction.
- README untouched (maintainer-gated).

## Verification

- Unit: `tests/bridge.spec.ts` — pending registration (file + image), pending list drain in order, name-only fallback, group bypass + @-gated follow-up, no image block ever; `tests/cards/render.spec.ts` — receipt card count + no buttons.
- Integration (`tests/integration/inbound-wait-instruction.spec.ts`, new): bare file → no turn; two files → two cards + one follow-up drains both; group without @ registers, @ text triggers. `tests/integration/inbound-attachments.spec.ts` updated to pending semantics (image/file drain on follow-up; missing key degrades, no wedge).
- Full matrix green: lint, typecheck, build, `FEISHU_INT_REQUIRED=1 vitest run` → **545 tests pass** (24 files, incl. real-composition + scenarios).