### PR TITLE
feat: reply loudly to known-but-unhandled Feishu message types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,6 +304,12 @@ stable-rc.7 line; newer dsh releases (`@next`) are tracked on `main`.
   arrive as `message_type: 'audio'`, which the surface silently dropped; the
   type now joins the supported set and routes through the file path like a
   video (its `file_key` downloads via `type=file`).
+- **Known-but-unhandled message types reply loudly instead of vanishing.**
+  A `folder` (or sticker / share_chat / share_user / system / media /
+  merge / interactive) message is no longer silently dropped: the bridge
+  replies `⚠️ I can't process messages of type '…' yet.` (folders get the
+  extra note that folder contents cannot be downloaded via the API — send
+  files or a zip instead). Unknown types stay ignored.
 - **Group messages without an @ are silently dropped on fresh apps** (user
   report: a 1-user-1-bot group stopped answering un-@ messages after the
   app was recreated). Two compounding setup bugs meant **no scopes were

--- a/docs/ux-specification.md
+++ b/docs/ux-specification.md
@@ -704,8 +704,14 @@ arrive in a p2p chat or a group (mention gate applies exactly as for text).
 | `file` | `{"file_key": "file_v2_…"}` | `text: ''`, one file attachment |
 
 `FeishuMessage` gains an optional `attachments` array
-(`{kind:'image'|'file'; key: string; name?: string}`). Unknown types stay
-ignored. A mixed message is not a Feishu concept — each message is one type.
+(`{kind:'image'|'file'; key: string; name?: string}`). A message whose
+`message_type` is a KNOWN but unhandled Feishu type (folder, sticker,
+share_chat, share_user, system, media, merge, interactive) normalizes with
+`unsupportedType` set, and the bridge replies with a loud notice instead of
+dropping it silently — a user sending a folder must learn the bot cannot
+process it (folder contents are not downloadable via the API). Unknown
+types (not in the platform's vocabulary) stay ignored. A mixed message is
+not a Feishu concept — each message is one type.
 
 **Unified attachment path (every attachment is a file)** — a Feishu image
 is a plain file to the agent: it is downloaded through the message-resource

--- a/docs/ux-specification.zh.md
+++ b/docs/ux-specification.zh.md
@@ -356,7 +356,7 @@ bridge 记住每个聊天的**最近被接受的发送者**（及其聊天类型
 | `image` | `{"image_key": "img_v2_…"}` | `text: ''`，一个 image 附件 |
 | `file` | `{"file_key": "file_v2_…"}` | `text: ''`，一个 file 附件 |
 
-`FeishuMessage` 增加可选 `attachments` 数组（`{kind:'image'|'file'; key: string; name?: string}`）。未知类型继续忽略。每条消息只有一种类型（飞书不支持混合消息）。
+`FeishuMessage` 增加可选 `attachments` 数组（`{kind:'image'|'file'; key: string; name?: string}`）。`message_type` 为**已知但未处理**的飞书类型（folder、sticker、share_chat、share_user、system、media、merge、interactive）时归一化为带 `unsupportedType` 的消息，bridge 回复响亮提示而非静默丢弃——用户发文件夹必须知道 bot 处理不了（文件夹内容无法通过 API 下载）。完全未知的类型仍忽略。每条消息只有一种类型（飞书不支持混合消息）。
 
 **统一附件路径（所有附件都是文件）** —— 飞书图片对 agent 就是普通文件：transport 通过**消息资源端点**下载图片字节（`im.v1.messageResource.get` —— `/messages/{message_id}/resources/{image_key}?type=image`；`im.v1.image.get` 只能下载机器人自己上传的图片，所以用户发的图片必须走 message-resource API；复用现有 `im:resource` scope），然后与文件一样保存进同一附件目录、由 agent 按路径读取。**没有 image 内容块 / 视觉输入路径**——裸图片消息像裸文件一样登记为 pending（见 inbound-wait-instruction part），agent 读取已保存的文件。这对应了"DSH Web 把图片粘贴进输入框"的能力在飞书场景没有意义这一决定。
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -665,6 +665,22 @@ export class Bridge {
   async handleMessage(message: FeishuMessage): Promise<void> {
     if (!this.dedup.claim(message.messageId)) return;
     if (!(await this.shouldRespond(message))) return;
+    // A known-but-unhandled Feishu message type (folder, sticker, …) gets a
+    // loud notice instead of vanishing — the user must learn the bot cannot
+    // process it (misconfiguration fails loud). No turn, no pending.
+    if (message.unsupportedType !== undefined) {
+      this.options.logger.info(
+        `message ${message.messageId}: unsupported type ${message.unsupportedType} (chat ${message.chatId})`,
+      );
+      await this.options.transport.sendText(
+        message.chatId,
+        `⚠️ I can't process messages of type \`${message.unsupportedType}\` yet.` +
+          (message.unsupportedType === 'folder'
+            ? ' Folder contents cannot be downloaded via the API — please send the files individually or as a zip archive instead.'
+            : ''),
+      );
+      return;
+    }
     this.lastInboundAtValue = Date.now();
     this.options.logger.info(
       `inbound message ${message.messageId} in ${message.chatId} (${message.chatType}): ${message.text.slice(0, 80)}`,

--- a/src/feishu/types.ts
+++ b/src/feishu/types.ts
@@ -30,6 +30,14 @@ export interface FeishuMessage {
    * key the transport can download (image_key / file_key).
    */
   readonly attachments: readonly InboundAttachment[];
+  /**
+   * Set when the message's `message_type` is a KNOWN Feishu type the surface
+   * does not handle (folder, sticker, share_chat, system, …). The bridge
+   * replies with a loud unsupported-type notice instead of silently dropping
+   * the message (misconfiguration fails loud; a user sending a folder must
+   * learn the bot cannot process it). `undefined` for handled messages.
+   */
+  readonly unsupportedType?: string;
   /** Unix epoch milliseconds from the Feishu `create_time` string. */
   readonly createdAt: number;
 }

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -115,6 +115,24 @@ const MENTION_PATTERN = /<at[^>]*>.*?<\/at>/g;
 /** Message types the surface understands; everything else is ignored. */
 const SUPPORTED_MESSAGE_TYPES = new Set(['text', 'image', 'file', 'post', 'video', 'audio']);
 
+/**
+ * Feishu `message_type` values the platform defines but this surface does
+ * NOT handle. Instead of silently dropping them (a user sending a folder or
+ * sticker would get zero feedback), they normalize into a message carrying
+ * `unsupportedType` so the bridge can reply with a loud notice. Unknown
+ * types (not in this set either) stay ignored — no invented feedback.
+ */
+const KNOWN_UNSUPPORTED_MESSAGE_TYPES = new Set([
+  'folder',
+  'sticker',
+  'share_chat',
+  'share_user',
+  'system',
+  'media',
+  'merge',
+  'interactive',
+]);
+
 /** Parse an image/file message's content JSON into its attachment, or
  *  `undefined` when the content is malformed. */
 function parseAttachment(content: string, messageType: string): InboundAttachment | undefined {
@@ -145,7 +163,25 @@ function parseAttachment(content: string, messageType: string): InboundAttachmen
  */
 export function normalizeMessageEvent(data: RawMessageEvent): FeishuMessage | undefined {
   const message = data.message;
-  if (!SUPPORTED_MESSAGE_TYPES.has(message.message_type)) return undefined;
+  if (!SUPPORTED_MESSAGE_TYPES.has(message.message_type)) {
+    // A known-but-unhandled Feishu type (folder, sticker, …) is surfaced as
+    // an unsupported-type notice instead of vanishing; unknown types are
+    // still ignored.
+    if (KNOWN_UNSUPPORTED_MESSAGE_TYPES.has(message.message_type)) {
+      return {
+        messageId: message.message_id,
+        chatId: message.chat_id,
+        chatType: message.chat_type === 'group' ? 'group' : 'p2p',
+        senderOpenId: data.sender?.sender_id?.open_id ?? '',
+        text: '',
+        attachments: [],
+        mentions: [],
+        unsupportedType: message.message_type,
+        createdAt: Number(message.create_time) || Date.now(),
+      };
+    }
+    return undefined;
+  }
   const senderOpenId = data.sender?.sender_id?.open_id ?? '';
   let text = '';
   let attachments: InboundAttachment[] = [];

--- a/tests/bridge.spec.ts
+++ b/tests/bridge.spec.ts
@@ -633,9 +633,7 @@ describe('Bridge', () => {
 
   it('replies with a loud notice for a known-but-unhandled message type', async () => {
     const h = makeHarness();
-    await h.bridge.handleMessage(
-      message({ unsupportedType: 'folder', text: '' }),
-    );
+    await h.bridge.handleMessage(message({ unsupportedType: 'folder', text: '' }));
     // The notice is a text reply, NOT a turn (no agent followup).
     expect(h.transport.sentTexts.some((t) => t.text.includes('folder'))).toBe(true);
     expect(h.transport.sentTexts.some((t) => t.text.includes("can't process"))).toBe(true);

--- a/tests/bridge.spec.ts
+++ b/tests/bridge.spec.ts
@@ -631,6 +631,17 @@ describe('Bridge', () => {
     });
   });
 
+  it('replies with a loud notice for a known-but-unhandled message type', async () => {
+    const h = makeHarness();
+    await h.bridge.handleMessage(
+      message({ unsupportedType: 'folder', text: '' }),
+    );
+    // The notice is a text reply, NOT a turn (no agent followup).
+    expect(h.transport.sentTexts.some((t) => t.text.includes('folder'))).toBe(true);
+    expect(h.transport.sentTexts.some((t) => t.text.includes("can't process"))).toBe(true);
+    expect(h.agentStore.followups.get('feishu-session-1')).toBeUndefined();
+  });
+
   it('deduplicates a redelivered message id', async () => {
     const h = makeHarness();
     await h.bridge.handleMessage(message());

--- a/tests/integration/inbound-wait-instruction.spec.ts
+++ b/tests/integration/inbound-wait-instruction.spec.ts
@@ -89,6 +89,7 @@ function sendMessage(
   fixedMessageId?: string,
   chatType: 'p2p' | 'group' = 'p2p',
   mentions: readonly string[] = [],
+  unsupportedType?: string,
 ): void {
   const messageId = fixedMessageId ?? `om-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   writeFileSync(
@@ -101,6 +102,7 @@ function sendMessage(
       text,
       ...(attachments !== undefined ? { attachments } : {}),
       mentions,
+      ...(unsupportedType !== undefined ? { unsupportedType } : {}),
       createdAt: Date.now(),
     }),
     'utf8',
@@ -358,5 +360,27 @@ describe.skipIf(!integrationReady)('integration > inbound-wait-instruction', () 
         `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}`,
       );
     }
+  }, 150_000);
+
+  it('a folder message gets a loud unsupported-type notice and no turn', async () => {
+    const { chatId } = await boot();
+    sendMessage(chatId, '', undefined, 'om-folder-1', 'p2p', [], 'folder');
+    try {
+      await waitFor(
+        'the unsupported-type notice',
+        () =>
+          readOutbox().some(
+            (r) => r.kind === 'text' && r.chatId === chatId && r.text?.includes("can't process"),
+          ),
+        30_000,
+      );
+    } catch (error) {
+      throw new Error(
+        `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}`,
+      );
+    }
+    // No turn, no receipt card, nothing pending.
+    expect(llmRequestCount()).toBe(0);
+    expect(cardMarkdowns('📎 File received')).toHaveLength(0);
   }, 150_000);
 });

--- a/tests/transport.spec.ts
+++ b/tests/transport.spec.ts
@@ -106,13 +106,16 @@ describe('normalizeMessageEvent', () => {
     expect(message).toBeUndefined();
   });
 
-  it('ignores unsupported message types (audio, post, …)', () => {
-    for (const type of ['audio', 'post', 'media']) {
+  it('surfaces known-but-unhandled types (media, sticker) as unsupported; ignores unknown ones', () => {
+    for (const type of ['media', 'sticker']) {
       const message = normalizeMessageEvent(
         rawEvent({ message: { message_type: type, content: '{}' } }),
       );
-      expect(message).toBeUndefined();
+      expect(message?.unsupportedType).toBe(type);
     }
+    expect(
+      normalizeMessageEvent(rawEvent({ message: { message_type: 'nonsense' } })),
+    ).toBeUndefined();
   });
 
   it('extracts mention open ids', () => {
@@ -182,6 +185,27 @@ describe('normalizeMessageEvent', () => {
     );
     expect(message?.text).toBe('');
     expect(message?.attachments).toEqual([{ kind: 'file', key: 'file_a1' }]);
+  });
+
+  it('surfaces a known-but-unhandled type (folder) as an unsupported-type message', () => {
+    const message = normalizeMessageEvent(
+      rawEvent({
+        message: {
+          message_type: 'folder',
+          content: JSON.stringify({ file_key: 'f1', file_name: 'folder' }),
+        },
+      }),
+    );
+    expect(message?.unsupportedType).toBe('folder');
+    expect(message?.text).toBe('');
+    expect(message?.attachments).toEqual([]);
+  });
+
+  it('ignores an unknown message type entirely', () => {
+    const message = normalizeMessageEvent(
+      rawEvent({ message: { message_type: 'definitely-not-a-feishu-type' } }),
+    );
+    expect(message).toBeUndefined();
   });
 
   it('ignores a malformed post content', () => {


### PR DESCRIPTION
## What

- A message whose `message_type` is a KNOWN but unhandled Feishu type — folder, sticker, share_chat, share_user, system, media, merge, interactive — is no longer silently dropped. It normalizes with an `unsupportedType` marker and the bridge replies `⚠️ I can't process messages of type '<type>' yet.`
- Folders get the extra note: folder contents cannot be downloaded via the API — send the files individually or as a zip archive.
- No turn, no pending registration, no receipt card — just the loud notice. Unknown types (not in the platform's vocabulary) stay ignored.

## Why

User-reported: sending a folder produced zero feedback (silently dropped). The user's request: instead of silent drops, reply loudly for ALL unhandled types uniformly. This also matches AGENTS.md's "misconfiguration fails loud" — a user must learn the bot cannot process a folder (the platform's message-resource API does not support folder download; botmux ignores folders entirely, so there is no reference download path to follow).

## Docs

- `CHANGELOG.md`: Added entry (loud unsupported-type notices).
- `docs/ux-specification.md` + `.zh.md`: inbound-attachments part now covers known-but-unhandled types + the loud notice.
- README untouched (maintainer-gated).

## Verification

- Unit: `tests/transport.spec.ts` — folder normalizes with unsupportedType; unknown type ignored; media/sticker surfaced as unsupported; `tests/bridge.spec.ts` — loud notice text, no turn.
- Integration: `tests/integration/inbound-wait-instruction.spec.ts` — folder message gets the notice, no turn, no receipt card.
- Full matrix green: lint, typecheck, build, `FEISHU_INT_REQUIRED=1 vitest run` → **565 tests pass**.