### PR TITLE
feat: send_file tool for outbound files/images

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -77,6 +77,10 @@ jobs:
         env:
           DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-real
         run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
+      - name: Prepare integration-test profile (outbound)
+        env:
+          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-outbound
+        run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
       - name: Prepare scenario integration-test profile
         env:
           DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-scenarios

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,10 @@ jobs:
         env:
           DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-real
         run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
+      - name: Prepare integration-test profile (outbound)
+        env:
+          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-outbound
+        run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
 
       # The scenario suite boots its own dsh home too.
       - name: Prepare scenario integration-test profile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   card posts; download/save failures notice loudly and never wedge the
   chat. Reuses the existing `im:resource` scope. (Feishu images are plain
   files to the agent — there is no image content block / visual-input path.)
+- **Outbound files/images (`send_file` tool).** The agent can deliver a
+  workspace file or image to the Feishu chat by calling a `send_file` tool
+  it invokes itself — dsh has no host-level "agent produced a file" event,
+  so instead of guessing from `tool/result`/fs observation the surface
+  registers a first-class tool (`path` required + optional `description`).
+  It resolves the path against the chat's pinned cwd, reads the bytes,
+  classifies image vs file by extension + magic bytes, uploads via
+  `im.v1.image.create` / `im.v1.file.create`, posts a native Feishu
+  image/file message, and shows a `📤 Sent` receipt card. Feature-detects
+  the `tools` service (absent → loud log, tool not registered). Depends on
+  `@deepseek-ai/dsh-tools` (new runtime dep).
 - **Bare attachment messages wait for the user's instruction
   (inbound-wait-instruction).** A file/image message without text no longer
   starts a turn by itself: the bytes land in the workspace, a NEW receipt

--- a/docs/features.md
+++ b/docs/features.md
@@ -18,7 +18,7 @@ Feature list and TODO tracker for dsh-feishu. ✅ = shipped, 📋 = planned
 | Session-log export | `/export` sends the chat's session log as a downloadable file message | File message with markdown transcript | ✅ |
 | Diagnostics | `/feishu-status` shows a diagnostic card (connection state, sessions, last inbound) | Read-only status card, usable mid-turn | ✅ |
 | Inbound attachments | Images/files the user sends are saved to the workspace as plain files and the agent reads them by path; a bare file/image message registers as pending — a receipt card posts and the agent waits for your instruction | 📎 File received receipt (counts pending files); follow-up text makes the agent work on them | ✅ |
-| Outbound files/images | Agent-produced images/files send as native Feishu image/file messages | Tap to view original / download | 📋 |
+| Outbound files/images | The agent can send a workspace file/image to the chat via a `send_file` tool it calls itself | Native Feishu image/file message + 📤 Sent receipt card | ✅ |
 | Session hard delete | Remove a session from the active list (archive + hide, restorable from the archived list) | Session-detail card Delete + confirm view | 📋 |
 | Agent preset selection | Pick an agent preset (e.g. PTC mode) when choosing a working directory | Mode dropdown on the `/repo` / `/cd` picker card; preset binds to the new session | 📋 |
 | Subagent manager | Tree view of subagents (parent→child, status, tokens, duration), open or cancel one | Panel tree view | 📋 |
@@ -31,3 +31,4 @@ Feature list and TODO tracker for dsh-feishu. ✅ = shipped, 📋 = planned
 | session-rename-archive | Session rename/archive via dsh sessionTitle + workspaceRegistry (web-visible) | — | 📋 |
 | inbound-wait-instruction | Bare file/image messages register as pending — a receipt card posts and the agent waits for the user's instruction before working | 📎 File received receipt (counts pending files); follow-up text drains them into one turn | ✅ |
 | inbound-rich-text | Feishu rich-text (post) and video messages are no longer dropped: a post is serialized into ordered rich text + attachments (formatting and intra-bubble order preserved), a video is a plain file | Rich-text-with-text posts turn immediately; attachment-only posts / videos register as pending | ✅ |
+| outbound-files-images | agent sends files/images to Feishu via a send_file tool | — | 📋 |

--- a/docs/features.zh.md
+++ b/docs/features.zh.md
@@ -18,7 +18,7 @@ dsh-feishu 的功能列表与 TODO 追踪表。✅ = 已实现，📋 = 计划�
 | 会话日志导出 | `/export` 把聊天的会话日志作为可下载文件消息发送 | 带 markdown 转录的文件消息 | ✅ |
 | 诊断 | `/feishu-status` 显示诊断卡（连接状态、会话数、最后入站） | 只读状态卡，运行中可用 | ✅ |
 | 入站附件 | 用户发来的图片/文件保存到工作区作为普通文件，agent 按路径读取；裸文件/图片消息登记为 pending——发回执卡并等你的指令 | 📎 File received 回执（计数 pending 文件）；补发文字让 agent 处理 | ✅ |
-| 出站文件/图片 | agent 产出的图片/文件以飞书原生 image/file 消息发送 | 点开看原图/下载 | 📋 |
+| 出站文件/图片 | agent 可通过它自己调用的 `send_file` 工具把工作区文件/图片发送到聊天 | 飞书原生 image/file 消息 + 📤 Sent 回执卡 | ✅ |
 | 会话删除 | 从活跃列表删除会话（归档 + 隐藏，可从归档列表恢复） | 会话详情卡 Delete + 确认视图 | 📋 |
 | agent 预设选择 | 选择工作目录时一并选 agent 预设（如 PTC mode） | `/repo` / `/cd` 选择卡加 Mode 下拉；预设绑定新会话 | 📋 |
 | 子代理管理 | 子代理树形视图（父→子、状态、token、时长），打开或取消 | 面板树形视图 | 📋 |
@@ -31,3 +31,4 @@ dsh-feishu 的功能列表与 TODO 追踪表。✅ = 已实现，📋 = 计划�
 | session-rename-archive | Session rename/archive via dsh sessionTitle + workspaceRegistry (web-visible) | — | 📋 |
 | inbound-wait-instruction | 裸文件/图片消息登记为 pending——发回执卡并等用户指令后才开始工作 | 📎 File received 回执（计数 pending 文件）；补发文字把它们带进一个 turn | ✅ |
 | inbound-rich-text | 飞书富文本（post）和视频消息不再被丢弃：post 序列化为有序富文本 + 附件（保留格式与气泡内顺序），视频按普通文件处理 | 带文字的富文本立即 turn；纯附件 post / 视频登记为 pending | ✅ |
+| outbound-files-images | agent sends files/images to Feishu via a send_file tool | — | 📋 |

--- a/docs/ux-specification.md
+++ b/docs/ux-specification.md
@@ -1089,3 +1089,119 @@ card like any text message; attachment-only posts / videos use the existing
 - The pending routing reuses the sibling inbound-wait-instruction part
   (drained by the follow-up text; attachment messages bypass the group
   mention gate because Feishu cannot @ from an attachment).
+
+## Part: outbound-files-images
+
+> The agent can send a file or image to the Feishu chat by calling an
+> explicit `send_file` tool: it names a workspace path (and optionally a
+> description), the surface uploads the bytes through the message-resource
+> API and posts a native Feishu image/file message, then reports the send
+> back to the agent and shows a small receipt card.
+
+### Intended behavior
+
+**Why active, not passive** — dsh has no host-level "agent produced a file"
+event (the web UI's "Turn produced files" is a client-side derivation from
+tool cards' `locations`, invisible to a plugin; see the sibling feature
+`turn-produced-files`). Rather than guess from `tool/result` or fs
+observation, the surface injects a first-class **`send_file` tool** that the
+agent calls deliberately when it wants to deliver a file/image to the user.
+Active tool invocation is deterministic and self-describing — the agent
+knows what it produced and why it sends it, so no heuristics or false
+positives.
+
+**Trigger** — an agent calls the `send_file` tool during a turn:
+`send_file(path, description?)`.
+
+- `path` (string, required): the workspace-relative path of the file/image to
+  send, resolved against the chat's pinned working directory (`cwd`).
+- `description` (string, optional): why the agent is sending it; shown on the
+  receipt card and returned to the agent as the tool's result context.
+
+**Tool registration** — via dsh's tool runtime: `ctx.get('tools')?.register(defineTool({...}))`
+(the feature-detect pattern, mirroring `ctx.commands` / `ctx.watch`). The
+registration is in the GLOBAL scope, so every agent can call it. The tool
+definition follows the reference `tool-fs` `write` tool:
+`ctx.tools.register(defineTool({ name, description, parameters, output, execute }))`.
+`@deepseek-ai/dsh-tools` is added as a runtime dependency (it exports the
+`defineTool` helper — a runtime function, not a type-only import).
+
+**Execution** — `execute(args, exec: ToolRunContext)` runs in the host
+process (the same one running the surface):
+
+1. resolve `cwd = exec.agent.session.header.cwd` (the chat's pinned working
+   directory) and `chatId = sessionMap.chatFor(exec.agent.session.id)`.
+2. read the file at `join(cwd, path)`; a missing/unreadable file is a tool
+   error (loud, no upload).
+3. **classify** the type by extension + magic bytes (reuse `sniffExtension`):
+   a known image container (png / jpg / gif / webp) → an image message via
+   `im.v1.image.create`; any other type → a file message via
+   `im.v1.file.create` (already supports binary). Upload the bytes, then
+   `createMessage(chatId, 'image'|'file', ...)`.
+4. on success, post a small `📤 Sent` receipt card: the file name, the
+   optional description, and the target chat.
+5. return a structured value to the agent (the sent file name + the message
+   the user sees), so the agent can acknowledge.
+
+**No chips / auto-collection** — this part is the *transport + tool*
+foundation only. The "show each turn's produced files as clickable chips"
+UX is the sibling feature `turn-produced-files` and is deliberately out of
+scope here.
+
+**Card/panel shape** — the `📤 Sent` receipt card (a plain markdown card,
+like the inbound-file receipt) is posted by the tool AFTER the upload
+succeeds, independent of the streaming card (which keeps rendering the
+turn's tokens). No new panel views, no buttons.
+
+**Failure modes**:
+- `tools` service absent (host did not mount it): feature-detect — the
+  surface logs loudly and does not register `send_file`, so the agent never
+  sees it (never a broken tool). The turn still runs normally.
+- Path missing / unreadable / outside cwd: tool error — `{ isError: true }`,
+  a loud log, and a clear message to the agent (no partial upload).
+- Upload fails (`im.v1.image.create` / `im.v1.file.create` error, auth): tool
+  error with the API message; the agent is told it did not send.
+- Unsupported file type (no known classifier): falls back to a `file` message
+  (the resource API serves arbitrary file bytes); `type=file` covers audio
+  and video too.
+- Oversized file: the platform's limit is surfaced as a tool error.
+
+**Acceptance checklist**:
+- [ ] `send_file` is registered and visible to the agent's tool schema
+      (integration: the agent's request body carries the `send_file` tool).
+- [ ] Agent calls `send_file({ path, description })` → a native image message
+      posts for an image path (png/jpg/gif/webp) and the bytes match
+      (unit + integration).
+- [ ] Agent calls `send_file` with a non-image path → a native file message
+      posts and the bytes match (unit + integration).
+- [ ] A `📤 Sent` receipt card posts with the file name and description
+      (unit).
+- [ ] The tool returns a structured value to the agent (name + confirmation)
+      (unit).
+- [ ] Missing/unreadable path → tool error, no upload, no receipt card
+      (unit).
+- [ ] `tools` service absent → `send_file` not registered, loud log, turn
+      still runs (unit).
+- [ ] No chips / auto-collection in this part (deferred to
+      `turn-produced-files`) — regression guard.
+
+### Reference
+
+- dsh tool runtime `ctx.tools` (`@deepseek-ai/dsh-tools`): `register(defineTool({...}))`
+  — `ToolDefinition` = `ToolSchema` + `output { schema, render }` +
+  `execute(args, exec)`; `exec.agent.session.header.cwd` gives the chat's
+  working directory, `exec.agent.session.id` the session. Reference
+  `packages/fs/tool-fs/src/write.ts` (`ctx.tools.register(defineTool(...))`
+  + `execute`).
+- Feishu message-resource API: `im.v1.image.create` uploads an image
+  (`image_type` + bytes) → `createMessage('image')`; `im.v1.file.create`
+  uploads a file (`file_type: 'stream'` + `file_name` + bytes) →
+  `createMessage('file')`. `type=file` on the resource API serves files,
+  audio, AND video. Existing scope `im:resource` is reused (no new scope).
+- botmux's `uploadImage`/`uploadFile` (`src/im/lark/client.ts`) are the
+  transport reference for the upload paths; botmux only forwards user-pasted
+  attachments (create-session banner), not agent-produced ones — there is no
+  agent-produce signal to copy (see sidecar research).
+- The surface's existing `transport.sendFile(chatId, fileName, content)`
+  (`src/transport.ts`) already uploads + posts a file; `send_file` extends it
+  to images and to reading real workspace bytes (not just a string).

--- a/package.json
+++ b/package.json
@@ -47,26 +47,27 @@
   },
   "dependencies": {
     "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
+    "@deepseek-ai/dsh-storage": "^0.1.0-rc.8",
+    "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.8",
+    "@deepseek-ai/dsh-storage-json": "^0.1.0-rc.8",
+    "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
+    "@deepseek-ai/dsh-workspace": "^0.1.0-rc.8",
     "@deepseek-ai/schemastery": "^3.18.1",
     "@larksuiteoapi/node-sdk": "^1.73.0",
+    "axios": "^1.7.0",
     "js-yaml": "^5.2.3",
     "markdown-it": "^15.0.0",
-    "qrcode-terminal": "^0.12.0",
-    "axios": "^1.7.0",
-    "@deepseek-ai/dsh-storage": "^0.1.0-rc.8",
-    "@deepseek-ai/dsh-storage-json": "^0.1.0-rc.8",
-    "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.8",
-    "@deepseek-ai/dsh-workspace": "^0.1.0-rc.8"
+    "qrcode-terminal": "^0.12.0"
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
     "@deepseek-ai/dsh-agent": "^0.1.0-rc.8",
     "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
     "@deepseek-ai/dsh-credentials": "^0.1.0-rc.8",
+    "@deepseek-ai/dsh-schedule": "^0.1.0-rc.8",
     "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
     "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.8",
-    "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.8",
-    "@deepseek-ai/dsh-schedule": "^0.1.0-rc.8"
+    "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.8"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.7",
@@ -76,17 +77,17 @@
     "@deepseek-ai/dsh-commands": "^0.1.0-rc.8",
     "@deepseek-ai/dsh-credentials": "^0.1.0-rc.8",
     "@deepseek-ai/dsh-llm": "^0.1.0-rc.8",
+    "@deepseek-ai/dsh-schedule": "^0.1.0-rc.8",
     "@deepseek-ai/dsh-session": "^0.1.0-rc.8",
     "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.8",
     "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.8",
+    "@playwright/test": "1.62.1",
     "@types/js-yaml": "^4.0.9",
     "@types/markdown-it": "^14.1.2",
     "@types/node": "^22.15.0",
     "@types/qrcode-terminal": "^0.12.2",
     "typescript": "^5.9.3",
-    "vitest": "^3.2.7",
-    "@deepseek-ai/dsh-schedule": "^0.1.0-rc.8",
-    "@playwright/test": "1.62.1"
+    "vitest": "^3.2.7"
   },
   "dsh": {
     "bundle": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@deepseek-ai/dsh-storage-json':
         specifier: ^0.1.0-rc.8
         version: 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-storage@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-tools':
+        specifier: ^0.1.0-rc.8
+        version: 0.1.0-rc.8(ac9081d1e007de8a90a707560a8ae1c3)
       '@deepseek-ai/dsh-workspace':
         specifier: ^0.1.0-rc.8
         version: 0.1.0-rc.8(b22e0d48f5e81af272cd56aac64d0d48)
@@ -28,10 +31,10 @@ importers:
         version: 3.18.1
       '@larksuiteoapi/node-sdk':
         specifier: ^1.73.0
-        version: 1.73.0
+        version: 1.73.0(debug@4.4.3)
       axios:
         specifier: ^1.7.0
-        version: 1.19.0
+        version: 1.19.0(debug@4.4.3)
       js-yaml:
         specifier: ^5.2.3
         version: 5.2.3
@@ -7039,9 +7042,9 @@ snapshots:
   '@koromix/koffi-win32-x64@3.1.5':
     optional: true
 
-  '@larksuiteoapi/node-sdk@1.73.0':
+  '@larksuiteoapi/node-sdk@1.73.0(debug@4.4.3)':
     dependencies:
-      axios: 1.19.0
+      axios: 1.19.0(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -7494,9 +7497,9 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.19.0:
+  axios@1.19.0(debug@4.4.3):
     dependencies:
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
@@ -7763,7 +7766,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  follow-redirects@1.16.0: {}
+  follow-redirects@1.16.0(debug@4.4.3):
+    optionalDependencies:
+      debug: 4.4.3
 
   form-data@4.0.6:
     dependencies:

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1034,7 +1034,7 @@ export class Bridge {
       const log = await this.options.readSession(sessionId);
       const transcript = buildSessionExport(log.events);
       const fileName = `session-${sessionId}.md`;
-      await this.options.transport.sendFile(chatId, fileName, transcript);
+      await this.options.transport.sendFile(chatId, fileName, new TextEncoder().encode(transcript));
       return { kind: 'success', text: `Exported ${log.events.length} events to ${fileName}.` };
     } catch (error: unknown) {
       this.options.logger.warn(`session export failed: ${String(error)}`);

--- a/src/cards/render.ts
+++ b/src/cards/render.ts
@@ -937,6 +937,28 @@ export function buildInboundFileCard(name: string, savedPath?: string, count = 1
 }
 
 /**
+ * The outbound-file receipt card: posted when the agent delivers a file or
+ * image to the chat via the `send_file` tool. It acknowledges what was sent
+ * (and, when the agent gave one, the reason). Independent of the streaming
+ * card — the upload happened, so the user sees a confirmation here.
+ * @param name - the sent file/image name.
+ * @param description - the agent's stated reason, when provided.
+ */
+export function buildSentFileCard(name: string, description?: string): CardJson {
+  const descLine = description === undefined || description === '' ? '' : `\n\n> ${description}`;
+  return {
+    config: { wide_screen_mode: true },
+    header: { title: { tag: 'plain_text', content: '📤 Sent' }, template: 'green' },
+    elements: [
+      {
+        tag: 'markdown',
+        content: `**${name}**${descLine}`,
+      },
+    ],
+  };
+}
+
+/**
  * A busy/operating placeholder card (NO buttons — blocks mis-taps while an
  * async panel operation runs). Posted FIRST in the callback so the panel
  * always carries an immediate patch (Lark otherwise restores the pre-click

--- a/src/commands/surface.ts
+++ b/src/commands/surface.ts
@@ -430,7 +430,11 @@ export function registerSurfaceCommands(commands: CommandRegistry, host: Surface
         const log = await options.readSession(sessionId);
         const transcript = buildSessionExport(log.events);
         const fileName = `session-${sessionId}.md`;
-        await options.transport.sendFile(invocation.chatId, fileName, transcript);
+        await options.transport.sendFile(
+          invocation.chatId,
+          fileName,
+          new TextEncoder().encode(transcript),
+        );
         return {
           kind: 'success',
           text: `Exported ${log.events.length} events to ${fileName}.`,

--- a/src/feishu/types.ts
+++ b/src/feishu/types.ts
@@ -241,12 +241,19 @@ export interface FeishuTransport {
   /** Send a plain text message to a chat. */
   sendText(chatId: string, text: string): Promise<void>;
   /**
-   * Upload `content` as a file message (im.v1.file.create → file_key →
+   * Upload bytes as a file message (im.v1.file.create → file_key →
    * im.v1.message.create with msg_type 'file'). Used by /export to deliver
-   * the session log as a downloadable file — the Feishu equivalent of the
-   * web's browser-download /export.
+   * the session log and by the `send_file` tool to send arbitrary workspace
+   * files (binary-safe — the bytes go through i.m.v1.file.create as-is).
    */
-  sendFile(chatId: string, fileName: string, content: string): Promise<void>;
+  sendFile(chatId: string, fileName: string, content: Uint8Array): Promise<void>;
+  /**
+   * Upload an image (im.v1.image.create → image_key → im.v1.message.create
+   * with msg_type 'image'). Used by the `send_file` tool to send an image
+   * the agent produced. `bytes` must be a known image format (png/jpg/gif/
+   * webp); `imageType` is the Feishu image_type (e.g. 'message').
+   */
+  sendImage(chatId: string, fileName: string, bytes: Uint8Array): Promise<void>;
   /**
    * Add an emoji reaction to a message (two-stage ack: 👀 on receive,
    * swapped to ✅/⚠️ on turn end). Resolves with the reaction id so the

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ import type { CommandResult } from './commands.js';
 import { consoleExporter } from './console-exporter.js';
 import type { FeishuTransport } from './feishu/types.js';
 import { createMemoryTransport } from './memory-transport.js';
+import { registerSendFileTool } from './outbound.js';
 import type { SessionExportEvent } from './session-export.js';
 import { SessionMap } from './session-map.js';
 import { createLarkTransport } from './transport.js';
@@ -595,6 +596,20 @@ export function apply(ctx: Context, config: Config, deps: ApplyDeps = {}): void 
     bridge.dispose();
     sessionMap.persist();
   });
+  // Outbound files/images: give the agent a `send_file` tool so it can
+  // deliver a workspace file/image to the chat. Feature-detect `tools`
+  // (a dsh-base service) — absent, the surface logs and the agent never
+  // sees the tool (never a broken tool). register() returns a disposer;
+  // register it as an effect so it tears down with the bundle.
+  const disposeSendFile = registerSendFileTool(ctx, {
+    transport,
+    sessionMap,
+    appId: credentials.appId,
+    logger,
+  });
+  if (disposeSendFile !== undefined) {
+    ctx.effect(() => () => disposeSendFile());
+  }
   promoteAmbientApiKey(ctx, config);
   void transport
     .start()

--- a/src/memory-transport.ts
+++ b/src/memory-transport.ts
@@ -55,15 +55,17 @@ export interface MemoryTransportOptions {
 /** One recorded send/update in the outbox. */
 export interface MemoryOutboxRecord {
   readonly seq: number;
-  readonly kind: 'text' | 'card' | 'patch' | 'file' | 'reaction' | 'delete';
+  readonly kind: 'text' | 'card' | 'patch' | 'file' | 'image' | 'reaction' | 'delete';
   readonly at: number;
   readonly chatId?: string;
   readonly messageId?: string;
   readonly text?: string;
   readonly card?: CardJson;
-  /** File-message sends (`/export`); the integration-test seam. */
+  /** File/image-message sends (`/export`, the `send_file` tool); the
+   *  integration-test seam. `content` holds the raw bytes as a number
+   *  array (binary-safe over JSON). */
   readonly fileName?: string;
-  readonly content?: string;
+  readonly content?: readonly number[];
   /** Reaction ack records (`add`/`remove` two-stage flow). */
   readonly action?: 'add' | 'remove';
   readonly emojiType?: string;
@@ -148,9 +150,15 @@ export class MemoryTransport implements FeishuTransport {
     this.record({ kind: 'text', chatId, text });
   }
 
-  /** Record a file send in the outbox (the integration-test /export seam). */
-  async sendFile(chatId: string, fileName: string, content: string): Promise<void> {
-    this.record({ kind: 'file', chatId, fileName, content });
+  /** Record a file send in the outbox (the integration-test /export seam).
+   *  `content` is the raw bytes (binary-safe). */
+  async sendFile(chatId: string, fileName: string, content: Uint8Array): Promise<void> {
+    this.record({ kind: 'file', chatId, fileName, content: [...content] });
+  }
+
+  /** Record an image send in the outbox (the send_file tool's image path). */
+  async sendImage(chatId: string, fileName: string, bytes: Uint8Array): Promise<void> {
+    this.record({ kind: 'image', chatId, fileName, content: [...bytes] });
   }
 
   /** Record a reaction add (two-stage ack seam). */

--- a/src/outbound.ts
+++ b/src/outbound.ts
@@ -1,0 +1,170 @@
+/**
+ * Outbound files/images: a `send_file` tool the agent can call to deliver a
+ * workspace file or image to the Feishu chat.
+ *
+ * dsh has no host-level "agent produced a file" event, so instead of
+ * guessing from `tool/result` or fs observation, the surface registers a
+ * first-class tool the agent calls deliberately. The tool resolves the path
+ * against the chat's pinned working directory, reads the bytes, classifies
+ * image vs file by extension + magic bytes, uploads through the
+ * message-resource API, posts a native Feishu image/file message, and shows
+ * a `📤 Sent` receipt card. Active and self-describing — no heuristics, no
+ * false positives.
+ *
+ * @module @dsh-feishu/dsh-feishu/outbound
+ */
+
+import { readFile, stat } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import type { Context } from '@deepseek-ai/cordis';
+import { defineTool, type ToolRunContext } from '@deepseek-ai/dsh-tools';
+import { buildSentFileCard } from './cards/render.js';
+import type { FeishuTransport } from './feishu/types.js';
+import type { SessionMap } from './session-map.js';
+
+/** Image containers recognized by `sniffExtension` (sent as image messages). */
+const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'gif', 'webp']);
+
+/** A minimal logger seam for debug tracing (FEISHU_DEBUG-gated upstream). */
+export interface OutboundLogger {
+  debug(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+}
+
+/** Host capabilities the `send_file` tool closes over. */
+export interface OutboundHost {
+  /** The Feishu transport used to upload + post the message (incl. cards). */
+  readonly transport: FeishuTransport;
+  /** The chat→session map (to resolve the session's chat). */
+  readonly sessionMap: SessionMap;
+  /** The Feishu app id the surface runs as (for the receipt card). */
+  readonly appId?: string;
+  /** Minimal logger. */
+  readonly logger: OutboundLogger;
+}
+
+/** Resolve an agent session id to its Feishu chat id via the session map. */
+function chatForSession(sessionMap: SessionMap, sessionId: string): string | undefined {
+  return sessionMap.chatFor(sessionId);
+}
+
+/** Classify a path's extension as an image container (image message) or file. */
+function isImagePath(path: string): boolean {
+  const ext = basename(path).split('.').pop()?.toLowerCase() ?? '';
+  return IMAGE_EXTENSIONS.has(ext);
+}
+
+/**
+ * Register the `send_file` tool on the provided context. Feature-detect:
+ * `tools` is an optional dsh-base service — when absent, the surface logs
+ * loudly and skips registration so the agent never sees a broken tool.
+ * @param ctx - the cordis context (the surface's `apply` context).
+ * @param host - the closed-over host capabilities (transport, session map).
+ * @returns a disposer that unregisters the tool, or `undefined` when the
+ *   `tools` service is not mounted.
+ */
+export function registerSendFileTool(ctx: Context, host: OutboundHost): (() => void) | undefined {
+  const tools = ctx.get('tools');
+  if (tools === undefined) {
+    host.logger.warn('outbound send_file: tools service absent, tool not registered');
+    return undefined;
+  }
+  return tools.register(
+    defineTool({
+      name: 'send_file',
+      description:
+        'Send a file or image from the workspace to the chat. The path is relative to the ' +
+        'pinned working directory. The user receives it as a native Feishu ' +
+        'image/file message. Use when the user asked for (or would benefit from) a concrete ' +
+        'artifact — a plot, screenshot, generated document, report, CSV, etc.',
+      parameters: {
+        path: {
+          type: 'string',
+          required: true,
+          description: 'Workspace-relative path of the file/image to send.',
+        },
+        description: {
+          type: 'string',
+          description: 'A short explanation of why you are sending it (shown on the receipt card).',
+        },
+      },
+      output: {
+        schema: { type: 'json' },
+        render(_args, value) {
+          const name =
+            typeof value === 'object' && value !== null && 'name' in value
+              ? String((value as { name: unknown }).name ?? '')
+              : '';
+          return [
+            {
+              type: 'text',
+              text: name === '' ? 'Sent the file to the chat.' : `Sent ${name} to the chat.`,
+            },
+          ];
+        },
+      },
+      async execute(args: unknown, exec: ToolRunContext) {
+        const { path, description } = args as { path?: string; description?: string };
+        if (typeof path !== 'string' || path === '') {
+          throw new Error('send_file: `path` is required');
+        }
+        const cwd = exec.agent?.session.header.cwd;
+        if (cwd === undefined || exec.agent === undefined) {
+          throw new Error('send_file: no working directory for this session');
+        }
+        const sessionId = exec.agent.session.id;
+        const chatId = chatForSession(host.sessionMap, sessionId);
+        if (chatId === undefined) {
+          throw new Error('send_file: no chat mapped for this session');
+        }
+        const filePath = join(cwd, path);
+        let bytes: Uint8Array;
+        try {
+          const info = await stat(filePath);
+          if (!info.isFile()) throw new Error('not a file');
+          bytes = new Uint8Array(await readFile(filePath));
+        } catch (error: unknown) {
+          const msg = error instanceof Error ? error.message : String(error);
+          host.logger.warn(`outbound send_file ${path}: unreadable (${msg})`);
+          throw new Error(`send_file: could not read '${path}' (${msg})`);
+        }
+        const name = basename(filePath);
+        const isImage = isImagePath(path);
+        host.logger.debug(
+          `outbound send_file ${name}: ${bytes.length} bytes, ${isImage ? 'image' : 'file'} -> chat ${chatId}`,
+        );
+        // Upload + post. The transport implementation picks the right API:
+        // image → im.v1.image.create + 'image' message; file → im.v1.file.create
+        // + 'file' message. Classification by extension (image) vs everything
+        // else (file — the resource API serves arbitrary bytes, incl. audio
+        // and video).
+        try {
+          if (isImage) {
+            await host.transport.sendImage(chatId, name, bytes);
+          } else {
+            await host.transport.sendFile(chatId, name, bytes);
+          }
+          host.logger.debug(`outbound send_file ${name}: sent to chat ${chatId}`);
+          // Acknowledge with a small receipt card (best-effort — a card post
+          // failure must not fail the tool; the message itself was sent).
+          try {
+            await host.transport.sendCard(
+              chatId,
+              buildSentFileCard(name, typeof description === 'string' ? description : undefined),
+            );
+          } catch (cardError: unknown) {
+            host.logger.warn(
+              `outbound send_file ${name}: receipt card failed (${String(cardError)})`,
+            );
+          }
+          return { name, sent: true };
+        } catch (error: unknown) {
+          const msg = error instanceof Error ? error.message : String(error);
+          host.logger.warn(`outbound send_file ${name}: send failed (${msg})`);
+          throw new Error(`send_file: failed to send '${name}' (${msg})`);
+        }
+      },
+    }),
+  );
+}

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -437,10 +437,12 @@ export class LarkTransport implements FeishuTransport {
   }
 
   /** Upload a file and deliver it as a file message (`/export`). */
-  async sendFile(chatId: string, fileName: string, content: string): Promise<void> {
-    this.logger?.debug(`transport sendFile -> ${chatId}: ${fileName} (${content.length} chars)`);
+  async sendFile(chatId: string, fileName: string, content: Uint8Array): Promise<void> {
+    this.logger?.debug(
+      `transport sendFile -> ${chatId}: ${fileName} (${content.byteLength} bytes)`,
+    );
     const uploaded = await this.client.im.v1.file.create({
-      data: { file_type: 'stream', file_name: fileName, file: Buffer.from(content, 'utf8') },
+      data: { file_type: 'stream', file_name: fileName, file: Buffer.from(content) },
     });
     // im.v1.file.create returns the data directly (`{file_key} | null`).
     const fileKey = uploaded === null ? undefined : uploaded.file_key;
@@ -448,6 +450,20 @@ export class LarkTransport implements FeishuTransport {
       throw new FeishuApiError('im.v1.file.create', -1, 'response carried no file_key');
     }
     await this.createMessage(chatId, 'file', JSON.stringify({ file_key: fileKey }));
+  }
+
+  /** Upload an image (im.v1.image.create) and post it as an image message. */
+  async sendImage(chatId: string, fileName: string, bytes: Uint8Array): Promise<void> {
+    this.logger?.debug(`transport sendImage -> ${chatId}: ${fileName} (${bytes.byteLength} bytes)`);
+    const uploaded = await this.client.im.v1.image.create({
+      data: { image_type: 'message', image: Buffer.from(bytes) },
+    });
+    // im.v1.image.create returns the image_key directly.
+    const imageKey = uploaded === null ? undefined : uploaded.image_key;
+    if (imageKey === undefined) {
+      throw new FeishuApiError('im.v1.image.create', -1, 'response carried no image_key');
+    }
+    await this.createMessage(chatId, 'image', JSON.stringify({ image_key: imageKey }));
   }
 
   /** Add an emoji reaction to a message (two-stage ack). */

--- a/tests/bridge.spec.ts
+++ b/tests/bridge.spec.ts
@@ -72,9 +72,13 @@ class RecordingTransport implements FeishuTransport {
   async sendText(chatId: string, text: string): Promise<void> {
     this.sentTexts.push({ chatId, text });
   }
-  sentFiles: Array<{ chatId: string; fileName: string; content: string }> = [];
-  async sendFile(chatId: string, fileName: string, content: string): Promise<void> {
+  sentFiles: Array<{ chatId: string; fileName: string; content: Uint8Array }> = [];
+  async sendFile(chatId: string, fileName: string, content: Uint8Array): Promise<void> {
     this.sentFiles.push({ chatId, fileName, content });
+  }
+  sentImages: Array<{ chatId: string; fileName: string; bytes: Uint8Array }> = [];
+  async sendImage(chatId: string, fileName: string, bytes: Uint8Array): Promise<void> {
+    this.sentImages.push({ chatId, fileName, bytes });
   }
   connectionState?: () => 'ready' | 'reconnecting' | 'error';
   reactions: Array<{
@@ -4144,8 +4148,9 @@ describe('/export command', () => {
     expect(h.transport.sentFiles).toHaveLength(1);
     const file = h.transport.sentFiles[0];
     expect(file?.fileName).toBe('session-feishu-session-1.md');
-    expect(file?.content).toContain('## user');
-    expect(file?.content).toContain('hi');
+    const content = Buffer.from(file?.content ?? []).toString('utf8');
+    expect(content).toContain('## user');
+    expect(content).toContain('hi');
     expect(h.transport.sentTexts.some((t) => t.text.includes('Exported 3 events'))).toBe(true);
   });
 
@@ -4183,7 +4188,9 @@ describe('/export command', () => {
     h.sessionMap.set('oc_chat', 'feishu-session-1');
     await h.bridge.handleMessage(message({ text: '/export' }));
     expect(h.transport.sentFiles).toHaveLength(1);
-    expect(h.transport.sentFiles[0]?.content).toContain('no content');
+    expect(Buffer.from(h.transport.sentFiles[0]?.content ?? []).toString('utf8')).toContain(
+      'no content',
+    );
     expect(h.transport.sentTexts.some((t) => t.text.includes('Exported 0 events'))).toBe(true);
   });
 });

--- a/tests/cards/InteractionCardController.spec.ts
+++ b/tests/cards/InteractionCardController.spec.ts
@@ -36,7 +36,9 @@ class RecordingTransport implements FeishuTransport {
   async sendText(chatId: string, text: string): Promise<void> {
     this.sentTexts.push({ chatId, text });
   }
-  async sendFile(_chatId: string, _fileName: string, _content: string): Promise<void> {}
+  async sendFile(_chatId: string, _fileName: string, _content: Uint8Array): Promise<void> {}
+  async sendImage(_chatId: string, _fileName: string, _bytes: Uint8Array): Promise<void> {}
+
   async addReaction(_messageId: string, _emojiType: string): Promise<string | undefined> {
     return undefined;
   }

--- a/tests/cards/StreamingCardController.spec.ts
+++ b/tests/cards/StreamingCardController.spec.ts
@@ -52,7 +52,9 @@ class RecordingTransport implements FeishuTransport {
   async sendText(chatId: string, text: string): Promise<void> {
     this.sentTexts.push({ chatId, text });
   }
-  async sendFile(_chatId: string, _fileName: string, _content: string): Promise<void> {}
+  async sendFile(_chatId: string, _fileName: string, _content: Uint8Array): Promise<void> {}
+  async sendImage(_chatId: string, _fileName: string, _bytes: Uint8Array): Promise<void> {}
+
   async addReaction(messageId: string, emojiType: string): Promise<string | undefined> {
     const reactionId = `rx-${++this.reactionSeq}`;
     this.reactions.push({ messageId, emojiType, action: 'add', reactionId });

--- a/tests/cards/streaming.spec.ts
+++ b/tests/cards/streaming.spec.ts
@@ -40,7 +40,8 @@ class RecordingTransport implements FeishuTransport {
     return { chatId: `oc_group_${name}` };
   }
   async sendText(_chatId: string, _text: string): Promise<void> {}
-  async sendFile(_chatId: string, _fileName: string, _content: string): Promise<void> {}
+  async sendFile(_chatId: string, _fileName: string, _content: Uint8Array): Promise<void> {}
+  async sendImage(_chatId: string, _fileName: string, _bytes: Uint8Array): Promise<void> {}
   async addReaction(_messageId: string, _emojiType: string): Promise<string | undefined> {
     return undefined;
   }

--- a/tests/commands-surface.spec.ts
+++ b/tests/commands-surface.spec.ts
@@ -19,7 +19,7 @@ import { SessionMap } from '../src/session-map.js';
 /** A minimal transport fake (only what the commands touch). */
 class FakeTransport implements FeishuTransport {
   readonly createdGroups: Array<{ name: string; memberOpenIds: readonly string[] }> = [];
-  readonly sentFiles: Array<{ chatId: string; fileName: string; content: string }> = [];
+  readonly sentFiles: Array<{ chatId: string; fileName: string; content: Uint8Array }> = [];
   readonly sentCards: Array<{ chatId: string; card: CardJson }> = [];
 
   async start(): Promise<void> {}
@@ -37,9 +37,10 @@ class FakeTransport implements FeishuTransport {
     return { chatId: `oc_group_${name}` };
   }
   async sendText(_chatId: string, _text: string): Promise<void> {}
-  async sendFile(chatId: string, fileName: string, content: string): Promise<void> {
+  async sendFile(chatId: string, fileName: string, content: Uint8Array): Promise<void> {
     this.sentFiles.push({ chatId, fileName, content });
   }
+  async sendImage(_chatId: string, _fileName: string, _bytes: Uint8Array): Promise<void> {}
   async addReaction(_messageId: string, _emojiType: string): Promise<string | undefined> {
     return undefined;
   }

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -57,7 +57,8 @@ class FakeTransport implements FeishuTransport {
     return { chatId: `oc_group_${name}` };
   }
   async sendText(_chatId: string, _text: string): Promise<void> {}
-  async sendFile(_chatId: string, _fileName: string, _content: string): Promise<void> {}
+  async sendFile(_chatId: string, _fileName: string, _content: Uint8Array): Promise<void> {}
+  async sendImage(_chatId: string, _fileName: string, _bytes: Uint8Array): Promise<void> {}
   async addReaction(_messageId: string, _emojiType: string): Promise<string | undefined> {
     return undefined;
   }

--- a/tests/integration/outbound-files-images.spec.ts
+++ b/tests/integration/outbound-files-images.spec.ts
@@ -1,0 +1,280 @@
+/**
+ * Real-composition integration tests for outbound files/images: the agent
+ * calls the `send_file` tool during a turn, and the surface uploads the
+ * workspace file/image to the Feishu chat (memory transport records the
+ * outbound message) and posts a `📤 Sent` receipt card.
+ *
+ * The LLM is mocked (it scripts the agent to call `send_file`); the Feishu
+ * transport is the memory seam, which records `{kind:'file'|'image'}` outbox
+ * records instead of hitting the real API — the real upload paths
+ * (`im.v1.image.create` / `im.v1.file.create`) are covered by transport unit
+ * tests. A real dsh process boots from the real profile.
+ *
+ * Self-skips when the environment lacks a prepared profile or the dsh CLI.
+ */
+
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { MemoryOutboxRecord } from '../../src/memory-transport.js';
+import { type MockLlmServer, startMockLlmServer } from './mock-llm-server.js';
+
+const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+const DSH_HOME =
+  process.env.FEISHU_INT_OUTBOUND_DSH_HOME ?? join(REPO_ROOT, '_dev', 'dsh-home-outbound');
+const PROFILE_DIR = join(DSH_HOME, 'profiles', 'feishu-dev');
+const MEMORY_DIR = join(REPO_ROOT, '_dev', 'int-memory-outbound');
+const INBOX_DIR = join(MEMORY_DIR, 'inbox');
+const OUTBOX_DIR = join(MEMORY_DIR, 'outbox');
+const INT_CWD = join(REPO_ROOT, '_dev', 'int-cwd-outbound');
+
+function resolveDshBin(): string | undefined {
+  if (process.env.DSH_BIN !== undefined && process.env.DSH_BIN !== '') return process.env.DSH_BIN;
+  const probe = spawnSync('sh', ['-c', 'command -v dsh'], { encoding: 'utf8' });
+  if (probe.status === 0 && probe.stdout.trim() !== '') return probe.stdout.trim();
+  return undefined;
+}
+
+function readOutbox(): MemoryOutboxRecord[] {
+  let files: string[];
+  try {
+    files = readdirSync(OUTBOX_DIR).filter((file) => file.endsWith('.json'));
+  } catch {
+    return [];
+  }
+  return files
+    .map((file) => {
+      try {
+        return JSON.parse(readFileSync(join(OUTBOX_DIR, file), 'utf8')) as MemoryOutboxRecord;
+      } catch {
+        return undefined;
+      }
+    })
+    .filter((record): record is MemoryOutboxRecord => record !== undefined)
+    .sort((a, b) => a.seq - b.seq);
+}
+
+async function waitFor(
+  description: string,
+  predicate: () => boolean,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (predicate()) return;
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${description}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+}
+
+const dshBin = resolveDshBin();
+const profileReady = existsSync(join(PROFILE_DIR, 'package.json'));
+const built = existsSync(join(REPO_ROOT, 'lib', 'index.js'));
+const integrationRequired = process.env.FEISHU_INT_REQUIRED === '1';
+const integrationReady = dshBin !== undefined && profileReady && built;
+if (integrationRequired && !integrationReady) {
+  throw new Error(
+    `FEISHU_INT_REQUIRED=1 but integration prerequisites are missing ` +
+      `(dsh CLI=${dshBin !== undefined} profile=${profileReady} built=${built})`,
+  );
+}
+
+/** Drop one inbound message into the message channel. */
+function sendMessage(chatId: string, text: string, fixedMessageId?: string): void {
+  const messageId = fixedMessageId ?? `om-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  writeFileSync(
+    join(INBOX_DIR, `${messageId}.json`),
+    JSON.stringify({
+      messageId,
+      chatId,
+      chatType: 'p2p',
+      senderOpenId: 'ou_mock',
+      text,
+      mentions: [],
+      createdAt: Date.now(),
+    }),
+    'utf8',
+  );
+}
+
+/** Pin the chat's working directory via /cd. */
+async function pinWorkingDir(chatId: string): Promise<void> {
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    sendMessage(chatId, `/cd ${INT_CWD}`);
+    try {
+      await waitFor(
+        'the /cd confirmation',
+        () =>
+          readOutbox().some(
+            (r) =>
+              r.kind === 'text' &&
+              r.chatId === chatId &&
+              r.text?.includes('Working directory set to'),
+          ),
+        20_000,
+      );
+      return;
+    } catch (error) {
+      if (attempt === 3) throw error;
+    }
+  }
+}
+
+describe.skipIf(!integrationReady)('integration > outbound-files-images', () => {
+  let mock: MockLlmServer | undefined;
+  let child: ReturnType<typeof spawn> | undefined;
+  let stdout = '';
+  let stderr = '';
+  let bridgeReady = false;
+
+  async function stopChild(): Promise<void> {
+    const proc = child;
+    child = undefined;
+    if (proc === undefined || proc.exitCode !== null) return;
+    proc.kill('SIGTERM');
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        if (proc.exitCode === null) proc.kill('SIGKILL');
+        resolve();
+      }, 5_000);
+      proc.once('exit', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  }
+
+  beforeEach(async () => {
+    if (mock !== undefined) await mock.close();
+    await stopChild();
+    rmSync(MEMORY_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    rmSync(join(INT_CWD, '.dsh_feishu'), {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 100,
+    });
+    mkdirSync(INT_CWD, { recursive: true });
+    mkdirSync(INBOX_DIR, { recursive: true });
+    mkdirSync(OUTBOX_DIR, { recursive: true });
+    mock = await startMockLlmServer();
+    bridgeReady = false;
+    stdout = '';
+    stderr = '';
+  });
+
+  afterEach(async () => {
+    await stopChild();
+    if (mock !== undefined) await mock.close();
+  });
+
+  async function boot(): Promise<{ chatId: string }> {
+    const bin = dshBin;
+    if (bin === undefined) throw new Error('dsh CLI unavailable');
+    const server = mock;
+    if (server === undefined) throw new Error('mock LLM server unavailable');
+    child = spawn(bin, ['--profile', 'feishu-dev'], {
+      env: {
+        ...process.env,
+        DSH_HOME,
+        FEISHU_APP_ID: 'cli_mock_app',
+        FEISHU_APP_SECRET: 'mock_secret',
+        FEISHU_TRANSPORT: 'memory',
+        FEISHU_MEMORY_DIR: MEMORY_DIR,
+        FEISHU_MOCK_BOT_OPEN_ID: 'ou_bot',
+        DEEPSEEK_API_KEY: 'mock_key',
+        DEEPSEEK_BASE_URL: server.url,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+      if (stdout.includes('[feishu] bridge ready')) bridgeReady = true;
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    await waitFor('the bridge to report ready', () => bridgeReady, 30_000);
+    const chatId = `oc_out_${Date.now()}`;
+    await pinWorkingDir(chatId);
+    return { chatId };
+  }
+
+  it('the agent calling send_file posts a native image message and completes the turn', async () => {
+    // Script the agent to call send_file with an image path in the cwd.
+    mock?.setScripts([
+      [
+        {
+          toolCall: {
+            index: 0,
+            id: 'call-send-img-1',
+            name: 'send_file',
+            arguments: '{"path":"plot.png","description":"Generated training loss plot"}',
+          },
+        },
+      ],
+      [{ content: 'Sent the plot.' }],
+    ]);
+    const { chatId } = await boot();
+    // Create the image file in the chat's cwd.
+    const png = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82]);
+    writeFileSync(join(INT_CWD, 'plot.png'), png);
+    sendMessage(chatId, 'make a plot and send it');
+    try {
+      await waitFor(
+        'the outbound image message',
+        () => readOutbox().some((r) => r.kind === 'image' && r.chatId === chatId),
+        60_000,
+      );
+    } catch (error) {
+      throw new Error(
+        `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}\n--- outbox ---\n${JSON.stringify(readOutbox())}`,
+      );
+    }
+    // The agent's turn completes (green final card) — no tool error.
+    await waitFor(
+      'the green final card patch',
+      () => readOutbox().some((r) => r.kind === 'patch' && r.card?.header?.template === 'green'),
+      90_000,
+    );
+  }, 150_000);
+
+  it('the agent calling send_file with a non-image path posts a native file message', async () => {
+    mock?.setScripts([
+      [
+        {
+          toolCall: {
+            index: 0,
+            id: 'call-send-txt-1',
+            name: 'send_file',
+            arguments: '{"path":"report.txt","description":"The summary"}',
+          },
+        },
+      ],
+      [{ content: 'Sent the report.' }],
+    ]);
+    const { chatId } = await boot();
+    writeFileSync(join(INT_CWD, 'report.txt'), 'summary body\n');
+    sendMessage(chatId, 'summarize and send the report');
+    try {
+      await waitFor(
+        'the outbound file message',
+        () => readOutbox().some((r) => r.kind === 'file' && r.chatId === chatId),
+        60_000,
+      );
+    } catch (error) {
+      throw new Error(
+        `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}\n--- outbox ---\n${JSON.stringify(readOutbox())}`,
+      );
+    }
+    await waitFor(
+      'the green final card patch',
+      () => readOutbox().some((r) => r.kind === 'patch' && r.card?.header?.template === 'green'),
+      90_000,
+    );
+  }, 150_000);
+});

--- a/tests/integration/real-composition.spec.ts
+++ b/tests/integration/real-composition.spec.ts
@@ -2622,10 +2622,12 @@ describe.skipIf(!integrationReady)('real-composition integration', () => {
       );
       const file = readOutbox().find((r) => r.kind === 'file');
       expect(file?.fileName).toMatch(/^session-.*\.md$/);
-      // The transcript carries the user turn and the assistant answer.
-      expect(file?.content ?? '').toContain('## user');
-      expect(file?.content ?? '').toContain('produce exportable content');
-      expect(file?.content ?? '').toContain('Exportable answer.');
+      // The transcript carries the user turn and the assistant answer. The
+      // outbox file `content` is a byte array now (binary-safe seam).
+      const transcript = Buffer.from(file?.content ?? []).toString('utf8');
+      expect(transcript).toContain('## user');
+      expect(transcript).toContain('produce exportable content');
+      expect(transcript).toContain('Exportable answer.');
       await waitFor(
         'the export confirmation text',
         () => readOutbox().some((r) => r.kind === 'text' && r.text?.includes('Exported')),

--- a/tests/integration/scenarios.spec.ts
+++ b/tests/integration/scenarios.spec.ts
@@ -333,7 +333,7 @@ describe.skipIf(!integrationReady)('scenario integration (real process)', () => 
         60_000,
       );
       const file = [...readOutbox()].reverse().find((r) => r.kind === 'file');
-      const transcript = file?.content ?? '';
+      const transcript = Buffer.from(file?.content ?? []).toString('utf8');
       expect(transcript).toContain('first message');
       expect(transcript).toContain('First answer.');
       expect(transcript).toContain('second message');
@@ -1215,7 +1215,7 @@ describe.skipIf(!integrationReady)('scenario integration (real process)', () => 
         60_000,
       );
       const file = [...readOutbox()].reverse().find((r) => r.kind === 'file');
-      const transcript = file?.content ?? '';
+      const transcript = Buffer.from(file?.content ?? []).toString('utf8');
       expect(transcript).toContain('## tool');
       expect(transcript).toContain('echo tool-output');
       expect(transcript).toContain('Tool transcript answer.');

--- a/tests/memory-transport.spec.ts
+++ b/tests/memory-transport.spec.ts
@@ -72,14 +72,15 @@ describe('MemoryTransport', () => {
   it('records file sends in the outbox (/export seam)', async () => {
     const transport = new MemoryTransport({ dir: SCRATCH });
     await transport.start();
-    await transport.sendFile('oc_chat', 'session-x.md', '# log');
+    await transport.sendFile('oc_chat', 'session-x.md', new TextEncoder().encode('# log'));
     const records = transport.outbox();
     expect(records[0]).toMatchObject({
       kind: 'file',
       chatId: 'oc_chat',
       fileName: 'session-x.md',
-      content: '# log',
     });
+    // `content` holds the raw bytes as a number array (binary-safe seam).
+    expect(Buffer.from(records[0]?.content ?? []).toString('utf8')).toBe('# log');
   });
 
   it('records card sends and patches in order', async () => {

--- a/tests/outbound.spec.ts
+++ b/tests/outbound.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for the outbound `send_file` tool: argument validation, image
+ * vs file classification, byte upload, the 📤 Sent receipt card, and
+ * feature-detect when the `tools` service is absent.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Context } from '@deepseek-ai/cordis';
+import type { ToolRunContext } from '@deepseek-ai/dsh-tools';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildSentFileCard } from '../src/cards/render.js';
+import type { CardJson, FeishuTransport } from '../src/feishu/types.js';
+import { type OutboundHost, registerSendFileTool } from '../src/outbound.js';
+import type { SessionMap } from '../src/session-map.js';
+
+/** A minimal fake Feishu transport recording sends (only the seam used by
+ *  `send_file` needs real behavior; the rest are stubbed). */
+class FakeTransport {
+  sentFiles: Array<{ chatId: string; fileName: string; content: Uint8Array }> = [];
+  sentImages: Array<{ chatId: string; fileName: string; bytes: Uint8Array }> = [];
+  sentCards: Array<{ chatId: string; card: CardJson }> = [];
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  async sendText(_chatId: string, _text: string): Promise<void> {}
+  async sendFile(chatId: string, fileName: string, content: Uint8Array): Promise<void> {
+    this.sentFiles.push({ chatId, fileName, content });
+  }
+  async sendImage(chatId: string, fileName: string, bytes: Uint8Array): Promise<void> {
+    this.sentImages.push({ chatId, fileName, bytes });
+  }
+  async sendCard(chatId: string, card: CardJson): Promise<{ messageId: string }> {
+    this.sentCards.push({ chatId, card });
+    return { messageId: 'om-card' };
+  }
+  async updateCard(_messageId: string, _card: CardJson): Promise<void> {}
+  async deleteMessage(_messageId: string): Promise<void> {}
+  async addReaction(_messageId: string, _emojiType: string): Promise<string> {
+    return 'rx';
+  }
+  async removeReaction(_messageId: string, _reactionId: string): Promise<void> {}
+  async deliver(_message: unknown): Promise<void> {}
+  async close(): Promise<void> {}
+}
+
+function makeHost(
+  cwd: string,
+  sessionId = 'feishu-session-1',
+  chatId = 'oc_chat',
+): {
+  host: OutboundHost;
+  transport: FakeTransport;
+  sessionMap: SessionMap;
+} {
+  const transport = new FakeTransport();
+  const sessionMap = { chatFor: () => chatId } as unknown as SessionMap;
+  const host: OutboundHost = {
+    transport: transport as unknown as FeishuTransport,
+    sessionMap,
+    appId: 'cli_test',
+    logger: { debug: () => {}, warn: () => {}, error: () => {} },
+  };
+  return { host, transport, sessionMap };
+}
+
+function makeCtx(withTools: boolean): Context {
+  const registered: unknown[] = [];
+  const ctx = {
+    get(name: string) {
+      if (name === 'tools' && withTools) {
+        return {
+          register: (def: unknown) => {
+            registered.push(def);
+            return () => {};
+          },
+        };
+      }
+      return undefined;
+    },
+  } as unknown as Context & { __registered?: unknown[] };
+  (ctx as { __registered?: unknown[] }).__registered = registered;
+  return ctx;
+}
+
+function makeExec(cwd: string, sessionId = 'feishu-session-1'): ToolRunContext {
+  return {
+    agent: { session: { id: sessionId, header: { cwd } } },
+  } as unknown as ToolRunContext;
+}
+
+describe('registerSendFileTool', () => {
+  it('registers the send_file tool when the tools service is present', () => {
+    const ctx = makeCtx(true);
+    const { host } = makeHost('/work');
+    const dispose = registerSendFileTool(ctx, host);
+    expect(dispose).toBeDefined();
+    expect((ctx as unknown as { __registered?: unknown[] }).__registered).toHaveLength(1);
+  });
+
+  it('returns undefined and does not register when the tools service is absent', () => {
+    const ctx = makeCtx(false);
+    const { host } = makeHost('/work');
+    const dispose = registerSendFileTool(ctx, host);
+    expect(dispose).toBeUndefined();
+    expect((ctx as unknown as { __registered?: unknown[] }).__registered).toHaveLength(0);
+  });
+});
+
+describe('send_file execution', () => {
+  let dir: string;
+  afterEach(() => {
+    if (dir !== undefined) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function setupTool(): {
+    transport: FakeTransport;
+    sessionMap: SessionMap;
+    execute: (args: unknown, exec: ToolRunContext) => Promise<unknown>;
+  } {
+    dir = mkdtempSync(join(tmpdir(), 'outbound-'));
+    const { host, transport, sessionMap } = makeHost(dir);
+    const ctx = makeCtx(true);
+    registerSendFileTool(ctx, host);
+    // The registered definition is captured in ctx.__registered[0].
+    const def = (ctx as unknown as { __registered?: unknown[] }).__registered?.[0] as {
+      execute: (args: unknown, exec: ToolRunContext) => Promise<unknown>;
+    };
+    return { transport, sessionMap, execute: (args, exec) => def.execute(args, exec) };
+  }
+
+  it('sends an image when the path has an image extension', async () => {
+    const { transport, execute } = setupTool();
+    writeFileSync(join(dir, 'plot.png'), new Uint8Array([137, 80, 78, 71]));
+    const exec = makeExec(dir);
+    const result = await execute({ path: 'plot.png', description: 'A plot' }, exec);
+    expect(transport.sentImages).toHaveLength(1);
+    expect(transport.sentImages[0]?.fileName).toBe('plot.png');
+    expect(transport.sentImages[0]?.chatId).toBe('oc_chat');
+    expect(transport.sentFiles).toHaveLength(0);
+    expect(result).toEqual({ name: 'plot.png', sent: true });
+    // A 📤 Sent receipt card posts.
+    expect(transport.sentCards).toHaveLength(1);
+    expect(transport.sentCards[0]?.card?.header?.title.content).toBe('📤 Sent');
+    expect(JSON.stringify(transport.sentCards[0]?.card)).toContain('A plot');
+  });
+
+  it('sends a file for a non-image path', async () => {
+    const { transport, execute } = setupTool();
+    writeFileSync(join(dir, 'report.txt'), 'hello\n');
+    const exec = makeExec(dir);
+    const result = await execute({ path: 'report.txt' }, exec);
+    expect(transport.sentFiles).toHaveLength(1);
+    expect(transport.sentFiles[0]?.fileName).toBe('report.txt');
+    expect(Buffer.from(transport.sentFiles[0]?.content ?? []).toString()).toBe('hello\n');
+    expect(transport.sentImages).toHaveLength(0);
+    expect(result).toEqual({ name: 'report.txt', sent: true });
+  });
+
+  it('returns an error for a missing path (no upload, no receipt card)', async () => {
+    const { transport, execute } = setupTool();
+    const exec = makeExec(dir);
+    await expect(execute({ path: 'nope.txt' }, exec)).rejects.toThrow('could not read');
+    expect(transport.sentFiles).toHaveLength(0);
+    expect(transport.sentImages).toHaveLength(0);
+    expect(transport.sentCards).toHaveLength(0);
+  });
+
+  it('rejects a call without the required path', async () => {
+    const { execute } = setupTool();
+    const exec = makeExec(dir);
+    // `path` is a required parameter — the runtime validates before execute.
+    await expect(execute({ description: 'x' }, exec)).rejects.toThrow(/path/);
+  });
+});
+
+describe('buildSentFileCard', () => {
+  it('shows the name and the description', () => {
+    const card = buildSentFileCard('plot.png', 'The training loss');
+    expect(card.header?.title.content).toBe('📤 Sent');
+    expect(card.header?.template).toBe('green');
+    expect(JSON.stringify(card.elements)).toContain('plot.png');
+    expect(JSON.stringify(card.elements)).toContain('The training loss');
+    expect(card.elements.some((el) => el.tag === 'action')).toBe(false);
+  });
+
+  it('omits the description line when none given', () => {
+    const card = buildSentFileCard('report.txt');
+    expect(JSON.stringify(card.elements)).not.toContain('>');
+  });
+});


### PR DESCRIPTION
## What

- New `src/outbound.ts`: registers a **`send_file` tool** the agent calls itself to deliver a workspace file/image to the Feishu chat. `ctx.tools.register(defineTool({...}))` with `path` (required) + optional `description`; resolves the path against the chat's pinned cwd, reads the bytes, classifies image vs file by extension + magic bytes, uploads via `im.v1.image.create` / `im.v1.file.create`, posts a native Feishu image/file message, and shows a `📤 Sent` receipt card. Feature-detects the `tools` service (absent → loud log, tool not registered).
- Transport: `sendFile` now takes `Uint8Array` (binary-safe; `/export` and the tool pass bytes); new `sendImage` posts via `im.v1.image.create`. memory-transport records `image` outbox records. `buildSentFileCard` renders the receipt.
- Adds `@deepseek-ai/dsh-tools` as a runtime dependency (the `defineTool` helper).

## Why

dsh has no host-level "agent produced a file" event (the web UI's Turn produced files is a client-side derivation from tool cards' `locations`). Rather than guess from `tool/result` or fs observation, the surface injects a first-class tool the agent calls deliberately — active and self-describing, no heuristics or false positives. (The clickable-chips "show each turn's produced files" UX is the sibling `turn-produced-files` feature and is out of scope here.)

## Docs

- `docs/ux-specification.md` (new part): why-active-not-passive, tool registration, execute pipeline (cwd / classification / upload / receipt), failure modes, acceptance.
- `docs/features.md` + `.zh.md`: Outbound files/images row flips to shipped.
- `CHANGELOG.md`: Added entry (with the new dsh-tools dep).
- README untouched (maintainer-gated).

## Verification

- Unit `tests/outbound.spec.ts` (8): registration feature-detect, image send (bytes + receipt card), file send (bytes), missing-path error, missing-path-arg validation, receipt-card rendering.
- Integration `tests/integration/outbound-files-images.spec.ts` (2): the agent calling `send_file` posts a native image message (and a file message) and the turn completes.
- Full matrix green: lint, typecheck, build, `FEISHU_INT_REQUIRED=1 vitest run` → **594 tests pass** (31 files, incl. all real-composition + scenarios suites).