### PR TITLE
feat: support Feishu rich-text (post) and video inbound messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   them without an input box, so an @ is physically impossible), but the
   follow-up TEXT instruction still requires an @ — the agent never acts
   without an accepted instruction.
+- **Rich-text (`post`) and `video` messages are no longer dropped
+  (inbound-rich-text).** A `post` message is normalized into a serialized
+  markdown-ish string that PRESERVES the inline element order (text / image
+  / video / file in one bubble — the intra-bubble order is information),
+  with inline `<image N>` / `<video N>` placeholders and an ordered
+  attachment list; the client-authored `md` field is preferred when present.
+  A rich-text post with text starts a turn immediately; an attachment-only
+  post and a bare `video` message register as pending like any file
+  (`type=file` on the resource API serves video — no new download path).
 - **Inbound files stream to disk and keep their original name.** The
   message-resource download previously read `response.file`, but the SDK
   interceptor already unwraps `resp.data`, so every inbound file failed to

--- a/docs/features.md
+++ b/docs/features.md
@@ -30,3 +30,4 @@ Feature list and TODO tracker for dsh-feishu. ✅ = shipped, 📋 = planned
 | Context occupancy | Current session's context-window usage | Percent on the card bottom, refreshed per turn; details (used/capacity, breakdown) in `/status` | 📋 |
 | session-rename-archive | Session rename/archive via dsh sessionTitle + workspaceRegistry (web-visible) | — | 📋 |
 | inbound-wait-instruction | Bare file/image messages register as pending — a receipt card posts and the agent waits for the user's instruction before working | 📎 File received receipt (counts pending files); follow-up text drains them into one turn | ✅ |
+| inbound-rich-text | Feishu rich-text (post) and video messages are no longer dropped: a post is serialized into ordered rich text + attachments (formatting and intra-bubble order preserved), a video is a plain file | Rich-text-with-text posts turn immediately; attachment-only posts / videos register as pending | ✅ |

--- a/docs/features.zh.md
+++ b/docs/features.zh.md
@@ -30,3 +30,4 @@ dsh-feishu 的功能列表与 TODO 追踪表。✅ = 已实现，📋 = 计划�
 | 上下文占用 | 当前会话的上下文窗口占用 | 卡底部百分比，随 turn 刷新；详情（used/capacity、分布）在 `/status` | 📋 |
 | session-rename-archive | Session rename/archive via dsh sessionTitle + workspaceRegistry (web-visible) | — | 📋 |
 | inbound-wait-instruction | 裸文件/图片消息登记为 pending——发回执卡并等用户指令后才开始工作 | 📎 File received 回执（计数 pending 文件）；补发文字把它们带进一个 turn | ✅ |
+| inbound-rich-text | 飞书富文本（post）和视频消息不再被丢弃：post 序列化为有序富文本 + 附件（保留格式与气泡内顺序），视频按普通文件处理 | 带文字的富文本立即 turn；纯附件 post / 视频登记为 pending | ✅ |

--- a/docs/ux-specification.md
+++ b/docs/ux-specification.md
@@ -936,3 +936,148 @@ cards stay in chat history. No panel views.
   the pending download path reuses the existing file seam for all of them.
 - post / video support is the sibling PR-A (inbound-rich-text), which drains
   into this pending path.
+
+## Part: inbound-rich-text
+
+> Feishu rich-text (`post`) and `video` messages are no longer silently
+> dropped. A `post` message is normalized into a serialized markdown-ish
+> string that PRESERVES the inline element order (text / image / media /
+> file in one bubble — "look at the picture, then read this" vs the
+> reverse), plus an ordered attachment list; a `video` message is a file
+> like any other. Rich-text-with-text posts start a turn immediately (the
+> existing mixed path); attachment-only posts and bare videos register as
+> pending (the sibling inbound-wait-instruction path).
+
+### Intended behavior
+
+**Trigger** — an inbound message whose `message_type` is `post` (rich text)
+or `video`. Today the surface's `SUPPORTED_MESSAGE_TYPES` is
+`['text','image','file']`, so both are silently ignored — the user's
+formatted message (bold / lists / quotes / links / code blocks) or video
+vanishes with no receipt, no save, no turn. This feature makes them first-
+class.
+
+**Feishu `post` content model** — a rich-text message's `content` is a
+2-D JSON array of inline element groups:
+
+```json
+{
+  "title": "…",
+  "content": [
+    [ {"tag":"text","text":"First line:","style":["bold"]}, {"tag":"a","href":"…","text":"link"}, {"tag":"at","user_id":"…","user_name":"…"} ],
+    [ {"tag":"img","image_key":"img_…"} ],
+    [ {"tag":"text","text":"Second line:"}, {"tag":"code_block","language":"PYTHON","text":"print(1)"} ],
+    [ {"tag":"media","file_key":"file_…","image_key":"img_…"} ],
+    [ {"tag":"hr"} ]
+  ]
+}
+```
+
+Each outer array element is a paragraph; the inner elements are inline and
+ORDERED — the order between text and attachments is information. The
+official element tags: `text` (with `style`: `bold` / `underline` /
+`lineThrough` / `italic`), `a` (link), `at`, `img` (image), `media` (video),
+`emotion` (emoji), `hr`, `code_block` (with `language` + `text`), `file`.
+The client also authors an `md` field (the markdown source) that already
+carries formatting and `![img](image_key)` tokens.
+
+**Normalization — `post` → serialized rich-text + ordered attachments** —
+a `post` message normalizes into:
+
+1. a `text` string — the linearized markdown-ish rendering of the inline
+   elements, in order, with attachment placeholders inline:
+
+```
+First line: **bold** [link](https://…) @User
+<image 1>
+
+Second line: ```python
+print(1)
+```
+
+<video 2>
+---
+```
+
+   Mapping: `text` styles → `**`/`*`/`~~`/`<u>…</u>`; `a` → `[text](href)`;
+   `at` → `@name`; `code_block` → fenced block (language + text); `hr` →
+   `---`; `emotion` → its emoji text; `img` → `<image N>`, `media` → `<video
+   N>`, `file` → `<file N>`. The `md` field, when present, is the preferred
+   source (it already carries formatting + `![img](image_key)` tokens —
+   rewritten to `<image N>` placeholders); the element array is the fallback
+   when `md` is absent. Each element group is separated by a newline; the
+   group order is preserved exactly.
+
+2. an `attachments` array, in placeholder order — each `img`/`media`/`file`
+   becomes an attachment (`{kind:'image'|'file', key, name?}`), numbered by
+   its placeholder position (1-based). The agent correlates `<image N>` with
+   the saved path via the ordered note list (the existing
+   `[user sent a file: … — saved at …]` notes).
+
+**`video` message** — `message_type: 'video'` with `file_key` (+ `image_key`
+cover). Normalizes to a single `file`-kind attachment (the video body),
+exactly like a bare file message — it registers as pending and the follow-up
+text drains it. `im.v1.messageResource.get?type=file` serves video (the
+resource API's `type=file` covers files, audio, AND video), so no new
+download path is needed.
+
+**Routing (reuses the sibling parts)** — after normalization:
+
+- `post` with non-empty text → the existing mixed path: immediate turn, the
+  serialized text as the `text` block and the attachments injected in
+  placeholder order (the inbound-attachments part's unified path).
+- `post` with text empty (attachments only) / bare `video` → the
+  inbound-wait-instruction pending path (receipt card, no turn, drained by
+  the follow-up text).
+- `post` with neither text nor attachments → ignored with a loud log (no
+  usable content).
+
+**Card/panel shape** — none new. Rich-text posts with text use the streaming
+card like any text message; attachment-only posts / videos use the existing
+`📎 File received` pending receipt cards. No buttons, no panel views.
+
+**Failure modes**:
+- `post` content JSON malformed (not parseable): the message degrades to a
+  text-only notice with a loud log — the raw content string is NOT delivered
+  as agent text (it is machine JSON, useless to the model).
+- `md` field absent: element-array serialization is the fallback — never an
+  empty agent message when elements exist.
+- Unknown element tag: skipped with a debug log (forward-compat — new Feishu
+  tags degrade gracefully rather than breaking the parse).
+- Attachment download/save fails inside a rich-text post: the sibling
+  degraded-receipt path (loud log, name-only note, never wedges).
+- `video` message with a stale key: same download-failure path.
+
+**Acceptance checklist**:
+- [ ] `post` with text + bold/link/code/at → agent's user message carries the
+      serialized markdown-ish text with formatting preserved (unit)
+- [ ] `post` mixing text + image + video → placeholders `<image 1>` /
+      `<video 2>` in order, attachments array in the same order, and the
+      saved paths correlate (unit + integration)
+- [ ] `post` with text → immediate turn (unit + integration)
+- [ ] `post` attachments-only → pending (receipt card, no turn; follow-up
+      drains) (integration)
+- [ ] `video` message → pending like a bare file, drained by follow-up text
+      (unit + integration)
+- [ ] `post` with `md` field → `md`-based serialization preferred (unit)
+- [ ] `post` malformed content → loud log, no crash, message not delivered
+      as raw JSON (unit)
+- [ ] Unknown tag → skipped with debug log, rest of the post intact (unit)
+
+### Reference
+
+- Feishu message content spec (`open.feishu.cn … message-content-description`):
+  `post` content is the 2-D element array with `text`/`a`/`at`/`img`/`media`/
+  `emotion`/`hr`/`code_block`/`file` tags and the client-authored `md` field;
+  styles are `bold`/`underline`/`lineThrough`/`italic`.
+- `im.v1.messageResource.get`: `type=image` covers images AND rich-text
+  images; `type=file` covers files, audio, AND video — the existing download
+  seams serve every post element and the `video` message, no new endpoint.
+- lark-cli's `lark-event-im` reference confirms `post` / `video` are distinct
+  `message_type` values alongside `text`/`image`/`file`/`audio`/`sticker`.
+- botmux's rich-text handling flattens post content to text only (no
+  attachment ordering) — dsh-feishu's ordered-placeholder serialization is
+  our own design, preserving the intra-bubble order the user asked for.
+- The pending routing reuses the sibling inbound-wait-instruction part
+  (drained by the follow-up text; attachment messages bypass the group
+  mention gate because Feishu cannot @ from an attachment).

--- a/docs/ux-specification.zh.md
+++ b/docs/ux-specification.zh.md
@@ -472,3 +472,122 @@ turn 运行中到达的新裸附件消息只追加（不影响正在跑的 turn�
 - `im.v1.messageResource.get`：`type=file` 覆盖文件、音频和视频——pending
   下载路径对它们全部复用现有 file seam。
 - post / video 支持是兄弟 PR（inbound-rich-text），它们排空进本 pending 路径。
+
+## Part: inbound-rich-text
+
+> 飞书富文本（`post`）和 `video` 消息不再被静默丢弃。`post` 归一化为保留
+> 气泡内元素顺序（文字 / 图片 / 视频 / 文件在一个气泡里——"先看图再看文字"
+> 与反过来不同）的 markdown 式序列化文本 + 有序附件列表；`video` 消息与
+> 其它文件一样处理。带文字的富文本立即触发 turn（现有混合路径）；纯附件
+> post 和裸 video 登记为 pending（兄弟特性 inbound-wait-instruction 路径）。
+
+### 预期行为
+
+**触发** —— `message_type` 为 `post`（富文本）或 `video` 的入站消息。现状
+`SUPPORTED_MESSAGE_TYPES` 是 `['text','image','file']`，两者都被静默忽略——
+用户带格式的消息（加粗/列表/引用/链接/代码块）或视频无回执、无保存、无
+turn 地消失。本特性让它们成为一等公民。
+
+**飞书 `post` content 模型** —— 富文本消息的 `content` 是二维 JSON 数组：
+
+```json
+{
+  "title": "…",
+  "content": [
+    [ {"tag":"text","text":"第一行","style":["bold"]}, {"tag":"a","href":"…","text":"链接"}, {"tag":"at","user_id":"…","user_name":"…"} ],
+    [ {"tag":"img","image_key":"img_…"} ],
+    [ {"tag":"text","text":"第二行"}, {"tag":"code_block","language":"PYTHON","text":"print(1)"} ],
+    [ {"tag":"media","file_key":"file_…","image_key":"img_…"} ],
+    [ {"tag":"hr"} ]
+  ]
+}
+```
+
+每个外层元素是一段（paragraph），内层元素有序且**顺序即信息**。官方元素
+tag：`text`（`style`：`bold`/`underline`/`lineThrough`/`italic`）、`a`（链接）、
+`at`、`img`（图片）、`media`（视频）、`emotion`（表情）、`hr`、
+`code_block`（`language`+`text`）、`file`。客户端还生成 `md` 字段（markdown
+原文，已含格式与 `![img](image_key)` token）。
+
+**归一化 —— `post` → 序列化富文本 + 有序附件** —— `post` 消息归一化为：
+
+1. `text` 字符串 —— 内联元素的线性化 markdown 式渲染，保持顺序，附件用
+   行内占位符：
+
+```
+第一行: **加粗** [链接](https://…) @用户
+<image 1>
+
+第二行: ```python
+print(1)
+```
+
+<video 2>
+---
+```
+
+   映射：`text` 样式 → `**`/`*`/`~~`/`<u>…</u>`；`a` → `[text](href)`；
+   `at` → `@名字`；`code_block` → 围栏代码块（语言+内容）；`hr` → `---`；
+   `emotion` → 表情文本；`img` → `<image N>`，`media` → `<video N>`，
+   `file` → `<file N>`。`md` 字段存在时优先（已含格式与 `![img](image_key)`
+   token，改写成 `<image N>` 占位符）；`md` 缺失时用元素数组序列化兜底。
+   每个元素组之间换行；组顺序严格保留。
+
+2. `attachments` 数组，按占位符顺序——每个 `img`/`media`/`file` 变成附件
+   （`{kind:'image'|'file', key, name?}`），按占位符位置（从 1 起）编号。
+   agent 通过有序的 `[user sent a file: … — saved at …]` 备注把 `<image N>`
+   与真实保存路径对应起来。
+
+**`video` 消息** —— `message_type: 'video'`，content 含 `file_key`（+ 封面
+`image_key`）。归一化为单个 `file` 类附件（视频本体），与裸文件消息完全一样
+——登记为 pending，跟进文字排空。`im.v1.messageResource.get?type=file` 服务
+视频（资源 API 的 `type=file` 覆盖文件、音频和视频），无需新下载路径。
+
+**路由（复用兄弟 part）** —— 归一化后：
+
+- `post` 带文字 → 现有混合路径：立即 turn，序列化文本作为 `text` 块，附件
+  按占位符顺序注入（inbound-attachments part 的统一路径）。
+- `post` 文字为空（仅附件）/ 裸 `video` → inbound-wait-instruction 的 pending
+  路径（回执卡、不触发 turn、由跟进文字排空）。
+- `post` 既无文字也无附件 → 响亮日志忽略（无可用内容）。
+
+**卡片/面板形态** —— 无新增。带文字的富文本用 streaming 卡（与普通文字
+消息一致）；纯附件 post / 视频用现有 `📎 File received` pending 回执卡。
+无按钮、无面板视图。
+
+**失败模式**：
+- `post` content JSON 解析失败：降级为纯文本提示 + 响亮日志——原始 content
+  字符串**不**作为 agent 文本投递（它是机器 JSON，对模型无用）。
+- `md` 字段缺失：元素数组序列化兜底——存在元素时绝不产生空 agent 消息。
+- 未知元素 tag：debug 日志跳过（向前兼容——新飞书 tag 优雅降级而非破坏解析）。
+- post 内附件下载/保存失败：兄弟特性的降级回执路径（响亮日志、仅名称备注、
+  绝不卡死）。
+- `video` 消息 key 过期：同下载失败路径。
+
+**验收清单**：
+- [ ] `post` 带文字 + 加粗/链接/代码/at → agent 用户消息带序列化 markdown
+      式文本、格式保留（单测）
+- [ ] `post` 混合文字 + 图片 + 视频 → `<image 1>`/`<video 2>` 占位符按顺序、
+      附件数组同序、保存路径对应（单测 + 集成）
+- [ ] `post` 带文字 → 立即 turn（单测 + 集成）
+- [ ] `post` 仅附件 → pending（回执卡、无 turn；跟进文字排空）（集成）
+- [ ] `video` 消息 → 像裸文件一样 pending，跟进文字排空（单测 + 集成）
+- [ ] `post` 有 `md` 字段 → 优先 `md` 序列化（单测）
+- [ ] `post` content 损坏 → 响亮日志、不崩溃、原始 JSON 不投递（单测）
+- [ ] 未知 tag → debug 日志跳过，其余 post 完整（单测）
+
+### Reference
+
+- 飞书消息内容规范（`open.feishu.cn … message-content-description`）：
+  `post` content 是二维元素数组，含 `text`/`a`/`at`/`img`/`media`/`emotion`/
+  `hr`/`code_block`/`file` tag 与客户端 `md` 字段；样式为
+  `bold`/`underline`/`lineThrough`/`italic`。
+- `im.v1.messageResource.get`：`type=image` 覆盖图片与富文本图片；`type=file`
+  覆盖文件、音频和视频——现有下载 seam 服务 post 的每个元素与 `video`
+  消息，无需新端点。
+- lark-cli 的 `lark-event-im` 参考确认 `post`/`video` 是与 `text`/`image`/
+  `file`/`audio`/`sticker` 并列的独立 `message_type`。
+- botmux 的富文本处理只把 post 内容摊平成纯文本（无附件顺序）——dsh-feishu
+  的有序占位符序列化是我们自己的设计，保留用户要求的气泡内顺序。
+- pending 路由复用兄弟特性 inbound-wait-instruction part（跟进文字排空；
+  附件消息绕过群 mention gate，因为飞书无法从附件里 @）。

--- a/src/rich-text.ts
+++ b/src/rich-text.ts
@@ -1,0 +1,208 @@
+/**
+ * Feishu rich-text (`post`) message serialization.
+ *
+ * A Feishu `post` message's `content` is a 2-D JSON array of inline element
+ * groups: each outer element is a paragraph, the inner elements are ordered
+ * and may mix text and attachments (`img` / `media` / `file`). The ORDER is
+ * information — "look at the picture, then read this" differs from the
+ * reverse — so the surface must not flatten it into text + a loose
+ * attachment list.
+ *
+ * This module serializes the element array into a linearized markdown-ish
+ * string with inline `<image N>` / `<video N>` / `<file N>` placeholders,
+ * plus an ordered attachment list whose indexes match the placeholders. The
+ * official client-authored `md` field is preferred when present (it already
+ * carries formatting and `![img](image_key)` tokens); the element array is
+ * the fallback.
+ *
+ * @module @dsh-feishu/dsh-feishu/rich-text
+ */
+
+import type { InboundAttachment } from './feishu/types.js';
+
+/** One inline element of a Feishu rich-text post. */
+interface PostElement {
+  readonly tag: string;
+  readonly text?: string;
+  readonly style?: readonly string[];
+  readonly href?: string;
+  readonly user_id?: string;
+  readonly user_name?: string;
+  readonly image_key?: string;
+  readonly file_key?: string;
+  readonly language?: string;
+  readonly emoji_type?: string;
+  [key: string]: unknown;
+}
+
+/** The parsed shape of a Feishu `post` message's content JSON. */
+interface PostContent {
+  readonly title?: string;
+  readonly content?: readonly (readonly PostElement[])[];
+  readonly md?: string;
+}
+
+/** The result of serializing a `post` message. */
+export interface SerializedPost {
+  /** The linearized markdown-ish text with inline attachment placeholders. */
+  readonly text: string;
+  /** The attachments in placeholder order (1-based indexes). */
+  readonly attachments: readonly InboundAttachment[];
+}
+
+/** Map an element's text styles to markdown-ish markers. */
+function styledText(text: string, style?: readonly string[]): string {
+  let out = text;
+  if (style?.includes('bold')) out = `**${out}**`;
+  if (style?.includes('italic')) out = `*${out}*`;
+  if (style?.includes('lineThrough')) out = `~~${out}~~`;
+  if (style?.includes('underline')) out = `<u>${out}</u>`;
+  return out;
+}
+
+/** Serialize one inline element to its text fragment; `img`/`media`/`file`
+ *  become placeholders and push an attachment. Returns the fragment, or ''
+ *  when the element is skipped (unknown tag — forward-compat). */
+function serializeElement(element: PostElement, attachments: InboundAttachment[]): string {
+  switch (element.tag) {
+    case 'text':
+      return styledText(element.text ?? '', element.style);
+    case 'a': {
+      const label = element.text ?? element.href ?? '';
+      return element.href === undefined || element.href === ''
+        ? label
+        : `[${label}](${element.href})`;
+    }
+    case 'at': {
+      const name = element.user_name ?? element.user_id ?? '';
+      return name === '' ? '@' : `@${name}`;
+    }
+    case 'code_block':
+      return `\`\`\`${element.language ?? ''}\n${element.text ?? ''}\n\`\`\``;
+    case 'hr':
+      return '---';
+    case 'emotion':
+      return element.emoji_type ?? '';
+    case 'img': {
+      const key = element.image_key;
+      if (typeof key !== 'string' || key === '') return '';
+      attachments.push({ kind: 'image', key });
+      return `<image ${attachments.length}>`;
+    }
+    case 'media': {
+      const key = element.file_key;
+      if (typeof key !== 'string' || key === '') return '';
+      const name = element.file_name;
+      attachments.push({
+        kind: 'file',
+        key,
+        ...(typeof name === 'string' && name !== '' ? { name } : {}),
+      });
+      return `<video ${attachments.length}>`;
+    }
+    case 'file': {
+      const key = element.file_key;
+      if (typeof key !== 'string' || key === '') return '';
+      const name = element.file_name;
+      attachments.push({
+        kind: 'file',
+        key,
+        ...(typeof name === 'string' && name !== '' ? { name } : {}),
+      });
+      return `<file ${attachments.length}>`;
+    }
+    default:
+      // Unknown tag (forward-compat): skip it — a new Feishu element must
+      // degrade gracefully instead of breaking the whole post's parse.
+      return '';
+  }
+}
+
+/** Rewrite markdown image tokens in the client-authored `md` source to
+ *  `<image N>` / `<video N>` placeholders (the `md` field references
+ *  `image_key` values; the placeholder numbering must match the attachment
+ *  list built from those same keys). Returns the rewritten text and the
+ *  ordered attachment list. */
+function serializeMarkdown(
+  md: string,
+  keys: readonly { readonly key: string; readonly kind: 'image' | 'file' }[],
+): { text: string; attachments: InboundAttachment[] } {
+  const attachments: InboundAttachment[] = [];
+  const byKey = new Map(keys.map((entry, index) => [entry.key, index]));
+  // `![img](img_…)` or `![video](file_…)` → `<image N>` / `<video N>`.
+  const text = md.replace(/!\[(img|video|file)\]\(([^)]+)\)/g, (match, kind, rawKey) => {
+    const key = String(rawKey).trim();
+    const index = byKey.get(key);
+    if (index === undefined) return match; // key not in the attachment map — leave as-is
+    const entry = keys[index];
+    if (entry === undefined) return match;
+    if (attachments.length === 0) {
+      // First pass: push all keys in order so numbering matches placeholders.
+      for (const k of keys) {
+        if (k.kind === 'image') attachments.push({ kind: 'image', key: k.key });
+        else attachments.push({ kind: 'file', key: k.key });
+      }
+    }
+    void kind;
+    return `<${entry.kind === 'image' ? 'image' : 'video'} ${index + 1}>`;
+  });
+  return { text, attachments };
+}
+
+/**
+ * Serialize a Feishu `post` message's content into ordered rich text +
+ * attachments. The `md` field (client-authored markdown) is preferred when
+ * present; otherwise the element array is serialized with the same
+ * placeholder mapping. The returned text is never empty when usable content
+ * exists.
+ * @param content - the raw `post` message content JSON string.
+ * @returns the serialized text + ordered attachments, or `undefined` when
+ *   the content is not parseable or carries no usable content.
+ */
+export function serializePost(content: string): SerializedPost | undefined {
+  let parsed: PostContent;
+  try {
+    parsed = JSON.parse(content) as PostContent;
+  } catch {
+    return undefined;
+  }
+  const md = parsed.md;
+  if (typeof md === 'string' && md.trim() !== '') {
+    // Collect the attachment keys the md references (img/media/file tags).
+    const keys: { readonly key: string; readonly kind: 'image' | 'file' }[] = [];
+    for (const group of parsed.content ?? []) {
+      for (const element of group) {
+        if (
+          element.tag === 'img' &&
+          typeof element.image_key === 'string' &&
+          element.image_key !== ''
+        ) {
+          keys.push({ key: element.image_key, kind: 'image' });
+        } else if (
+          (element.tag === 'media' || element.tag === 'file') &&
+          typeof element.file_key === 'string' &&
+          element.file_key !== ''
+        ) {
+          keys.push({ key: element.file_key, kind: 'file' });
+        }
+      }
+    }
+    if (keys.length > 0) {
+      const { text, attachments } = serializeMarkdown(md, keys);
+      if (attachments.length > 0) {
+        return { text, attachments };
+      }
+    }
+    // No attachments in the md: fall through to element serialization for
+    // the text (the md itself is the text when there are no placeholders).
+    return { text: md, attachments: [] };
+  }
+  // Element-array serialization (the `md` field is absent).
+  const attachments: InboundAttachment[] = [];
+  const groups = (parsed.content ?? []).map((group) =>
+    group.map((element) => serializeElement(element, attachments)).join(''),
+  );
+  const text = groups.join('\n').trim();
+  if (text === '' && attachments.length === 0) return undefined;
+  return { text, attachments };
+}

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -34,6 +34,7 @@ import type {
   InboundAttachment,
   SentCard,
 } from './feishu/types.js';
+import { serializePost } from './rich-text.js';
 
 /**
  * The HTTP instance the SDK's `Client` and `WSClient` use for every Feishu
@@ -112,7 +113,7 @@ export class FeishuApiError extends Error {
 const MENTION_PATTERN = /<at[^>]*>.*?<\/at>/g;
 
 /** Message types the surface understands; everything else is ignored. */
-const SUPPORTED_MESSAGE_TYPES = new Set(['text', 'image', 'file']);
+const SUPPORTED_MESSAGE_TYPES = new Set(['text', 'image', 'file', 'post', 'video']);
 
 /** Parse an image/file message's content JSON into its attachment, or
  *  `undefined` when the content is malformed. */
@@ -147,7 +148,7 @@ export function normalizeMessageEvent(data: RawMessageEvent): FeishuMessage | un
   if (!SUPPORTED_MESSAGE_TYPES.has(message.message_type)) return undefined;
   const senderOpenId = data.sender?.sender_id?.open_id ?? '';
   let text = '';
-  let attachment: InboundAttachment | undefined;
+  let attachments: InboundAttachment[] = [];
   if (message.message_type === 'text') {
     try {
       const parsed = JSON.parse(message.content) as { text?: string };
@@ -156,10 +157,24 @@ export function normalizeMessageEvent(data: RawMessageEvent): FeishuMessage | un
       return undefined;
     }
     text = text.replace(MENTION_PATTERN, ' ').replace(/\s+/g, ' ').trim();
+  } else if (message.message_type === 'post') {
+    // Rich text: serialize the inline element order into a markdown-ish
+    // string with `<image N>` / `<video N>` placeholders, plus the ordered
+    // attachment list. Malformed content degrades to a loud-ignored message
+    // (the raw JSON is never delivered to the agent as text).
+    const serialized = serializePost(message.content);
+    if (serialized === undefined) {
+      // Loud log at the transport boundary (no logger here — the bridge
+      // logs dropped messages; return undefined to ignore).
+      return undefined;
+    }
+    text = serialized.text;
+    attachments = [...serialized.attachments];
   } else {
-    attachment = parseAttachment(message.content, message.message_type);
+    const attachment = parseAttachment(message.content, message.message_type);
     // A malformed image/file content (no key) is not a usable message.
     if (attachment === undefined) return undefined;
+    attachments = [attachment];
   }
   return {
     messageId: message.message_id,
@@ -167,7 +182,7 @@ export function normalizeMessageEvent(data: RawMessageEvent): FeishuMessage | un
     chatType: message.chat_type === 'group' ? 'group' : 'p2p',
     senderOpenId,
     text,
-    attachments: attachment === undefined ? [] : [attachment],
+    attachments,
     mentions: (message.mentions ?? [])
       .map((mention) => mention.id?.open_id)
       .filter((id): id is string => id !== undefined && id !== ''),

--- a/tests/integration/inbound-rich-text.spec.ts
+++ b/tests/integration/inbound-rich-text.spec.ts
@@ -1,0 +1,335 @@
+/**
+ * Real-composition integration tests for inbound rich-text (`post`) and
+ * `video` messages: a `post` with text starts a turn immediately carrying
+ * the serialized rich text + ordered attachments; a text-less `post` and a
+ * bare `video` register as pending (the inbound-wait-instruction path). A
+ * real dsh process boots from the real profile with only Feishu (memory
+ * transport) and the LLM API (mock server) mocked.
+ *
+ * The memory transport passes inbox JSON straight to the bridge (no
+ * normalizeMessageEvent re-parse), so these tests feed already-normalized
+ * messages (text + ordered attachments) — the transport-layer post
+ * serialization is covered by unit tests (tests/transport.spec.ts,
+ * tests/rich-text.spec.ts).
+ *
+ * Self-skips when the environment lacks a prepared profile or the dsh CLI.
+ */
+
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { MemoryOutboxRecord } from '../../src/memory-transport.js';
+import { type MockLlmServer, startMockLlmServer } from './mock-llm-server.js';
+
+const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+const DSH_HOME = process.env.FEISHU_INT_DSH_HOME ?? join(REPO_ROOT, '_dev', 'dsh-home');
+const PROFILE_DIR = join(DSH_HOME, 'profiles', 'feishu-dev');
+const MEMORY_DIR = join(REPO_ROOT, '_dev', 'int-memory-rich-text');
+const INBOX_DIR = join(MEMORY_DIR, 'inbox');
+const OUTBOX_DIR = join(MEMORY_DIR, 'outbox');
+const ATTACH_DIR = join(REPO_ROOT, '_dev', 'int-attachments-rich-text');
+const INT_CWD = join(REPO_ROOT, '_dev', 'int-cwd-rich-text');
+
+function resolveDshBin(): string | undefined {
+  if (process.env.DSH_BIN !== undefined && process.env.DSH_BIN !== '') return process.env.DSH_BIN;
+  const probe = spawnSync('sh', ['-c', 'command -v dsh'], { encoding: 'utf8' });
+  if (probe.status === 0 && probe.stdout.trim() !== '') return probe.stdout.trim();
+  return undefined;
+}
+
+function readOutbox(): MemoryOutboxRecord[] {
+  let files: string[];
+  try {
+    files = readdirSync(OUTBOX_DIR).filter((file) => file.endsWith('.json'));
+  } catch {
+    return [];
+  }
+  return files
+    .map((file) => {
+      try {
+        return JSON.parse(readFileSync(join(OUTBOX_DIR, file), 'utf8')) as MemoryOutboxRecord;
+      } catch {
+        return undefined;
+      }
+    })
+    .filter((record): record is MemoryOutboxRecord => record !== undefined)
+    .sort((a, b) => a.seq - b.seq);
+}
+
+async function waitFor(
+  description: string,
+  predicate: () => boolean,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (predicate()) return;
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${description}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+}
+
+const dshBin = resolveDshBin();
+const profileReady = existsSync(join(PROFILE_DIR, 'package.json'));
+const built = existsSync(join(REPO_ROOT, 'lib', 'index.js'));
+const integrationRequired = process.env.FEISHU_INT_REQUIRED === '1';
+const integrationReady = dshBin !== undefined && profileReady && built;
+if (integrationRequired && !integrationReady) {
+  throw new Error(
+    `FEISHU_INT_REQUIRED=1 but integration prerequisites are missing ` +
+      `(dsh CLI=${dshBin !== undefined} profile=${profileReady} built=${built})`,
+  );
+}
+
+/** Drop one normalized inbound message into the message channel. */
+function sendMessage(
+  chatId: string,
+  text: string,
+  attachments?: readonly { kind: 'image' | 'file'; key: string; name?: string }[],
+  fixedMessageId?: string,
+): void {
+  const messageId = fixedMessageId ?? `om-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  writeFileSync(
+    join(INBOX_DIR, `${messageId}.json`),
+    JSON.stringify({
+      messageId,
+      chatId,
+      chatType: 'p2p',
+      senderOpenId: 'ou_mock',
+      text,
+      ...(attachments !== undefined ? { attachments } : {}),
+      mentions: [],
+      createdAt: Date.now(),
+    }),
+    'utf8',
+  );
+}
+
+/** Seed downloadable bytes for an attachment key. */
+function seedAttachment(key: string, bytes: Uint8Array, mediaType?: string): void {
+  writeFileSync(join(ATTACH_DIR, `${key}.bin`), bytes);
+  if (mediaType !== undefined) {
+    writeFileSync(join(ATTACH_DIR, `${key}.mediaType`), mediaType, 'utf8');
+  }
+}
+
+/** Pin the chat's working directory via /cd. */
+async function pinWorkingDir(chatId: string): Promise<void> {
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    sendMessage(chatId, `/cd ${INT_CWD}`);
+    try {
+      await waitFor(
+        'the /cd confirmation',
+        () =>
+          readOutbox().some(
+            (r) =>
+              r.kind === 'text' &&
+              r.chatId === chatId &&
+              r.text?.includes('Working directory set to'),
+          ),
+        20_000,
+      );
+      return;
+    } catch (error) {
+      if (attempt === 3) throw error;
+    }
+  }
+}
+
+describe.skipIf(!integrationReady)('integration > inbound-rich-text', () => {
+  let mock: MockLlmServer | undefined;
+  let child: ReturnType<typeof spawn> | undefined;
+  let stdout = '';
+  let stderr = '';
+  let bridgeReady = false;
+
+  async function stopChild(): Promise<void> {
+    const proc = child;
+    child = undefined;
+    if (proc === undefined || proc.exitCode !== null) return;
+    proc.kill('SIGTERM');
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        if (proc.exitCode === null) proc.kill('SIGKILL');
+        resolve();
+      }, 5_000);
+      proc.once('exit', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  }
+
+  beforeEach(async () => {
+    if (mock !== undefined) await mock.close();
+    await stopChild();
+    rmSync(MEMORY_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    rmSync(ATTACH_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    rmSync(join(INT_CWD, '.dsh_feishu'), {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 100,
+    });
+    mkdirSync(INT_CWD, { recursive: true });
+    mkdirSync(INBOX_DIR, { recursive: true });
+    mkdirSync(OUTBOX_DIR, { recursive: true });
+    mkdirSync(ATTACH_DIR, { recursive: true });
+    mock = await startMockLlmServer();
+    bridgeReady = false;
+    stdout = '';
+    stderr = '';
+  });
+
+  afterEach(async () => {
+    await stopChild();
+    if (mock !== undefined) await mock.close();
+  });
+
+  async function boot(): Promise<{ chatId: string }> {
+    const bin = dshBin;
+    if (bin === undefined) throw new Error('dsh CLI unavailable');
+    const server = mock;
+    if (server === undefined) throw new Error('mock LLM server unavailable');
+    child = spawn(bin, ['--profile', 'feishu-dev'], {
+      env: {
+        ...process.env,
+        DSH_HOME,
+        FEISHU_APP_ID: 'cli_mock_app',
+        FEISHU_APP_SECRET: 'mock_secret',
+        FEISHU_TRANSPORT: 'memory',
+        FEISHU_MEMORY_DIR: MEMORY_DIR,
+        FEISHU_MEMORY_ATTACHMENTS: ATTACH_DIR,
+        FEISHU_MOCK_BOT_OPEN_ID: 'ou_bot',
+        DEEPSEEK_API_KEY: 'mock_key',
+        DEEPSEEK_BASE_URL: server.url,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+      if (stdout.includes('[feishu] bridge ready')) bridgeReady = true;
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    await waitFor('the bridge to report ready', () => bridgeReady, 30_000);
+    const chatId = `oc_rt_${Date.now()}`;
+    await pinWorkingDir(chatId);
+    return { chatId };
+  }
+
+  /** The last request body the mock LLM received (agent's view of the turn). */
+  function agentLastBody(): unknown {
+    return mock?.lastRequestBody();
+  }
+
+  /** How many LLM completion requests the mock server has served. */
+  function llmRequestCount(): number {
+    return mock?.completionRequests() ?? 0;
+  }
+
+  it('a rich-text post with text and ordered attachments starts a turn carrying both', async () => {
+    const png = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82]);
+    seedAttachment('rt-img', png, 'image/png');
+    seedAttachment('rt-file', new TextEncoder().encode('rich text file body\n'));
+    const { chatId } = await boot();
+    const dir = join(INT_CWD, '.dsh_feishu', 'attachments', 'cli_mock_app', chatId);
+    // Normalized post: serialized text (order preserved) + ordered
+    // attachments (image then file).
+    sendMessage(
+      chatId,
+      '**Bold intro**\n<image 1>\n<file 2>',
+      [
+        { kind: 'image', key: 'rt-img' },
+        { kind: 'file', key: 'rt-file', name: 'notes.txt' },
+      ],
+      'om-post-1',
+    );
+    try {
+      await waitFor(
+        'the agent turn to carry the serialized text and BOTH saved paths',
+        () => {
+          const b = agentLastBody() as { messages?: unknown[] } | undefined;
+          const body = JSON.stringify(b?.messages ?? []);
+          return (
+            body.includes('**Bold intro**') &&
+            body.includes(join(dir, 'rt-img.png')) &&
+            body.includes(join(dir, 'notes.txt'))
+          );
+        },
+        90_000,
+      );
+    } catch (error) {
+      throw new Error(
+        `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}\n--- last body ---\n${JSON.stringify(agentLastBody())}`,
+      );
+    }
+  }, 150_000);
+
+  it('a text-less post (attachments only) registers as pending, drained by follow-up text', async () => {
+    seedAttachment('rt-a', new TextEncoder().encode('post only file\n'));
+    const { chatId } = await boot();
+    const dir = join(INT_CWD, '.dsh_feishu', 'attachments', 'cli_mock_app', chatId);
+    sendMessage(chatId, '', [{ kind: 'file', key: 'rt-a', name: 'only.txt' }], 'om-post-2');
+    // No turn yet — the file lands on disk.
+    try {
+      await waitFor('the pending file on disk', () => existsSync(join(dir, 'only.txt')), 30_000);
+    } catch (error) {
+      throw new Error(
+        `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}`,
+      );
+    }
+    expect(llmRequestCount()).toBe(0);
+    // The follow-up text drains it.
+    sendMessage(chatId, 'analyze it', undefined, 'om-post-2-followup');
+    try {
+      await waitFor(
+        'the saved path in the agent turn',
+        () => {
+          const b = agentLastBody() as { messages?: unknown[] } | undefined;
+          return JSON.stringify(b?.messages ?? []).includes(join(dir, 'only.txt'));
+        },
+        90_000,
+      );
+    } catch (error) {
+      throw new Error(
+        `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}\n--- last body ---\n${JSON.stringify(agentLastBody())}`,
+      );
+    }
+  }, 150_000);
+
+  it('a bare video message registers as pending and drains like a file', async () => {
+    seedAttachment('vid-1', new TextEncoder().encode('fake video bytes\n'));
+    const { chatId } = await boot();
+    const dir = join(INT_CWD, '.dsh_feishu', 'attachments', 'cli_mock_app', chatId);
+    sendMessage(chatId, '', [{ kind: 'file', key: 'vid-1', name: 'clip.mp4' }], 'om-vid-1');
+    try {
+      await waitFor('the pending video on disk', () => existsSync(join(dir, 'clip.mp4')), 30_000);
+    } catch (error) {
+      throw new Error(
+        `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}`,
+      );
+    }
+    expect(llmRequestCount()).toBe(0);
+    sendMessage(chatId, 'summarize this video', undefined, 'om-vid-1-followup');
+    try {
+      await waitFor(
+        'the video path in the agent turn',
+        () => {
+          const b = agentLastBody() as { messages?: unknown[] } | undefined;
+          return JSON.stringify(b?.messages ?? []).includes(join(dir, 'clip.mp4'));
+        },
+        90_000,
+      );
+    } catch (error) {
+      throw new Error(
+        `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}\n--- last body ---\n${JSON.stringify(agentLastBody())}`,
+      );
+    }
+  }, 150_000);
+});

--- a/tests/rich-text.spec.ts
+++ b/tests/rich-text.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for Feishu rich-text (`post`) serialization: order-preserving
+ * markdown-ish text with inline attachment placeholders, and the ordered
+ * attachment list.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { serializePost } from '../src/rich-text.js';
+
+describe('serializePost', () => {
+  it('serializes a mixed text+image+video post preserving element order', () => {
+    const content = JSON.stringify({
+      title: '',
+      content: [
+        [{ tag: 'text', text: 'First line:', style: ['bold'] }],
+        [{ tag: 'img', image_key: 'img_1' }],
+        [
+          { tag: 'text', text: 'Second: ' },
+          { tag: 'text', text: 'under', style: ['underline'] },
+        ],
+        [{ tag: 'media', file_key: 'file_v', image_key: 'img_cover' }],
+      ],
+    });
+    const result = serializePost(content);
+    expect(result?.text).toBe('**First line:**\n<image 1>\nSecond: <u>under</u>\n<video 2>');
+    expect(result?.attachments).toEqual([
+      { kind: 'image', key: 'img_1' },
+      { kind: 'file', key: 'file_v' },
+    ]);
+  });
+
+  it('maps links, at-mentions, code blocks, hr, and styles', () => {
+    const content = JSON.stringify({
+      title: '',
+      content: [
+        [
+          { tag: 'text', text: 'bold', style: ['bold'] },
+          { tag: 'text', text: 'struck', style: ['lineThrough'] },
+        ],
+        [{ tag: 'a', href: 'https://x.dev', text: 'link' }],
+        [{ tag: 'at', user_id: 'ou_1', user_name: 'Alice' }],
+        [{ tag: 'code_block', language: 'PYTHON', text: 'print(1)' }],
+        [{ tag: 'hr' }],
+      ],
+    });
+    expect(serializePost(content)?.text).toBe(
+      '**bold**~~struck~~\n[link](https://x.dev)\n@Alice\n```PYTHON\nprint(1)\n```\n---',
+    );
+  });
+
+  it('prefers the client-authored md field with image tokens rewritten to placeholders', () => {
+    const content = JSON.stringify({
+      title: '',
+      md: '**Bold** text\n\n![img](img_1)\n\n![video](file_v)',
+      content: [
+        [{ tag: 'img', image_key: 'img_1' }],
+        [{ tag: 'media', file_key: 'file_v', image_key: 'img_c' }],
+      ],
+    });
+    const result = serializePost(content);
+    expect(result?.text).toContain('**Bold** text');
+    expect(result?.text).toContain('<image 1>');
+    expect(result?.text).toContain('<video 2>');
+    expect(result?.attachments).toEqual([
+      { kind: 'image', key: 'img_1' },
+      { kind: 'file', key: 'file_v' },
+    ]);
+  });
+
+  it('returns the md text alone when it carries no attachments', () => {
+    const content = JSON.stringify({
+      title: '',
+      md: 'Just **formatted** text',
+      content: [],
+    });
+    expect(serializePost(content)).toEqual({ text: 'Just **formatted** text', attachments: [] });
+  });
+
+  it('skips unknown tags (forward-compat) without breaking the rest', () => {
+    const content = JSON.stringify({
+      title: '',
+      content: [[{ tag: 'fancy_new_tag', something: 'x' }], [{ tag: 'text', text: 'survives' }]],
+    });
+    expect(serializePost(content)?.text).toBe('survives');
+  });
+
+  it('returns undefined for malformed JSON', () => {
+    expect(serializePost('not json')).toBeUndefined();
+  });
+
+  it('returns undefined when there is no text and no attachments', () => {
+    expect(serializePost(JSON.stringify({ title: '', content: [] }))).toBeUndefined();
+  });
+
+  it('emotion elements render as their emoji type', () => {
+    const content = JSON.stringify({
+      title: '',
+      content: [[{ tag: 'emotion', emoji_type: 'THUMBSUP' }]],
+    });
+    expect(serializePost(content)?.text).toBe('THUMBSUP');
+  });
+});

--- a/tests/transport.spec.ts
+++ b/tests/transport.spec.ts
@@ -134,6 +134,49 @@ describe('normalizeMessageEvent', () => {
     const message = normalizeMessageEvent(rawEvent({ message: { content: 'not json' } }));
     expect(message).toBeUndefined();
   });
+
+  it('normalizes a rich-text post into serialized text + ordered attachments', () => {
+    const message = normalizeMessageEvent(
+      rawEvent({
+        message: {
+          message_type: 'post',
+          content: JSON.stringify({
+            title: '',
+            content: [
+              [{ tag: 'text', text: 'First:', style: ['bold'] }],
+              [{ tag: 'img', image_key: 'img_1' }],
+              [{ tag: 'media', file_key: 'file_v', image_key: 'img_c' }],
+            ],
+          }),
+        },
+      }),
+    );
+    expect(message?.text).toBe('**First:**\n<image 1>\n<video 2>');
+    expect(message?.attachments).toEqual([
+      { kind: 'image', key: 'img_1' },
+      { kind: 'file', key: 'file_v' },
+    ]);
+  });
+
+  it('normalizes a video message into a file attachment', () => {
+    const message = normalizeMessageEvent(
+      rawEvent({
+        message: {
+          message_type: 'video',
+          content: JSON.stringify({ file_key: 'file_v1', image_key: 'img_c1' }),
+        },
+      }),
+    );
+    expect(message?.text).toBe('');
+    expect(message?.attachments).toEqual([{ kind: 'file', key: 'file_v1' }]);
+  });
+
+  it('ignores a malformed post content', () => {
+    const message = normalizeMessageEvent(
+      rawEvent({ message: { message_type: 'post', content: 'not json' } }),
+    );
+    expect(message).toBeUndefined();
+  });
 });
 
 describe('normalizeCardAction', () => {


### PR DESCRIPTION
## What

- **Rich-text (post) support.** A `post` message is no longer silently dropped. New `src/rich-text.ts` serializes its 2-D element array into a linearized markdown-ish string that PRESERVES the inline order (text / image / video / file in one bubble — the intra-bubble order is information), with inline `<image N>` / `<video N>` / `<file N>` placeholders and an ordered attachment list. Formatting maps to markdown (`**bold**`, `*italic*`, `~~strike~~`, `<u>under</u>`, `[link](url)`, `@name`, fenced code blocks, `---` hr, emoji). The client-authored `md` field is preferred when present (its `![img](image_key)` tokens rewritten to placeholders); the element array is the fallback; unknown tags degrade gracefully.
- **Video support.** A `video` message normalizes to a plain `file` attachment (its `file_key`); `type=file` on the message-resource API serves video — no new download endpoint.
- **Routing reuses the existing paths.** A post with text starts a turn immediately (serialized text + ordered attachments via the unified inbound-attachments path); an attachment-only post and a bare video register as pending (inbound-wait-instruction) and drain on the follow-up text.

## Why

User-reported: Feishu supports rich text (bold / lists / quotes / links / code blocks) and videos, and you can put image+text in one bubble — but the surface's `SUPPORTED_MESSAGE_TYPES` was `['text','image','file']`, so all of that was silently dropped (no receipt, no save, no turn). This makes rich-text posts and videos first-class, preserving the intra-bubble order the user asked for.

## Docs

- `docs/ux-specification.md` + `.zh.md`: new `inbound-rich-text` part (post content model, serialization mapping, video-as-file, routing, failure modes, acceptance; cites the Feishu content spec and resource-API type coverage).
- `docs/features.md` + `.zh.md`: `inbound-rich-text` row flips to shipped.
- `CHANGELOG.md`: Added entry.
- README untouched (maintainer-gated).

## Verification

- Unit: `tests/rich-text.spec.ts` (8 cases: mixed text+image+video order, styles/links/at/code/hr, md-field preference, md-without-attachments, unknown-tag skip, malformed JSON, empty content, emotion); `tests/transport.spec.ts` +3 (post normalization with ordered attachments, video → file attachment, malformed post ignored).
- Integration (`tests/integration/inbound-rich-text.spec.ts`, new): post with text + ordered attachments starts a turn carrying both saved paths; text-less post registers pending, drained by follow-up; bare video registers pending, drained like a file.
- Full matrix green: lint, typecheck, build, `FEISHU_INT_REQUIRED=1 vitest run` → **559 tests pass** (26 files, incl. all real-composition suites).