### PR TITLE
ci(canary): prepare per-suite dsh homes like ci.yml

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -58,12 +58,25 @@ jobs:
         run: pnpm run build
 
       # Same integration profile preparation as ci.yml; DSH_BIN is the
-      # freshly installed newest CLI.
-      - name: Prepare integration-test profile
+      # freshly installed newest CLI. Each integration suite gets its OWN
+      # dsh home (parallel suites racing session-map.json writes — see
+      # ci.yml).
+      - name: Prepare integration-test profiles
         env:
-          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home
+          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-attachments
         run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
-
+      - name: Prepare integration-test profile (rich-text)
+        env:
+          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-rich-text
+        run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
+      - name: Prepare integration-test profile (wait-instruction)
+        env:
+          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-wait-instruction
+        run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
+      - name: Prepare integration-test profile (real-composition)
+        env:
+          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-real
+        run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
       - name: Prepare scenario integration-test profile
         env:
           DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-scenarios


### PR DESCRIPTION
## What

- The canary workflow now prepares all five per-suite dsh homes (dsh-home-attachments / -rich-text / -wait-instruction / -real / -scenarios), mirroring ci.yml (#26).

## Why

The first canary run of the day went red: it still prepared only the legacy `_dev/dsh-home` + `dsh-home-scenarios`, but the integration suites each now use their own home (#26), so every integration file failed its prerequisite check with `profile=false` → `FEISHU_INT_REQUIRED=1` hard-failed the job. Not a test regression — a workflow that was not updated with the per-suite-home change.

## Docs

None — workflow-only change (README untouched).

## Verification

Workflow YAML mirrors ci.yml's proven steps; no code/test touched.