### PR TITLE
fix: sniff video container extensions for inbound videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,12 @@ stable-rc.7 line; newer dsh releases (`@next`) are tracked on `main`.
 
 ### Fixed
 
+- **Inbound videos saved with a `.bin` extension.** `sniffExtension` did not
+  recognize video containers (MP4/MOV `ftyp`, WebM/MKV EBML, AVI `RIFF`), so
+  a `video` message — whose content carries no `file_name`, falling back to
+  the resource key — landed as `<key>.bin`. The sniffer now maps those magic
+  bytes to `mp4` / `webm` / `avi` (and this also fixed the WebP branch, whose
+  `RIFF`+`WEBP` check read an 8-byte head and never matched).
 - **Group messages without an @ are silently dropped on fresh apps** (user
   report: a 1-user-1-bot group stopped answering un-@ messages after the
   app was recreated). Two compounding setup bugs meant **no scopes were

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -89,7 +89,20 @@ export function sniffExtension(data: Uint8Array): string {
   if (startsWith([0x89, 0x50, 0x4e, 0x47])) return 'png';
   if (startsWith([0xff, 0xd8, 0xff])) return 'jpg';
   if (text.startsWith('GIF8')) return 'gif';
-  if (startsWith([0x52, 0x49, 0x46, 0x46]) && text.slice(8, 12) === 'WEBP') return 'webp';
+  if (
+    startsWith([0x52, 0x49, 0x46, 0x46]) &&
+    String.fromCharCode(data[8] ?? 0, data[9] ?? 0, data[10] ?? 0, data[11] ?? 0) === 'WEBP'
+  )
+    return 'webp';
+  if (
+    startsWith([0x52, 0x49, 0x46, 0x46]) &&
+    String.fromCharCode(data[8] ?? 0, data[9] ?? 0, data[10] ?? 0, data[11] ?? 0) === 'AVI '
+  )
+    return 'avi';
+  // MP4/MOV (ISO BMFF): the `ftyp` box starts at offset 4.
+  if (data[4] === 0x66 && data[5] === 0x74 && data[6] === 0x79 && data[7] === 0x70) return 'mp4';
+  // WebM/MKV (EBML): 1A 45 DF A3.
+  if (startsWith([0x1a, 0x45, 0xdf, 0xa3])) return 'webm';
   if (text.startsWith('{"') || text.startsWith('[{')) return 'json';
   if (text.startsWith('<?xml')) return 'xml';
   // Plain text (no control bytes in the head) → txt.

--- a/tests/bridge.spec.ts
+++ b/tests/bridge.spec.ts
@@ -399,6 +399,20 @@ describe('Bridge', () => {
       expect(sniffExtension(enc('GIF89a'))).toBe('gif');
     });
 
+    it('detects video containers from their magic bytes', () => {
+      // MP4/MOV: 'ftyp' at offset 4 (ISO BMFF).
+      const mp4 = new Uint8Array([
+        0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d,
+      ]);
+      expect(sniffExtension(mp4)).toBe('mp4');
+      // WebM/MKV: EBML magic 1A 45 DF A3.
+      const webm = new Uint8Array([0x1a, 0x45, 0xdf, 0xa3, 0x01, 0x00, 0x00, 0x00]);
+      expect(sniffExtension(webm)).toBe('webm');
+      // AVI: 'RIFF' + 'AVI ' at offset 8.
+      const avi = enc('RIFF\x24\x00\x00\x00AVI LIST');
+      expect(sniffExtension(avi)).toBe('avi');
+    });
+
     it('classifies printable text as txt and unknown binary as bin', () => {
       expect(sniffExtension(enc('hello world\n'))).toBe('txt');
       expect(sniffExtension(new Uint8Array([0x00, 0x01, 0xff, 0xfe]))).toBe('bin');


### PR DESCRIPTION
## What

- `sniffExtension` now recognizes video containers: MP4/MOV (`ftyp` at offset 4 → `mp4`), WebM/MKV (EBML `1A 45 DF A3` → `webm`), AVI (`RIFF`+`AVI ` → `avi`).
- Also fixes the existing WebP branch, whose `RIFF`+`WEBP` check sliced an 8-byte head (`text.slice(8,12)` on an 8-byte view is always empty) — WebP was never actually detected; it now reads the 12-byte offset from the full data.

## Why

User-reported: an inbound video saved as `<key>.bin`. A `video` message's content carries no `file_name` (only `file_key` + `image_key`), so the on-disk name falls back to the resource key and the extension comes solely from sniffing — which had no video branch, so every video landed as `.bin`.

## Docs

- `CHANGELOG.md`: Fixed entry (video sniff + the WebP branch correction).
- README untouched (maintainer-gated). No other doc surface affected.

## Verification

- Regression test first: `tests/bridge.spec.ts` → "detects video containers from their magic bytes" failed with `expected 'bin' to be 'mp4'` before the fix, passes after (mp4 / webm / avi).
- Full matrix green: lint, typecheck, build, `FEISHU_INT_REQUIRED=1 vitest run` → **560 tests pass**.
- Test bot restarted on the fixed build; a real video send now saves as `file_v3_xxx.mp4` (or webm/avi by container).