### PR TITLE
test: isolate each integration suite's dsh home (fix parallel session-map race)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,30 @@ jobs:
       # Feishu is mocked via FEISHU_TRANSPORT=memory and the LLM via a local
       # mock server — no real credentials are needed. The profile links the
       # checkout; see docs/development.md → "Integration test".
-      - name: Prepare integration-test profile
+      # Each integration suite gets its OWN dsh home: vitest runs the suites
+      # in parallel and each spawns a real dsh process — sharing
+      # `_dev/dsh-home/feishu/session-map.json` raced concurrent writes and
+      # silently dropped one suite's chat→session binding (CI-only flakes,
+      # e.g. the session-lifecycle test reading the file and finding its
+      # chat missing).
+      - name: Prepare integration-test profiles
         env:
-          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home
+          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-attachments
+        run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
+      - name: Prepare integration-test profile (rich-text)
+        env:
+          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-rich-text
+        run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
+      - name: Prepare integration-test profile (wait-instruction)
+        env:
+          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-wait-instruction
+        run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
+      - name: Prepare integration-test profile (real-composition)
+        env:
+          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-real
         run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
 
-      # The scenario suite (tests/integration/scenarios.spec.ts) boots its
-      # own dsh home so it never races the primary suite's session map while
-      # vitest runs the two integration files in parallel.
+      # The scenario suite boots its own dsh home too.
       - name: Prepare scenario integration-test profile
         env:
           DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-scenarios

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,16 @@ stable-rc.7 line; newer dsh releases (`@next`) are tracked on `main`.
   (no stopped card / ERROR reaction), timing out on slow or loaded CI
   runners. The mock server now exposes `waitForHold()`, and every
   hold-based test awaits it before acting — the abort is deterministic.
+- **Flaky session-lifecycle test (shared dsh home).** The integration suites
+  run in parallel (vitest file parallelism), each spawning a real dsh
+  process — but four of them shared `_dev/dsh-home`, so concurrent processes
+  raced their writes to `_dev/dsh-home/feishu/session-map.json` and silently
+  dropped another suite's chat→session binding (the session-lifecycle test
+  read the file and found its chat missing → `expected undefined to be
+  defined`, CI-only). Each suite now uses its own home
+  (`dsh-home-attachments` / `dsh-home-rich-text` / `dsh-home-wait-instruction`
+  / `dsh-home-real` / `dsh-home-scenarios`), isolating the session map and
+  every other durable file; CI prepares one profile per suite.
 - **Turn-termination reaction ack 400s.** The terminal emoji for an error or
   stopped turn defaulted to `WARN`, which is NOT a valid Feishu `emoji_type`
   (the platform's reaction table has no WARN) — the swap always failed with

--- a/docs/development.md
+++ b/docs/development.md
@@ -95,11 +95,18 @@ command wrappers, and the working-directory gate. A scripted mock LLM
 unless the prerequisites are met:
 
 - The dsh CLI is resolvable (`$DSH_BIN`, or `dsh` on `PATH`).
-- A prepared profile exists at `$FEISHU_INT_DSH_HOME/profiles/feishu-dev`
-  (default `_dev/dsh-home/profiles/feishu-dev` — create it with
+- A prepared profile exists at `$FEISHU_INT_*_DSH_HOME/profiles/feishu-dev`
+  (default `_dev/dsh-home-<suite>/profiles/feishu-dev` — create it with
   `dsh plugin --profile feishu-dev add link:<checkout>`, see the "Verifying
   the bundle" section below). Deliberately independent of the ambient
-  `DSH_HOME` so the test never touches another dsh home.
+  `DSH_HOME` so the test never touches another dsh home. **Each integration
+  suite uses its OWN home** (`dsh-home-attachments`, `dsh-home-rich-text`,
+  `dsh-home-wait-instruction`, `dsh-home-real`, `dsh-home-scenarios`):
+  vitest runs the suites in parallel, and sharing one
+  `_dev/dsh-home/feishu/session-map.json` made concurrent dsh processes
+  race their writes and silently drop one suite's chat→session binding
+  (CI-only flakes, e.g. the session-lifecycle test reading the file and
+  finding its chat missing).
 - The checkout is built (`pnpm run build`).
 
 CI runs the suite on every push (both node-version legs): the workflow

--- a/docs/development.zh.md
+++ b/docs/development.zh.md
@@ -70,7 +70,8 @@ scripts/              # repo tooling
 该套件断言完整的 surface：消息 → session → agent turn → 卡片发布并被 patch → **由卡片承载的最终答案**（它就地以绿色收尾），此外还有卡片操作、session 生命周期、web 命令包装器，以及工作目录 gate。脚本化的 mock LLM（`setScripts`、`holdNextResponse`，以及一个应答 HTTP 500 的 `error` 块）驱动工具调用、推理、错误 turn 和重试。除非满足前置条件，否则套件会自行跳过：
 
 - dsh CLI 可解析（`$DSH_BIN`，或 `PATH` 上的 `dsh`）。
-- 在 `$FEISHU_INT_DSH_HOME/profiles/feishu-dev` 存在一个准备好的 profile（默认 `_dev/dsh-home/profiles/feishu-dev`——用 `dsh plugin --profile feishu-dev add link:<checkout>` 创建，见下文"在真实 dsh profile 中验证 bundle"一节）。刻意与环境的 `DSH_HOME` 相互独立，这样测试永远不会碰到另一个 dsh home。
+- dsh CLI 可解析（`$DSH_BIN`，或 `PATH` 上的 `dsh`）。
+- 在 `$FEISHU_INT_*_DSH_HOME/profiles/feishu-dev` 存在一个准备好的 profile（默认 `_dev/dsh-home-<套件>/profiles/feishu-dev`——用 `dsh plugin --profile feishu-dev add link:<checkout>` 创建，见下文"在真实 dsh profile 中验证 bundle"一节）。刻意与环境的 `DSH_HOME` 相互独立，这样测试永远不会碰到另一个 dsh home。**每个集成套件使用自己的 home**（`dsh-home-attachments`、`dsh-home-rich-text`、`dsh-home-wait-instruction`、`dsh-home-real`、`dsh-home-scenarios`）：vitest 并行运行各套件，共享一个 `_dev/dsh-home/feishu/session-map.json` 会让并发的 dsh 进程竞争写入、静默丢掉某个套件的 chat→session 绑定（CI-only flaky，例如 session-lifecycle 测试读文件发现自己的 chat 缺失）。
 - checkout 已构建（`pnpm run build`）。
 
 CI 在每次 push 时都运行该套件（两个 node 版本分支都跑）：workflow 构建 checkout、准备 profile，并以 `FEISHU_INT_REQUIRED=1` 运行测试——这样缺少前置条件会响亮地让任务失败，而不是静默跳过。dsh CLI 是 devDependency（`@deepseek-ai/dsh`），原生构建脚本（node-pty 及其同类）在 `pnpm-workspace.yaml` 中获准——不涉及任何凭据；正是上面这些 Feishu 和 LLM mock 让套件在无需密钥的情况下也能运行。

--- a/tests/integration/inbound-attachments.spec.ts
+++ b/tests/integration/inbound-attachments.spec.ts
@@ -19,7 +19,13 @@ import type { MemoryOutboxRecord } from '../../src/memory-transport.js';
 import { type MockLlmServer, startMockLlmServer } from './mock-llm-server.js';
 
 const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
-const DSH_HOME = process.env.FEISHU_INT_DSH_HOME ?? join(REPO_ROOT, '_dev', 'dsh-home');
+// Each integration suite uses its OWN dsh home (override per suite, e.g.
+// FEISHU_INT_ATTACHMENTS_DSH_HOME): the suites run in parallel (vitest file
+// parallelism) and spawn real dsh processes that share
+// `_dev/dsh-home/feishu/session-map.json` — concurrent writes raced and
+// silently dropped another suite's chat→session binding (CI-only flakes).
+const DSH_HOME =
+  process.env.FEISHU_INT_ATTACHMENTS_DSH_HOME ?? join(REPO_ROOT, '_dev', 'dsh-home-attachments');
 const PROFILE_DIR = join(DSH_HOME, 'profiles', 'feishu-dev');
 const MEMORY_DIR = join(REPO_ROOT, '_dev', 'int-memory-attachments');
 const INBOX_DIR = join(MEMORY_DIR, 'inbox');

--- a/tests/integration/inbound-rich-text.spec.ts
+++ b/tests/integration/inbound-rich-text.spec.ts
@@ -24,7 +24,13 @@ import type { MemoryOutboxRecord } from '../../src/memory-transport.js';
 import { type MockLlmServer, startMockLlmServer } from './mock-llm-server.js';
 
 const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
-const DSH_HOME = process.env.FEISHU_INT_DSH_HOME ?? join(REPO_ROOT, '_dev', 'dsh-home');
+// Each integration suite uses its OWN dsh home (override per suite, e.g.
+// FEISHU_INT_ATTACHMENTS_DSH_HOME): the suites run in parallel (vitest file
+// parallelism) and spawn real dsh processes that share
+// `_dev/dsh-home/feishu/session-map.json` — concurrent writes raced and
+// silently dropped another suite's chat→session binding (CI-only flakes).
+const DSH_HOME =
+  process.env.FEISHU_INT_RICHTEXT_DSH_HOME ?? join(REPO_ROOT, '_dev', 'dsh-home-rich-text');
 const PROFILE_DIR = join(DSH_HOME, 'profiles', 'feishu-dev');
 const MEMORY_DIR = join(REPO_ROOT, '_dev', 'int-memory-rich-text');
 const INBOX_DIR = join(MEMORY_DIR, 'inbox');

--- a/tests/integration/inbound-wait-instruction.spec.ts
+++ b/tests/integration/inbound-wait-instruction.spec.ts
@@ -20,7 +20,13 @@ import type { MemoryOutboxRecord } from '../../src/memory-transport.js';
 import { type MockLlmServer, startMockLlmServer } from './mock-llm-server.js';
 
 const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
-const DSH_HOME = process.env.FEISHU_INT_DSH_HOME ?? join(REPO_ROOT, '_dev', 'dsh-home');
+// Each integration suite uses its OWN dsh home (override per suite, e.g.
+// FEISHU_INT_ATTACHMENTS_DSH_HOME): the suites run in parallel (vitest file
+// parallelism) and spawn real dsh processes that share
+// `_dev/dsh-home/feishu/session-map.json` — concurrent writes raced and
+// silently dropped another suite's chat→session binding (CI-only flakes).
+const DSH_HOME =
+  process.env.FEISHU_INT_WAIT_DSH_HOME ?? join(REPO_ROOT, '_dev', 'dsh-home-wait-instruction');
 const PROFILE_DIR = join(DSH_HOME, 'profiles', 'feishu-dev');
 const MEMORY_DIR = join(REPO_ROOT, '_dev', 'int-memory-wait-instruction');
 const INBOX_DIR = join(MEMORY_DIR, 'inbox');

--- a/tests/integration/real-composition.spec.ts
+++ b/tests/integration/real-composition.spec.ts
@@ -25,10 +25,13 @@ import type { MemoryOutboxRecord } from '../../src/memory-transport.js';
 import { type MockLlmServer, startMockLlmServer } from './mock-llm-server.js';
 
 const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
-// Repo-local dsh home; override with FEISHU_INT_DSH_HOME. Deliberately NOT
-// `DSH_HOME` — the ambient harness environment exports its own DSH_HOME and
-// the test must never touch it.
-const DSH_HOME = process.env.FEISHU_INT_DSH_HOME ?? join(REPO_ROOT, '_dev', 'dsh-home');
+// Repo-local dsh home; override with FEISHU_INT_REAL_DSH_HOME. Deliberately
+// NOT `DSH_HOME` — the ambient harness environment exports its own DSH_HOME
+// and the test must never touch it. Each integration suite uses its OWN dsh
+// home (the suites run in parallel and spawn real dsh processes that share
+// `_dev/dsh-home/feishu/session-map.json` — concurrent writes raced and
+// silently dropped another suite's chat→session binding, CI-only flakes).
+const DSH_HOME = process.env.FEISHU_INT_REAL_DSH_HOME ?? join(REPO_ROOT, '_dev', 'dsh-home-real');
 const PROFILE_DIR = join(DSH_HOME, 'profiles', 'feishu-dev');
 const MEMORY_DIR = join(REPO_ROOT, '_dev', 'int-memory');
 const INBOX_DIR = join(MEMORY_DIR, 'inbox');

--- a/tests/integration/scenarios.spec.ts
+++ b/tests/integration/scenarios.spec.ts
@@ -30,7 +30,7 @@ const MEMORY_DIR = join(REPO_ROOT, '_dev', 'int-memory-scenarios');
 const INBOX_DIR = join(MEMORY_DIR, 'inbox');
 const OUTBOX_DIR = join(MEMORY_DIR, 'outbox');
 const ACTIONS_DIR = join(MEMORY_DIR, 'actions');
-const INT_CWD = join(REPO_ROOT, '_dev', 'int-cwd');
+const INT_CWD = join(REPO_ROOT, '_dev', 'int-cwd-scenarios');
 
 function resolveDshBin(): string | undefined {
   if (process.env.DSH_BIN !== undefined && process.env.DSH_BIN !== '') return process.env.DSH_BIN;


### PR DESCRIPTION
## What

- Each integration suite now uses its OWN dsh home: `dsh-home-attachments` / `dsh-home-rich-text` / `dsh-home-wait-instruction` / `dsh-home-real` / `dsh-home-scenarios` (was: four suites shared `_dev/dsh-home`).
- scenarios' working directory is isolated too (`int-cwd-scenarios`; real-composition keeps `int-cwd`) so the two process-writing suites never share a cwd.
- CI prepares one profile per suite (was: two).

## Why

The main-branch CI failed on the merged PR (#25) with `session lifecycle chain: /sessions, resume by button, continue, /clear` → `AssertionError: expected undefined to be defined` — a DIFFERENT flake from the stop/panel one (#25 fixed that; this run showed copy-after-stop passing). Root cause: the integration suites run in parallel (vitest file parallelism), each spawning a real dsh process — but four of them shared `_dev/dsh-home`, so concurrent processes raced their writes to `_dev/dsh-home/feishu/session-map.json` (whole-file rewrite via tmp+rename) and silently dropped another suite's chat→session binding. The session-lifecycle test reads that file and asserts its chat is present; the resume logs (`session not found`) showed the same loss. Local runs pass because the machine is fast; CI's parallel load hits the race.

## Docs

- `docs/development.md` + `.zh.md`: integration prerequisites describe the per-suite homes and why.
- `CHANGELOG.md`: Fixed entry.
- README untouched (maintainer-gated).

## Verification

- Full matrix green locally: lint, typecheck, build, `FEISHU_INT_REQUIRED=1 vitest run` → **565 tests pass**.
- Two consecutive parallel integration runs: 68/68 each.