### PR TITLE
feat: run the real-client E2E acceptance before every release

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -142,6 +142,11 @@ FEISHU_DEBUG=1           # the plugin's own debug tracing (visible now that
 No chat name is needed: every case creates its own group chat
 (`<caseId>-<runId>`) through the backend and opens it.
 
+The suite doubles as the **release acceptance gate**: `scripts/release.mjs`
+runs `e2e:ui` before tagging and refuses to release when the environment is
+not prepared (run `e2e:setup` once per machine first) or the run fails —
+see `docs/development.md` → "Releasing".
+
 ## Report
 
 Every run writes a timestamped directory under `e2e/.output/<runId>/`

--- a/docs/e2e-testing.zh.md
+++ b/docs/e2e-testing.zh.md
@@ -89,6 +89,10 @@ FEISHU_DEBUG=1           # 插件自身 debug 追踪（dsh 子进程日志现在
 
 不需要聊天名：每个用例自己通过后台创建群聊（`<caseId>-<runId>`）并打开它。
 
+这套套件同时充当**发版验收门禁**：`scripts/release.mjs` 会在打 tag 前运行
+`e2e:ui`，环境未准备（先在本机跑一次 `e2e:setup`）或运行失败时拒绝发版——见
+`docs/development.md` → "发版步骤"。
+
 ## 报告
 
 每次运行写入 `e2e/.output/<runId>/` 下的一个带时间戳目录（`latest` 软链指向最新）。报告**只有一个入口**——`summary.html`，采用 Playwright HTML 报告的视觉风格（深色侧边栏用例列表 + 状态点 + 浅色主面板），链接到每个用例的自包含页面：

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -7,6 +7,8 @@
  * Usage:
  *   node scripts/release.mjs <major|minor|patch>   # e.g. node scripts/release.mjs patch
  *   node scripts/release.mjs --dry-run <bump>      # print what would happen
+ *   node scripts/release.mjs --skip-e2e <bump>     # skip the E2E acceptance
+ *                                                  # (explicit escape hatch only)
  *
  * Releases happen ONLY from a `release/*` branch (e.g. release/v0.2.1):
  * main is a development branch and may carry unreleased work, so a release
@@ -18,11 +20,15 @@
  *
  * Gates run through the local binaries (node scripts/run-gates.mjs) rather
  * than `pnpm run` so the script works in constrained shells where pnpm's
- * store check cannot open its SQLite database.
+ * store check cannot open its SQLite database. After the gates, the
+ * real-client E2E suite runs as a release acceptance step (see
+ * docs/e2e-testing.md); the environment must be prepared once with
+ * `pnpm run e2e:setup`.
  */
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const [, , ...args] = process.argv;
@@ -75,6 +81,34 @@ if (!dryRun) {
 // Gates exactly as CI runs them, via the local gate runner (direct binaries,
 // no pnpm store dependency — see the header comment).
 run('node scripts/run-gates.mjs');
+
+// Real-client E2E acceptance before every release: the unit/integration
+// gates mock the Feishu wire, so the release must also verify the real
+// long connection + browser client locally (see docs/e2e-testing.md).
+// The environment is prepared once with `pnpm run e2e:setup` (QR scans);
+// afterwards `e2e:ui` is hands-free and idempotent. Failing the E2E run
+// aborts the release. `--skip-e2e` is an explicit escape hatch for cases
+// where the E2E environment cannot be provisioned (e.g. no test account
+// access) — never the default.
+const skipE2E = args.includes('--skip-e2e');
+if (!skipE2E) {
+  const { existsSync } = await import('node:fs');
+  const stateDir = join(repoRoot, 'e2e', '.state');
+  const e2eReady =
+    existsSync(join(stateDir, 'creds.json')) &&
+    existsSync(join(stateDir, 'web-session.json')) &&
+    existsSync(join(stateDir, 'user.json'));
+  if (!e2eReady) {
+    console.error(
+      '\n✗ E2E environment is not ready (missing creds.json / web-session.json / user.json in e2e/.state/).\n' +
+        '  Run `pnpm run e2e:setup` once (QR scans with the test account), then re-run the release.\n' +
+        '  Use `--skip-e2e` only if the E2E environment cannot be provisioned.',
+    );
+    process.exit(1);
+  }
+  console.log('\n── E2E acceptance (real feishu.cn web client) ──');
+  run('pnpm run e2e:ui');
+}
 
 // Tag and push BOTH the release branch and the tag; the release workflow
 // publishes from the tag.


### PR DESCRIPTION
## What

`scripts/release.mjs` now runs the **real-client E2E acceptance**
(`pnpm run e2e:ui`) between the unit/integration gates and the tag/push —
the gates mock the Feishu wire (memory transport), so a release should
verify the real long connection + browser client locally before publishing.

Behavior:
- Requires a ready E2E environment: `e2e/.state/creds.json`,
  `web-session.json` and `user.json` must exist (prepared once per machine
  with `pnpm run e2e:setup` — QR scans with the test account, then
  hands-free). If not ready, the release **refuses to proceed** and prints
  the `e2e:setup` instruction.
- `--skip-e2e` is an explicit escape hatch for environments that cannot
  provision the test account — never the default.
- Works with `--dry-run` (prints what would run, still validates the
  readiness check).

## Why

The E2E suite landed in #17 as the only layer where the Feishu wire and the
browser client are both real. Making it a release gate (not CI) matches the
decision to keep it local: CI runs the mock-wire gates on every push; the
real-client verification happens once, right before the release is tagged.

## Docs

- `docs/development.md` + `docs/development.zh.md` — "Releasing" /
  "发版步骤": `e2e:setup` once, release runs the acceptance, `--skip-e2e`
- `docs/e2e-testing.md` + `docs/e2e-testing.zh.md` — the suite doubles as
  the release acceptance gate
- `CHANGELOG.md` — Changed entry

## Verification

- `node scripts/release.mjs --dry-run patch` on a `release/*` branch:
  - no `.state` → refuses with the `e2e:setup` hint
  - `--skip-e2e` → skips the E2E step
  - ready `.state` → prints `would run: pnpm run e2e:ui`
- lint + convention checks pass (the integration suites need the local
  `_dev/dsh-home-*` profiles, which CI prepares)
