### PR TITLE
fix: valid reaction emoji for error/stopped turns; handle inbound audio messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -295,6 +295,15 @@ stable-rc.7 line; newer dsh releases (`@next`) are tracked on `main`.
   the resource key — landed as `<key>.bin`. The sniffer now maps those magic
   bytes to `mp4` / `webm` / `avi` (and this also fixed the WebP branch, whose
   `RIFF`+`WEBP` check read an 8-byte head and never matched).
+- **Turn-termination reaction ack 400s.** The terminal emoji for an error or
+  stopped turn defaulted to `WARN`, which is NOT a valid Feishu `emoji_type`
+  (the platform's reaction table has no WARN) — the swap always failed with
+  a 400 (logged, non-blocking). The defaults are now `ERROR` / `ERROR`
+  (valid), so stopped/error turns ack cleanly.
+- **Inbound audio (voice) messages are now handled.** Feishu voice bubbles
+  arrive as `message_type: 'audio'`, which the surface silently dropped; the
+  type now joins the supported set and routes through the file path like a
+  video (its `file_key` downloads via `type=file`).
 - **Group messages without an @ are silently dropped on fresh apps** (user
   report: a 1-user-1-bot group stopped answering un-@ messages after the
   app was recreated). Two compounding setup bugs meant **no scopes were

--- a/docs/ux-specification.md
+++ b/docs/ux-specification.md
@@ -951,11 +951,11 @@ cards stay in chat history. No panel views.
 ### Intended behavior
 
 **Trigger** — an inbound message whose `message_type` is `post` (rich text)
-or `video`. Today the surface's `SUPPORTED_MESSAGE_TYPES` is
-`['text','image','file']`, so both are silently ignored — the user's
-formatted message (bold / lists / quotes / links / code blocks) or video
-vanishes with no receipt, no save, no turn. This feature makes them first-
-class.
+or `video` (or `audio` — voice bubbles; the same `type=file` download
+path serves them). These were silently ignored: the user's formatted
+message (bold / lists / quotes / links / code blocks), video, or voice
+vanishes with no receipt, no save, no turn. This feature makes them
+first-class.
 
 **Feishu `post` content model** — a rich-text message's `content` is a
 2-D JSON array of inline element groups:
@@ -1014,21 +1014,21 @@ print(1)
    the saved path via the ordered note list (the existing
    `[user sent a file: … — saved at …]` notes).
 
-**`video` message** — `message_type: 'video'` with `file_key` (+ `image_key`
-cover). Normalizes to a single `file`-kind attachment (the video body),
-exactly like a bare file message — it registers as pending and the follow-up
-text drains it. `im.v1.messageResource.get?type=file` serves video (the
-resource API's `type=file` covers files, audio, AND video), so no new
-download path is needed.
+**`video` / `audio` messages** — `message_type: 'video'` (with `file_key` +
+`image_key` cover) and `message_type: 'audio'` (voice bubble, `file_key` +
+`duration`) normalize to a single `file`-kind attachment (the media body),
+exactly like a bare file message — they register as pending and the
+follow-up text drains them. `im.v1.messageResource.get?type=file` serves
+files, audio, AND video, so no new download path is needed.
 
 **Routing (reuses the sibling parts)** — after normalization:
 
 - `post` with non-empty text → the existing mixed path: immediate turn, the
   serialized text as the `text` block and the attachments injected in
   placeholder order (the inbound-attachments part's unified path).
-- `post` with text empty (attachments only) / bare `video` → the
-  inbound-wait-instruction pending path (receipt card, no turn, drained by
-  the follow-up text).
+- `post` with text empty (attachments only) / bare `video` / bare `audio` →
+  the inbound-wait-instruction pending path (receipt card, no turn, drained
+  by the follow-up text).
 - `post` with neither text nor attachments → ignored with a loud log (no
   usable content).
 
@@ -1046,7 +1046,7 @@ card like any text message; attachment-only posts / videos use the existing
   tags degrade gracefully rather than breaking the parse).
 - Attachment download/save fails inside a rich-text post: the sibling
   degraded-receipt path (loud log, name-only note, never wedges).
-- `video` message with a stale key: same download-failure path.
+- `video` / `audio` message with a stale key: same download-failure path.
 
 **Acceptance checklist**:
 - [ ] `post` with text + bold/link/code/at → agent's user message carries the
@@ -1059,6 +1059,8 @@ card like any text message; attachment-only posts / videos use the existing
       drains) (integration)
 - [ ] `video` message → pending like a bare file, drained by follow-up text
       (unit + integration)
+- [ ] `audio` (voice) message → pending like a bare file, drained by
+      follow-up text (unit)
 - [ ] `post` with `md` field → `md`-based serialization preferred (unit)
 - [ ] `post` malformed content → loud log, no crash, message not delivered
       as raw JSON (unit)

--- a/docs/ux-specification.zh.md
+++ b/docs/ux-specification.zh.md
@@ -483,9 +483,9 @@ turn 运行中到达的新裸附件消息只追加（不影响正在跑的 turn�
 
 ### 预期行为
 
-**触发** —— `message_type` 为 `post`（富文本）或 `video` 的入站消息。现状
-`SUPPORTED_MESSAGE_TYPES` 是 `['text','image','file']`，两者都被静默忽略——
-用户带格式的消息（加粗/列表/引用/链接/代码块）或视频无回执、无保存、无
+**触发** —— `message_type` 为 `post`（富文本）、`video` 或 `audio`（语音条；
+同一 `type=file` 下载路径服务它们）的入站消息。它们曾被静默忽略——用户带
+格式的消息（加粗/列表/引用/链接/代码块）、视频或语音无回执、无保存、无
 turn 地消失。本特性让它们成为一等公民。
 
 **飞书 `post` content 模型** —— 富文本消息的 `content` 是二维 JSON 数组：
@@ -538,22 +538,23 @@ print(1)
    agent 通过有序的 `[user sent a file: … — saved at …]` 备注把 `<image N>`
    与真实保存路径对应起来。
 
-**`video` 消息** —— `message_type: 'video'`，content 含 `file_key`（+ 封面
-`image_key`）。归一化为单个 `file` 类附件（视频本体），与裸文件消息完全一样
-——登记为 pending，跟进文字排空。`im.v1.messageResource.get?type=file` 服务
-视频（资源 API 的 `type=file` 覆盖文件、音频和视频），无需新下载路径。
+**`video` / `audio` 消息** —— `message_type: 'video'`（content 含 `file_key`
++ 封面 `image_key`）与 `message_type: 'audio'`（语音条，`file_key` +
+`duration`）归一化为单个 `file` 类附件（媒体本体），与裸文件消息完全一样
+——登记为 pending，跟进文字排空。`im.v1.messageResource.get?type=file`
+服务文件、音频和视频，无需新下载路径。
 
 **路由（复用兄弟 part）** —— 归一化后：
 
 - `post` 带文字 → 现有混合路径：立即 turn，序列化文本作为 `text` 块，附件
   按占位符顺序注入（inbound-attachments part 的统一路径）。
-- `post` 文字为空（仅附件）/ 裸 `video` → inbound-wait-instruction 的 pending
-  路径（回执卡、不触发 turn、由跟进文字排空）。
+- `post` 文字为空（仅附件）/ 裸 `video` / 裸 `audio` → inbound-wait-instruction
+  的 pending 路径（回执卡、不触发 turn、由跟进文字排空）。
 - `post` 既无文字也无附件 → 响亮日志忽略（无可用内容）。
 
 **卡片/面板形态** —— 无新增。带文字的富文本用 streaming 卡（与普通文字
-消息一致）；纯附件 post / 视频用现有 `📎 File received` pending 回执卡。
-无按钮、无面板视图。
+消息一致）；纯附件 post / 视频 / 语音用现有 `📎 File received` pending
+回执卡。无按钮、无面板视图。
 
 **失败模式**：
 - `post` content JSON 解析失败：降级为纯文本提示 + 响亮日志——原始 content
@@ -562,7 +563,7 @@ print(1)
 - 未知元素 tag：debug 日志跳过（向前兼容——新飞书 tag 优雅降级而非破坏解析）。
 - post 内附件下载/保存失败：兄弟特性的降级回执路径（响亮日志、仅名称备注、
   绝不卡死）。
-- `video` 消息 key 过期：同下载失败路径。
+- `video` / `audio` 消息 key 过期：同下载失败路径。
 
 **验收清单**：
 - [ ] `post` 带文字 + 加粗/链接/代码/at → agent 用户消息带序列化 markdown
@@ -572,6 +573,7 @@ print(1)
 - [ ] `post` 带文字 → 立即 turn（单测 + 集成）
 - [ ] `post` 仅附件 → pending（回执卡、无 turn；跟进文字排空）（集成）
 - [ ] `video` 消息 → 像裸文件一样 pending，跟进文字排空（单测 + 集成）
+- [ ] `audio`（语音）消息 → 像裸文件一样 pending，跟进文字排空（单测）
 - [ ] `post` 有 `md` 字段 → 优先 `md` 序列化（单测）
 - [ ] `post` content 损坏 → 响亮日志、不崩溃、原始 JSON 不投递（单测）
 - [ ] 未知 tag → debug 日志跳过，其余 post 完整（单测）

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -396,8 +396,9 @@ export interface BridgeOptions {
   /**
    * Two-stage reaction ack emojis: `received` is added to an accepted turn
    * message, then swapped for `done` / `error` / `stopped` when the turn
-   * settles. Defaults GoGoGo / DONE / WARN / WARN (botmux codes). Reaction
-   * failures only log — they never block the turn.
+   * settles. Defaults GoGoGo / DONE / ERROR / ERROR — valid Feishu
+   * `emoji_type` values (WARN is not in the platform's reaction table).
+   * Reaction failures only log — they never block the turn.
    */
   readonly reactions?: {
     readonly received?: string;

--- a/src/cards/StreamingCardController.ts
+++ b/src/cards/StreamingCardController.ts
@@ -252,8 +252,8 @@ export class StreamingCardController {
     return {
       received: reactions?.received ?? 'GoGoGo',
       done: reactions?.done ?? 'DONE',
-      error: reactions?.error ?? 'WARN',
-      stopped: reactions?.stopped ?? 'WARN',
+      error: reactions?.error ?? 'ERROR',
+      stopped: reactions?.stopped ?? 'ERROR',
     };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,8 +116,9 @@ export interface Config {
   readonly requireWorkingDir?: boolean;
   /**
    * Two-stage reaction ack emojis (received / done / error / stopped).
-   * Defaults GoGoGo / DONE / WARN / WARN. Set `received` to '' to disable
-   * the ack entirely.
+   * Defaults GoGoGo / DONE / ERROR / ERROR — valid Feishu `emoji_type`
+   * values (WARN is NOT in the platform's reaction table and the ack 400s).
+   * Set `received` to '' to disable the ack entirely.
    */
   readonly reactions?: {
     readonly received?: string;

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -113,7 +113,7 @@ export class FeishuApiError extends Error {
 const MENTION_PATTERN = /<at[^>]*>.*?<\/at>/g;
 
 /** Message types the surface understands; everything else is ignored. */
-const SUPPORTED_MESSAGE_TYPES = new Set(['text', 'image', 'file', 'post', 'video']);
+const SUPPORTED_MESSAGE_TYPES = new Set(['text', 'image', 'file', 'post', 'video', 'audio']);
 
 /** Parse an image/file message's content JSON into its attachment, or
  *  `undefined` when the content is malformed. */

--- a/tests/bridge.spec.ts
+++ b/tests/bridge.spec.ts
@@ -4204,7 +4204,7 @@ describe('two-stage reaction ack', () => {
     ]);
   });
 
-  it('swaps to WARN on error and stopped', async () => {
+  it('swaps to ERROR on error and stopped (WARN is not a valid Feishu emoji_type)', async () => {
     for (const reason of ['error', 'aborted']) {
       const h = makeHarness({ throttleMs: 0 });
       await h.bridge.handleMessage(message());
@@ -4216,7 +4216,7 @@ describe('two-stage reaction ack', () => {
       );
       await new Promise((resolve) => setTimeout(resolve, 0));
       const adds = h.transport.reactions.filter((r) => r.action === 'add').map((r) => r.emojiType);
-      expect(adds).toEqual(['GoGoGo', 'WARN']);
+      expect(adds).toEqual(['GoGoGo', 'ERROR']);
       expect(h.transport.reactions.some((r) => r.action === 'remove')).toBe(true);
     }
   });

--- a/tests/integration/real-composition.spec.ts
+++ b/tests/integration/real-composition.spec.ts
@@ -2868,14 +2868,14 @@ describe.skipIf(!integrationReady)('real-composition integration', () => {
         90_000,
       );
       await waitFor(
-        'the WARN reaction swap',
+        'the ERROR reaction swap',
         () =>
           readOutbox().some(
             (r) =>
               r.kind === 'reaction' &&
               r.messageId === messageId &&
               r.action === 'add' &&
-              r.emojiType === 'WARN',
+              r.emojiType === 'ERROR',
           ),
         30_000,
       );
@@ -2884,7 +2884,7 @@ describe.skipIf(!integrationReady)('real-composition integration', () => {
       );
       expect(records[0]).toMatchObject({ action: 'add', emojiType: 'GoGoGo' });
       expect(records[1]).toMatchObject({ action: 'remove', reactionId: records[0]?.reactionId });
-      expect(records[2]).toMatchObject({ action: 'add', emojiType: 'WARN' });
+      expect(records[2]).toMatchObject({ action: 'add', emojiType: 'ERROR' });
     } catch (error) {
       throw new Error(
         `${String(error)}\n--- dsh stderr ---\n${stderr}\n--- dsh stdout ---\n${stdout}`,

--- a/tests/integration/scenarios.spec.ts
+++ b/tests/integration/scenarios.spec.ts
@@ -1153,14 +1153,14 @@ describe.skipIf(!integrationReady)('scenario integration (real process)', () => 
         value: { kind: 'stop' },
       });
       // The aborted turn settles the card orange; the pending reaction is
-      // swapped (remove + add WARN). The aborted loop may race, so wait for
+      // swapped (remove + add ERROR). The aborted loop may race, so wait for
       // the swap rather than asserting timing.
       await waitFor(
         'the stopped reaction swap',
         () => {
           const records = readOutbox().filter((r) => r.kind === 'reaction');
           return (
-            records.some((r) => r.action === 'add' && r.emojiType === 'WARN') &&
+            records.some((r) => r.action === 'add' && r.emojiType === 'ERROR') &&
             records.some((r) => r.action === 'remove')
           );
         },

--- a/tests/transport.spec.ts
+++ b/tests/transport.spec.ts
@@ -171,6 +171,19 @@ describe('normalizeMessageEvent', () => {
     expect(message?.attachments).toEqual([{ kind: 'file', key: 'file_v1' }]);
   });
 
+  it('normalizes an audio (voice) message into a file attachment', () => {
+    const message = normalizeMessageEvent(
+      rawEvent({
+        message: {
+          message_type: 'audio',
+          content: JSON.stringify({ file_key: 'file_a1', duration: '5000' }),
+        },
+      }),
+    );
+    expect(message?.text).toBe('');
+    expect(message?.attachments).toEqual([{ kind: 'file', key: 'file_a1' }]);
+  });
+
   it('ignores a malformed post content', () => {
     const message = normalizeMessageEvent(
       rawEvent({ message: { message_type: 'post', content: 'not json' } }),


### PR DESCRIPTION
## What

- **Fix: turn-termination reaction ack 400s.** The terminal emoji for an error or stopped turn defaulted to `WARN`, which is NOT in Feishu's reaction table (valid `emoji_type` values are a fixed set — OK / THUMBSUP / DONE / ERROR / …). Every error/stopped ack 400ed (logged, non-blocking). Defaults are now `ERROR` / `ERROR`; config docs and the WARN-asserting tests updated.
- **Feat: inbound audio (voice) messages.** Feishu voice bubbles arrive as `message_type: 'audio'`, which the surface silently dropped (not in `SUPPORTED_MESSAGE_TYPES`). The type now joins the set and routes through the existing file path — its `file_key` downloads via `type=file` on the message-resource API, registers as pending like a video, and drains on the follow-up text.

## Why

Two small noises surfaced while testing the F1.5 inbound work: (1) the reaction ack 400 on every stopped/error turn (WARN is not a valid Feishu emoji_type — confirmed against the platform's reaction table); (2) voice bubbles vanished with no receipt, no save, no turn — audio is a distinct message_type, not a file attachment, so it needs the type added (the download path already covers it: `type=file` serves files, audio, AND video).

## Docs

- `CHANGELOG.md`: Fixed entry (reaction emoji) + Added entry (audio messages).
- `docs/ux-specification.md` + `.zh.md`: inbound-rich-text part now covers audio (trigger, video/audio paragraph, routing, failure modes, acceptance).
- README untouched (maintainer-gated).

## Verification

- Unit: `tests/bridge.spec.ts` — "swaps to ERROR on error and stopped" (was WARN); `tests/transport.spec.ts` +1 — audio normalizes to a file attachment.
- Integration: `tests/integration/real-composition.spec.ts` + `scenarios.spec.ts` WARN assertions updated to ERROR.
- Full matrix green: lint, typecheck, build, `FEISHU_INT_REQUIRED=1 vitest run` → **561 tests pass**.