### PR TITLE
test: fix CI-only flaky stop/panel integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -295,6 +295,14 @@ stable-rc.7 line; newer dsh releases (`@next`) are tracked on `main`.
   the resource key — landed as `<key>.bin`. The sniffer now maps those magic
   bytes to `mp4` / `webm` / `avi` (and this also fixed the WebP branch, whose
   `RIFF`+`WEBP` check read an 8-byte head and never matched).
+- **Flaky stop/panel integration tests (CI-only timeouts).** Tests that
+  `holdNextResponse()` then drove a stop/panel action waited only for the
+  working card — which appears as soon as the turn starts, BEFORE the agent's
+  LLM request is established (buildRequest → resolveApiKey → fetch). A stop
+  issued in that window cancelled nothing and the turn completed normally
+  (no stopped card / ERROR reaction), timing out on slow or loaded CI
+  runners. The mock server now exposes `waitForHold()`, and every
+  hold-based test awaits it before acting — the abort is deterministic.
 - **Turn-termination reaction ack 400s.** The terminal emoji for an error or
   stopped turn defaulted to `WARN`, which is NOT a valid Feishu `emoji_type`
   (the platform's reaction table has no WARN) — the swap always failed with

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -240,6 +240,14 @@ The harness sandbox (and this checkout's environment) has specific rules:
 - Every new session fires a **title-generation completion** ("Create a
   concise title for an AI coding…"). Never assert an exact LLM completion
   count; assert card contents.
+- **After `holdNextResponse()`, await `waitForHold()` before driving a
+  stop/panel action.** The working card appears as soon as the turn starts,
+  but the agent's LLM request is established asynchronously (buildRequest →
+  resolveApiKey → fetch). A stop issued before the request reaches the mock
+  (and its abort signal binds to the in-flight body) cancels nothing and the
+  turn completes normally — no stopped card / ERROR reaction, a timeout on
+  slow or loaded CI runners. `waitForHold()` resolves when the held request
+  is actually in flight, making the abort deterministic.
 - Message ids built from `Date.now()` collide when two messages are written
   in the same millisecond (and the surface's dedup silently drops the
   second). Append a random suffix. waitFor predicates that match ANY chat's

--- a/docs/pitfalls.zh.md
+++ b/docs/pitfalls.zh.md
@@ -214,6 +214,13 @@ harness 沙箱（以及本 checkout 的环境）有一些特定规则：
   否则后续运行和真实 bot 都会继承该更改。
 - 每个新会话都会触发一个 **标题生成完成**（"Create a concise title for an
   AI coding…"）。绝不要断言精确的 LLM 完成次数；断言卡片内容。
+- **`holdNextResponse()` 之后、驱动 stop/panel 动作之前，先 `await
+  waitForHold()`。** working 卡在 turn 一开始就出现，但 agent 的 LLM 请求
+  是异步建立的（buildRequest → resolveApiKey → fetch）。在请求到达 mock
+  （且其 abort signal 绑定到在途 body）之前发出的 stop 什么也取消不了，
+  turn 会正常完成——没有 stopped 卡 / ERROR 表情，在慢或高负载的 CI
+  上超时。`waitForHold()` 在 hold 请求真正在途时 resolve，使 abort 确定性
+  落地。
 - 由 `Date.now()` 构建的消息 id 在同一毫秒内写入两条消息时会冲突（并且
   表面的去重会静默丢弃第二条）。追加一个随机后缀。匹配 ANY 聊天回复的
   waitFor 谓词会提前通过先前聊天的文本 —— 用 `r.chatId` 过滤。

--- a/tests/integration/mock-llm-server.ts
+++ b/tests/integration/mock-llm-server.ts
@@ -60,6 +60,17 @@ export interface MockLlmServer {
    * (turn/end aborted) whether or not the stream was released.
    */
   holdNextResponse(): void;
+  /**
+   * Resolve when the next completion request has actually been received and
+   * held. A test must await this AFTER `holdNextResponse()` and BEFORE
+   * driving a stop/panel action: the working card appears as soon as the
+   * turn starts, but the agent's LLM request is established asynchronously —
+   * a stop issued before the request reaches the server (and its abort
+   * signal binds to the in-flight body) silently cancels nothing and the
+   * turn completes normally (no stopped card → test timeout on slow/loaded
+   * CI runners). Awaiting the hold guarantees the abort will land.
+   */
+  waitForHold(): Promise<void>;
   /** Release a held response; no-op when none is held. */
   release(): void;
 }
@@ -92,6 +103,11 @@ export async function startMockLlmServer(): Promise<MockLlmServer> {
   let scripts: readonly (readonly MockScriptChunk[])[] | undefined;
   let hold = false;
   let releaseHold: (() => void) | undefined;
+  /** Resolver for the next `waitForHold()` — resolved when a request is
+   *  actually held, so tests can stop AFTER the agent's request (and its
+   *  abort binding) is in flight. */
+  let heldResolve: (() => void) | undefined;
+  let heldPromise: Promise<void> | undefined;
 
   /** Stream one scripted response: reasoning, a tool call, then the answer. */
   /** The script for the NEXT completion request, or undefined (default). */
@@ -181,6 +197,11 @@ export async function startMockLlmServer(): Promise<MockLlmServer> {
           writeScripted(res, script);
           res.end('data: [DONE]\n\n');
         };
+        // Signal any waiting `waitForHold()` — the request is in flight and
+        // the test may now drive stop/panel actions deterministically.
+        heldResolve?.();
+        heldResolve = undefined;
+        heldPromise = undefined;
         return;
       }
       writeScripted(res, script);
@@ -216,6 +237,17 @@ export async function startMockLlmServer(): Promise<MockLlmServer> {
     },
     holdNextResponse: () => {
       hold = true;
+      if (heldPromise === undefined) {
+        heldPromise = new Promise<void>((resolve) => {
+          heldResolve = resolve;
+        });
+      }
+    },
+    waitForHold: async () => {
+      // A caller that forgot holdNextResponse would deadlock forever; only
+      // wait when a hold is actually armed.
+      if (heldPromise === undefined) return;
+      await heldPromise;
     },
     release: () => {
       releaseHold?.();

--- a/tests/integration/real-composition.spec.ts
+++ b/tests/integration/real-composition.spec.ts
@@ -680,6 +680,9 @@ describe.skipIf(!integrationReady)('real-composition integration', () => {
         () => readOutbox().some((r) => r.kind === 'card'),
         30_000,
       );
+      // Ensure the agent's request is actually in flight (held) before
+      // driving the panel/stop actions — see the copy-after-stop test.
+      await server.waitForHold();
 
       // Panel while running carries ⏹ Stop current.
       writeAction({
@@ -1231,6 +1234,10 @@ describe.skipIf(!integrationReady)('real-composition integration', () => {
         () => readOutbox().some((r) => r.kind === 'card' && r.chatId === chatId),
         30_000,
       );
+      // The turn must actually be running (request in flight, held) before
+      // the mutating-command refusal is tested — see the copy-after-stop
+      // test for the race this guards against.
+      await server.waitForHold();
 
       // Compact button (palette command) while running → the confirm view
       // opens, and CONFIRMING is refused.
@@ -3243,6 +3250,12 @@ describe.skipIf(!integrationReady)('real-composition integration', () => {
         () => readOutbox().some((r) => r.kind === 'card' && r.chatId === chatId),
         30_000,
       );
+      // The working card appears as soon as the turn starts, but the agent's
+      // LLM request is established asynchronously — a stop issued before it
+      // reaches the server cancels nothing and the turn completes normally
+      // (no stopped card → timeout on slow CI runners). Await the hold so
+      // the abort deterministically lands.
+      await server.waitForHold();
       writeAction({
         messageId: 'mem-sc-1',
         chatId,

--- a/tests/integration/scenarios.spec.ts
+++ b/tests/integration/scenarios.spec.ts
@@ -423,6 +423,9 @@ describe.skipIf(!integrationReady)('scenario integration (real process)', () => 
         () => readOutbox().some((r) => r.kind === 'card'),
         30_000,
       );
+      // Ensure the held request is actually in flight before sending /status
+      // (the working card precedes the LLM request being established).
+      await mock?.waitForHold();
       sendMessage(chatId, '/status');
       await waitFor(
         'the status text while working',
@@ -1146,6 +1149,10 @@ describe.skipIf(!integrationReady)('scenario integration (real process)', () => 
         () => readOutbox().some((r) => r.kind === 'card'),
         30_000,
       );
+      // Ensure the held request is in flight before stopping — otherwise a
+      // stop issued during request establishment cancels nothing and the
+      // turn completes normally (DONE reaction, never ERROR → timeout).
+      await mock?.waitForHold();
       writeAction({
         messageId: 'mem-1',
         chatId,


### PR DESCRIPTION
## What

- The mock LLM server gains `waitForHold()`: `holdNextResponse()` arms a promise that resolves when the next request is actually received and held.
- Every hold-based integration test now awaits `waitForHold()` after the working card and before driving the stop/panel/compact action: copy-after-stop, stop-while-running, stop-reaction swap, mutating-commands refusal, /status-while-running.

## Why

CI-only flaky timeouts (`timed out waiting for the stopped card` etc.) on 4 tests (copy-after-stop 3×, stop-while-running / stop-reaction / approval 1× each; plus 2 same-pattern siblings). Root cause: the working streaming card appears as soon as the turn starts, but the agent's LLM request is established asynchronously (buildRequest → resolveApiKey → fetch). A stop issued in that window cancels nothing — the abort signal has not bound to an in-flight body — and the turn completes normally (no stopped card / no ERROR reaction). Local runs pass because the machine is fast; slow/loaded CI hits the window. (A subagent's title-generation-race hypothesis was tested and disproven: the profile issues no title request — completion counts equal turn requests exactly.)

## Docs

- `docs/pitfalls.md` + `.zh.md`: new integration-test rule — after `holdNextResponse()`, await `waitForHold()` before driving stop/panel actions.
- `CHANGELOG.md`: Fixed entry.
- README untouched (maintainer-gated).

## Verification

- All 6 hold-based tests pass locally; full matrix green: lint, typecheck, build, `FEISHU_INT_REQUIRED=1 vitest run` → **565 tests pass**.
- Two consecutive parallel runs of real-composition + scenarios suites: 57/57 pass each.