### PR TITLE
test(e2e): cover local-resolving surface commands with smoke scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **More E2E smoke scenarios for the real-client suite.** The E2E suite
+  now covers the local-resolving surface commands (no LLM round-trip), each
+  in its own backend group that is disbanded afterwards: `/status`,
+  `/feishu-status` (the real long-connection check), `/schedule` (no-session
+  notice), `/panel` (control-panel card + a button that resolves to the
+  stop-turn command), `/repo` (project picker card) and bare `/model` (model
+  picker card). Added shared scenario scaffolding (`e2e/helpers/scenario.ts`)
+  and helpers `waitForCardContaining` / `clickCardButton`. See
+  `docs/e2e-testing.md` → "Scenarios".
+
 - **dsh family bumped to `0.1.0-rc.8`.** `@deepseek-ai/dsh` is pinned
   exactly in devDependencies; the rest of the `@deepseek-ai/*` surface
   moves to `^0.1.0-rc.8` (dev, peer, AND runtime deps — the runtime

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -83,7 +83,31 @@ Key pieces:
   / `im.v1.chat.delete`, the same calls `/group` wraps) + the unique group
   name builder.
 - **e2e/helpers/assert.ts** — rule-based chat assertions.
+- **e2e/helpers/scenario.ts** — the shared group-chat lifecycle every scenario
+  uses (create backend group → open → screenshot → disband in `finally`).
 - **e2e/scenarios/*.spec.ts** — one file per scenario.
+
+### Scenarios
+
+The suite covers the surface commands that resolve locally (no LLM round-trip
+in the loop), so every assertion is deterministic. Each scenario runs in its
+own backend group and disbands it afterwards.
+
+| Scenario | Asserts |
+| --- | --- |
+| `help.spec.ts` | `/help` → `dsh-feishu commands:` block |
+| `status.spec.ts` | `/status` → local `chat:` / `mention mode:` text |
+| `feishu-status.spec.ts` | `/feishu-status` → diagnostic card (`connection:`) — the real long-connection check |
+| `schedule.spec.ts` | `/schedule` on a fresh group → `no session yet` notice |
+| `panel.spec.ts` | `/panel` → control-panel card with command buttons; clicking `Stop turn` resolves to the stop-turn command |
+| `repo-picker.spec.ts` | `/repo` → project-picker panel card (`Pick a project`) |
+| `model-picker.spec.ts` | bare `/model` → model-picker panel card (`Choose a model`) |
+
+The deeper picker selections (choosing a project/model) and interactions that
+need a real session/catalog/allowlist stay in the integration suite — the
+E2E layer proves the cards render and the panel buttons fire, not the choice
+logic.
+
 - **e2e/Dockerfile** — the run image: Playwright's official image + full
   ffmpeg (the bundled one only encodes VP8; mp4 conversion needs H.264).
 
@@ -190,29 +214,23 @@ video/screenshot policy) lives in `summary.json` / `summary.html`.
    ```ts
    import { test } from '@playwright/test';
    import { loadE2eConfig } from '../helpers/config.js';
-   import { waitForBotReplyContaining } from '../helpers/assert.js';
-   import { openApp, openChat, sendMessage, snapshot } from '../helpers/feishu.js';
+   import { waitForCardContaining } from '../helpers/assert.js';
+   import { sendMessage, snapshot } from '../helpers/feishu.js';
    import { caseIdFromTitle } from '../helpers/report.js';
-   import { createGroup, deleteGroup, groupNameFor } from '../helpers/group.js';
+   import { disbandGroup, openCaseGroup, scenarioDebug } from '../helpers/scenario.js';
 
    const cfg = loadE2eConfig();
+   const debug = scenarioDebug(process.env.E2E_DEBUG === '1');
 
    test('send /model → model picker card', async ({ page }, testInfo) => {
      const caseId = caseIdFromTitle(testInfo.title);
-     const groupName = groupNameFor(caseId, cfg.runId);
-     const { chatId } = await createGroup(cfg, groupName, [cfg.userOpenId!]);
+     const { groupName, chatId } = await openCaseGroup(page, cfg, caseId, cfg.timeoutMs, debug);
      try {
-       await openApp(page, cfg);
-       await openChat(page, groupName, cfg.timeoutMs);
-       await snapshot(page, cfg, 'model-chat-open', caseId);
        await sendMessage(page, '/model');
-       await waitForBotReplyContaining(page, 'Model', cfg.timeoutMs);
+       await waitForCardContaining(page, 'Choose a model', cfg.timeoutMs);
        await snapshot(page, cfg, 'model-picker', caseId);
      } finally {
-       // Disband the group so runs do not accumulate chats.
-       await deleteGroup(cfg, chatId).catch((error) =>
-         console.warn(`[cleanup] could not disband ${groupName}: ${error.message}`),
-       );
+       await disbandGroup(cfg, groupName, chatId, debug);
      }
    });
    ```
@@ -232,8 +250,12 @@ video/screenshot policy) lives in `summary.json` / `summary.html`.
 | `sendMessage(page, text)` | type into the chat composer and send |
 | `chatMessages(page)` | read the rendered messages `{text, isSelf}[]` |
 | `clickButton(page, label)` / `clickCardText(page, label)` | click a card button / card text |
+| `clickCardButton(page, label)` | click a button inside the last bot card (panel action) |
 | `snapshot(page, cfg, label, caseId)` | save a key screenshot into `report/screenshots/<caseId>/` |
 | `waitForBotReplyContaining(page, text, timeoutMs)` | wait for a bot reply containing text (rule-based) |
+| `waitForCardContaining(page, text, timeoutMs)` | wait for a rendered card containing text (rule-based) |
+| `openCaseGroup(page, cfg, caseId, timeoutMs, debug)` | create a per-case backend group and open its chat |
+| `disbandGroup(cfg, groupName, chatId, debug)` | best-effort group cleanup |
 | `groupNameFor(caseId, runId)` | unique group name `<caseId>-<runId>`, truncated to ≤ 60 chars |
 | `createGroup(cfg, name, memberOpenIds)` / `deleteGroup(cfg, chatId)` | backend group create/delete (`im.v1.chat.create` / `im.v1.chat.delete`) |
 
@@ -248,7 +270,8 @@ helper together.
 | App shell URL | path matches `/(messenger\|home\|space\|contact\|drive)/` (any tenant subdomain) |
 | Chat message item | `.js-message-item`; `.message-self` marks the user's own |
 | Chat input (composer) | `.innerdocbody` / `.zone-container.editor-kit-container` (visible) |
-| Card buttons | `<button>` elements; match by accessible name |
+| Card buttons | `<button>` elements inside the last `.js-message-item:not(.message-self)`; match by accessible name |
+| Pickers | Feishu card `select_static` dropdowns (or numbered buttons); the card's markdown title is the deterministic anchor (`Pick a project` / `Choose a model`) |
 | Login QR | a `canvas` inside `[class*="scan-QR-code"]` on the accounts login page (expires — the login helper reloads for a fresh one) |
 
 ## Troubleshooting

--- a/docs/e2e-testing.zh.md
+++ b/docs/e2e-testing.zh.md
@@ -51,8 +51,25 @@ pnpm run e2e:ui     →  e2e/scripts/e2e-ui.mjs（宿主启动器）
 - **e2e/helpers/feishu.ts** — feishu.cn 网页 helper（打开应用/聊天、发消息、读聊天、点按钮、截图）。
 - **e2e/helpers/group.ts** — 后台建群/删群（`im.v1.chat.create` / `im.v1.chat.delete`，与 `/group` 同一底层调用）+ 唯一群名构造器。
 - **e2e/helpers/assert.ts** — 规则化聊天断言。
+- **e2e/helpers/scenario.ts** — 每个场景共用的群聊生命周期（后台建群 → 打开 → 截图 → `finally` 解散）。
 - **e2e/scenarios/*.spec.ts** — 每个场景一个文件。
 - **e2e/Dockerfile** — 运行镜像：Playwright 官方镜像 + 完整 ffmpeg（自带版只支持 VP8；转 mp4 需要 H.264）。
+
+### 场景
+
+本套件覆盖**本地解析**的 surface 命令（不经过 LLM 往返），因此每个断言都是确定的。每个场景在独立的后台群里运行，结束后解散。
+
+| 场景 | 断言 |
+| --- | --- |
+| `help.spec.ts` | `/help` → `dsh-feishu commands:` 块 |
+| `status.spec.ts` | `/status` → 本地 `chat:` / `mention mode:` 文本 |
+| `feishu-status.spec.ts` | `/feishu-status` → 诊断卡（`connection:`）——真实长连接验证点 |
+| `schedule.spec.ts` | 新群的 `/schedule` → `no session yet` 通知 |
+| `panel.spec.ts` | `/panel` → 控制面板卡（含命令按钮）；点 `Stop turn` 解析为 stop-turn 命令 |
+| `repo-picker.spec.ts` | `/repo` → 项目选择面板卡（`Pick a project`） |
+| `model-picker.spec.ts` | 裸 `/model` → 模型选择面板卡（`Choose a model`） |
+
+更深的 picker 选择（选项目/模型）以及需要真实会话/目录/白名单的交互仍留在集成套件——E2E 层证明卡片渲染、面板按钮能触发，而不证明选择逻辑。
 
 ## Setup（一次性，之后免人工）
 
@@ -121,29 +138,23 @@ FEISHU_DEBUG=1           # 插件自身 debug 追踪（dsh 子进程日志现在
    ```ts
    import { test } from '@playwright/test';
    import { loadE2eConfig } from '../helpers/config.js';
-   import { waitForBotReplyContaining } from '../helpers/assert.js';
-   import { openApp, openChat, sendMessage, snapshot } from '../helpers/feishu.js';
+   import { waitForCardContaining } from '../helpers/assert.js';
+   import { sendMessage, snapshot } from '../helpers/feishu.js';
    import { caseIdFromTitle } from '../helpers/report.js';
-   import { createGroup, deleteGroup, groupNameFor } from '../helpers/group.js';
+   import { disbandGroup, openCaseGroup, scenarioDebug } from '../helpers/scenario.js';
 
    const cfg = loadE2eConfig();
+   const debug = scenarioDebug(process.env.E2E_DEBUG === '1');
 
    test('send /model → model picker card', async ({ page }, testInfo) => {
      const caseId = caseIdFromTitle(testInfo.title);
-     const groupName = groupNameFor(caseId, cfg.runId);
-     const { chatId } = await createGroup(cfg, groupName, [cfg.userOpenId!]);
+     const { groupName, chatId } = await openCaseGroup(page, cfg, caseId, cfg.timeoutMs, debug);
      try {
-       await openApp(page, cfg);
-       await openChat(page, groupName, cfg.timeoutMs);
-       await snapshot(page, cfg, 'model-chat-open', caseId);
        await sendMessage(page, '/model');
-       await waitForBotReplyContaining(page, 'Model', cfg.timeoutMs);
+       await waitForCardContaining(page, 'Choose a model', cfg.timeoutMs);
        await snapshot(page, cfg, 'model-picker', caseId);
      } finally {
-       // 就地解散群聊，避免运行积累聊天
-       await deleteGroup(cfg, chatId).catch((error) =>
-         console.warn(`[cleanup] could not disband ${groupName}: ${error.message}`),
-       );
+       await disbandGroup(cfg, groupName, chatId, debug);
      }
    });
    ```
@@ -160,8 +171,12 @@ FEISHU_DEBUG=1           # 插件自身 debug 追踪（dsh 子进程日志现在
 | `sendMessage(page, text)` | 在聊天输入框输入并发送 |
 | `chatMessages(page)` | 读取已渲染消息 `{text, isSelf}[]` |
 | `clickButton(page, label)` / `clickCardText(page, label)` | 点击卡片按钮 / 卡片文本 |
-| `snapshot(page, cfg, label, caseId)` | 保存关键截图到 `report/screenshots/` |
+| `clickCardButton(page, label)` | 点击最后一张 bot 卡内的按钮（面板动作） |
+| `snapshot(page, cfg, label, caseId)` | 保存关键截图到 `report/screenshots/<caseId>/` |
 | `waitForBotReplyContaining(page, text, timeoutMs)` | 等待包含指定文本的 bot 回复（规则化） |
+| `waitForCardContaining(page, text, timeoutMs)` | 等待渲染出的卡片包含文本（规则化） |
+| `openCaseGroup(page, cfg, caseId, timeoutMs, debug)` | 创建每用例的后台群并打开其聊天 |
+| `disbandGroup(cfg, groupName, chatId, debug)` | 尽力而为的群清理 |
 | `groupNameFor(caseId, runId)` | 唯一群名 `<caseId>-<runId>`，截断至 ≤ 60 字符 |
 | `createGroup(cfg, name, memberOpenIds)` / `deleteGroup(cfg, chatId)` | 后台建群/删群（`im.v1.chat.create` / `im.v1.chat.delete`） |
 
@@ -174,7 +189,8 @@ FEISHU_DEBUG=1           # 插件自身 debug 追踪（dsh 子进程日志现在
 | 应用外壳 URL | 路径匹配 `/(messenger\|home\|space\|contact\|drive)/`（任意租户子域） |
 | 聊天消息项 | `.js-message-item`；`.message-self` 标记自己发的 |
 | 聊天输入框（composer） | `.innerdocbody` / `.zone-container.editor-kit-container`（可见） |
-| 卡片按钮 | `<button>` 元素；按可访问名称匹配 |
+| 卡片按钮 | 最后一个 `.js-message-item:not(.message-self)` 内的 `<button>`；按可访问名称匹配 |
+| 选择器（picker） | 飞书卡片 `select_static` 下拉（或编号按钮）；卡片 markdown 标题是确定性锚点（`Pick a project` / `Choose a model`） |
 | 登录二维码 | accounts 登录页 `[class*="scan-QR-code"]` 内的 `canvas`（会过期——登录 helper 会 reload 换新） |
 
 ## 排障

--- a/e2e/helpers/assert.ts
+++ b/e2e/helpers/assert.ts
@@ -42,3 +42,35 @@ export async function waitForBotReplyContaining(
     await page.waitForTimeout(500);
   }
 }
+
+/**
+ * Wait until a bot message (a rendered card, which is also a message item)
+ * contains `text`. Intended for interactive cards whose body text may spread
+ * across elements — the whole message textContent is the assertion target.
+ * @param page - the browser page.
+ * @param text - substring the card must contain.
+ * @param timeoutMs - how long to wait.
+ */
+export async function waitForCardContaining(
+  page: Page,
+  text: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let recent: ChatMessage[] = [];
+  for (;;) {
+    recent = await chatMessages(page);
+    const cardMatch = recent.find((m) => !m.isSelf && m.text.includes(text));
+    if (cardMatch !== undefined) return;
+    if (Date.now() > deadline) {
+      const tail = recent
+        .slice(-6)
+        .map((m) => `${m.isSelf ? 'self' : 'bot'}: ${m.text.slice(0, 120)}`)
+        .join('\n');
+      throw new Error(
+        `timed out waiting for a card containing "${text}"\nlast messages:\n${tail || '(none rendered)'}`,
+      );
+    }
+    await page.waitForTimeout(500);
+  }
+}

--- a/e2e/helpers/feishu.ts
+++ b/e2e/helpers/feishu.ts
@@ -210,3 +210,19 @@ export async function clickButton(page: Page, label: string): Promise<void> {
 export async function clickCardText(page: Page, label: string): Promise<void> {
   await page.getByText(label, { exact: false }).first().click();
 }
+
+/**
+ * Click a button that lives INSIDE the most recent bot message (a card's
+ * action button). Scoped to the last `.js-message-item` so a panel button
+ * never resolves against a stale button elsewhere on the page.
+ * @param page - the browser page.
+ * @param label - substring of the button label.
+ */
+export async function clickCardButton(page: Page, label: string): Promise<void> {
+  // The last non-self message item is the bot's most recent card.
+  const lastBotMessage = page.locator('.js-message-item:not(.message-self)').last();
+  await lastBotMessage
+    .getByRole('button', { name: new RegExp(label) })
+    .first()
+    .click();
+}

--- a/e2e/helpers/report.ts
+++ b/e2e/helpers/report.ts
@@ -211,6 +211,22 @@ export function flattenCases(report: PlaywrightReport): E2eCase[] {
               ? 'failed'
               : (statusRaw as E2eCase['status']);
         const firstError = result?.errors?.find((e) => e.message !== undefined && e.message !== '');
+        // Playwright's error.location is an OBJECT ({file, column, line}), not
+        // a string — normalize it to "file:line" so the HTML escapes cleanly.
+        const normalizeLocation = (loc: unknown): string | undefined => {
+          if (typeof loc === 'string' && loc !== '') return loc;
+          if (loc !== null && typeof loc === 'object') {
+            const o = loc as Record<string, unknown>;
+            const file = typeof o.file === 'string' ? o.file : undefined;
+            const line = typeof o.line === 'number' ? o.line : undefined;
+            return file !== undefined
+              ? `${file}${line !== undefined ? `:${line}` : ''}`
+              : undefined;
+          }
+          return undefined;
+        };
+        const errorLocation =
+          firstError !== undefined ? normalizeLocation(firstError.location) : undefined;
         out.push({
           caseId: caseIdFromTitle(title),
           title,
@@ -222,7 +238,7 @@ export function flattenCases(report: PlaywrightReport): E2eCase[] {
             ? {
                 error: {
                   message: firstError.message ?? 'unknown error',
-                  ...(firstError.location !== undefined ? { location: firstError.location } : {}),
+                  ...(errorLocation !== undefined ? { location: errorLocation } : {}),
                 },
               }
             : {}),
@@ -321,7 +337,10 @@ function screenshotKind(path: string): 'screenshot' | undefined {
 }
 
 function esc(s: string): string {
-  return s
+  // Coerce non-strings (a normalized field could still be an object) — the
+  // HTML must never crash the whole report on one bad value.
+  const str = typeof s === 'string' ? s : String(s);
+  return str
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')

--- a/e2e/helpers/scenario.ts
+++ b/e2e/helpers/scenario.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared scenario scaffolding: the group-chat lifecycle every scenario uses.
+ * Each test case creates its OWN backend group (name `<caseId>-<runId>`,
+ * unique per run — the same `im.v1.chat.create` the plugin's `/group` wraps),
+ * opens it in the browser, and disbands it in `finally` so runs never
+ * accumulate chats. The bot stays the group owner (no `owner_id`), so the
+ * app's `im.v1.chat.delete` is permitted.
+ *
+ * @module e2e/helpers/scenario
+ */
+
+import type { Page } from '@playwright/test';
+import type { E2eConfig } from './config.js';
+import { openApp, openChat, snapshot } from './feishu.js';
+import { createGroup, deleteGroup, groupNameFor } from './group.js';
+
+/** E2E_DEBUG=1 diagnostic logger (no-op when off). */
+export function scenarioDebug(enabled: boolean): (...args: unknown[]) => void {
+  return (...args: unknown[]) => {
+    if (enabled) console.log('[debug]', ...args);
+  };
+}
+
+/** Assert the E2E state the scenarios need; throws a clear message otherwise. */
+export function requireUserOpenId(cfg: E2eConfig): string {
+  if (cfg.userOpenId === undefined) {
+    throw new Error('E2E_USER_OPEN_ID is required (run `pnpm run e2e:setup` first)');
+  }
+  return cfg.userOpenId;
+}
+
+/**
+ * Create a per-case group and open its chat, returning the disbands handle.
+ * The caller must `await cleanup.chatId`-knowing cleanup in `finally`.
+ * @param page - the browser page.
+ * @param cfg - resolved E2E config (runId + userOpenId).
+ * @param caseTitledId - the caseId (caseIdFromTitle output).
+ * @param timeoutMs - chat-open timeout.
+ * @param debug - diagnostic logger.
+ * @returns the group name and chat id.
+ */
+export async function openCaseGroup(
+  page: Page,
+  cfg: E2eConfig,
+  caseId: string,
+  timeoutMs: number,
+  debug: (...args: unknown[]) => void,
+): Promise<{ groupName: string; chatId: string }> {
+  const groupName = groupNameFor(caseId, cfg.runId);
+  debug('case', `caseId=${caseId} group=${groupName} runId=${cfg.runId}`);
+  const userOpenId = requireUserOpenId(cfg);
+  const { chatId } = await createGroup(cfg, groupName, [userOpenId], fetch, debug);
+  await openApp(page, cfg);
+  await openChat(page, groupName, timeoutMs);
+  await snapshot(page, cfg, `${caseId}-chat-open`, caseId);
+  return { groupName, chatId };
+}
+
+/** Disband the group (best effort — log and move on). */
+export async function disbandGroup(
+  cfg: E2eConfig,
+  groupName: string,
+  chatId: string,
+  debug: (...args: unknown[]) => void,
+): Promise<void> {
+  try {
+    await deleteGroup(cfg, chatId, fetch, debug);
+    console.log(`  [cleanup] disbanded group ${groupName} (${chatId})`);
+  } catch (error) {
+    console.warn(
+      `  [cleanup] could not disband ${groupName}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/e2e/scenarios/feishu-status.spec.ts
+++ b/e2e/scenarios/feishu-status.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * E2E scenario: `/feishu-status` renders the surface diagnostic card.
+ *
+ * This is the ONLY scenario that exercises the real long connection: the
+ * card's `connection:` field reflects the live WSClient state (`ready` /
+ * `reconnecting` / ...), so a passing run proves the long connection that
+ * the integration tests mock. The card header (`📊 dsh-feishu status`) and
+ * the `connection:` / `sessions:` body are rule-based assertions on the
+ * rendered card text.
+ *
+ * @module e2e/scenarios/feishu-status
+ */
+
+import { test } from '@playwright/test';
+import { waitForCardContaining } from '../helpers/assert.js';
+import { loadE2eConfig } from '../helpers/config.js';
+import { sendMessage, snapshot } from '../helpers/feishu.js';
+import { caseIdFromTitle } from '../helpers/report.js';
+import { disbandGroup, openCaseGroup, scenarioDebug } from '../helpers/scenario.js';
+
+const cfg = loadE2eConfig();
+const debugEnabled = process.env.E2E_DEBUG === '1';
+const debug = scenarioDebug(debugEnabled);
+
+test('send /feishu-status → diagnostic card', async ({ page }, testInfo) => {
+  const caseId = caseIdFromTitle(testInfo.title);
+  const { groupName, chatId } = await openCaseGroup(page, cfg, caseId, cfg.timeoutMs, debug);
+  try {
+    await sendMessage(page, '/feishu-status');
+    await snapshot(page, cfg, `${caseId}-sent`, caseId);
+
+    // The card header + a live connection field. `connection:` should read
+    // ready (the real WSClient connected) in a passing run.
+    await waitForCardContaining(page, 'dsh-feishu status', cfg.timeoutMs);
+    await waitForCardContaining(page, 'connection:', cfg.timeoutMs);
+
+    await snapshot(page, cfg, `${caseId}-card`, caseId);
+    debug('assert', 'feishu-status card received');
+
+    testInfo.annotations.push({
+      type: 'evidence',
+      description: `group: ${groupName} | feishu-status diagnostic card rendered`,
+    });
+  } finally {
+    await disbandGroup(cfg, groupName, chatId, debug);
+  }
+});

--- a/e2e/scenarios/model-picker.spec.ts
+++ b/e2e/scenarios/model-picker.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * E2E scenario: bare `/model` opens the model-picker panel card.
+ *
+ * The `/model` handler opens a `picker: 'model'` view when the `llm`
+ * service is mounted (which the e2e profile does), rendering a card with a
+ * model dropdown (`Choose a model`). This scenario asserts the PICKER CARD
+ * renders. Selecting a specific model is the integration suite's job (it
+ * needs the real catalog and must restore the prior selection).
+ *
+ * @module e2e/scenarios/model-picker
+ */
+
+import { test } from '@playwright/test';
+import { waitForCardContaining } from '../helpers/assert.js';
+import { loadE2eConfig } from '../helpers/config.js';
+import { sendMessage, snapshot } from '../helpers/feishu.js';
+import { caseIdFromTitle } from '../helpers/report.js';
+import { disbandGroup, openCaseGroup, scenarioDebug } from '../helpers/scenario.js';
+
+const cfg = loadE2eConfig();
+const debugEnabled = process.env.E2E_DEBUG === '1';
+const debug = scenarioDebug(debugEnabled);
+
+test('send /model → model picker panel card', async ({ page }, testInfo) => {
+  const caseId = caseIdFromTitle(testInfo.title);
+  const { groupName, chatId } = await openCaseGroup(page, cfg, caseId, cfg.timeoutMs, debug);
+  try {
+    await sendMessage(page, '/model');
+    await snapshot(page, cfg, `${caseId}-sent`, caseId);
+
+    // The model-picker card's deterministic title always renders when the
+    // llm service is mounted (the e2e profile's config).
+    await waitForCardContaining(page, 'Choose a model', cfg.timeoutMs);
+    debug('assert', 'model picker card received');
+    await snapshot(page, cfg, `${caseId}-picker`, caseId);
+
+    testInfo.annotations.push({
+      type: 'evidence',
+      description: `group: ${groupName} | /model rendered the model picker card`,
+    });
+  } finally {
+    await disbandGroup(cfg, groupName, chatId, debug);
+  }
+});

--- a/e2e/scenarios/panel.spec.ts
+++ b/e2e/scenarios/panel.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * E2E scenario: `/panel` opens the control-panel card and its buttons work.
+ *
+ * The `/panel` handler (src/commands/surface.ts → `openPanel`) renders a
+ * card with every surface command as a button (grouped by category). This
+ * scenario asserts the panel card appears (with a command button) and then
+ * CLICKS one of its buttons (`Stop turn`) to verify the panel button resolves
+ * to the surface's stop-turn command — a real card-button round-trip, no LLM
+ * in the loop.
+ *
+ * @module e2e/scenarios/panel
+ */
+
+import { test } from '@playwright/test';
+import { waitForBotReplyContaining, waitForCardContaining } from '../helpers/assert.js';
+import { loadE2eConfig } from '../helpers/config.js';
+import { clickCardButton, sendMessage, snapshot } from '../helpers/feishu.js';
+import { caseIdFromTitle } from '../helpers/report.js';
+import { disbandGroup, openCaseGroup, scenarioDebug } from '../helpers/scenario.js';
+
+const cfg = loadE2eConfig();
+const debugEnabled = process.env.E2E_DEBUG === '1';
+const debug = scenarioDebug(debugEnabled);
+
+test('send /panel → control panel card with working buttons', async ({ page }, testInfo) => {
+  const caseId = caseIdFromTitle(testInfo.title);
+  const { groupName, chatId } = await openCaseGroup(page, cfg, caseId, cfg.timeoutMs, debug);
+  try {
+    await sendMessage(page, '/panel');
+    await snapshot(page, cfg, `${caseId}-sent`, caseId);
+
+    // The panel card appears (its header carries the surface name). The card
+    // opens a paged command palette — wait for it before clicking a button.
+    await waitForCardContaining(page, 'dsh-feishu panel', cfg.timeoutMs);
+    debug('assert', 'panel card received');
+    await snapshot(page, cfg, `${caseId}-panel`, caseId);
+
+    // Click a Session-group button on the FIRST page — `Stop turn` (emoji in
+    // the label is cosmetic; match the accessible name without it), whose
+    // handler with no active session returns the deterministic local text
+    // `no active session to stop.` (no LLM). This proves the panel button
+    // resolves to a surface command. (`📊 Status` sits on page 2, so we use
+    // a first-page button instead of paging.)
+    await clickCardButton(page, 'Stop turn');
+    await waitForBotReplyContaining(page, 'no active session to stop.', cfg.timeoutMs);
+    debug('assert', 'panel button -> stop-turn reply received');
+    await snapshot(page, cfg, `${caseId}-button-reply`, caseId);
+
+    testInfo.annotations.push({
+      type: 'evidence',
+      description: `group: ${groupName} | panel rendered + its "Stop turn" button resolved to the stop-turn command`,
+    });
+  } finally {
+    await disbandGroup(cfg, groupName, chatId, debug);
+  }
+});

--- a/e2e/scenarios/repo-picker.spec.ts
+++ b/e2e/scenarios/repo-picker.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * E2E scenario: `/repo` opens the project-picker panel card.
+ *
+ * The `/repo` handler (src/commands/surface.ts) pushes a `picker: 'repo'`
+ * view onto the panel state machine, which renders a card with a
+ * `select_static` dropdown (or numbered buttons when the candidate list is
+ * large). This scenario asserts the PICKER CARD renders (its deterministic
+ * title text) — whether the mock profile has candidates or not, the picker
+ * itself must appear. Choosing a specific project is the integration suite's
+ * job (it needs a real repoRoots).
+ *
+ * @module e2e/scenarios/repo-picker
+ */
+
+import { test } from '@playwright/test';
+import { waitForCardContaining } from '../helpers/assert.js';
+import { loadE2eConfig } from '../helpers/config.js';
+import { sendMessage, snapshot } from '../helpers/feishu.js';
+import { caseIdFromTitle } from '../helpers/report.js';
+import { disbandGroup, openCaseGroup, scenarioDebug } from '../helpers/scenario.js';
+
+const cfg = loadE2eConfig();
+const debugEnabled = process.env.E2E_DEBUG === '1';
+const debug = scenarioDebug(debugEnabled);
+
+test('send /repo → project picker panel card', async ({ page }, testInfo) => {
+  const caseId = caseIdFromTitle(testInfo.title);
+  const { groupName, chatId } = await openCaseGroup(page, cfg, caseId, cfg.timeoutMs, debug);
+  try {
+    await sendMessage(page, '/repo');
+    await snapshot(page, cfg, `${caseId}-sent`, caseId);
+
+    // The picker card's deterministic title always renders.
+    await waitForCardContaining(page, 'Pick a project', cfg.timeoutMs);
+    debug('assert', 'repo picker card received');
+    await snapshot(page, cfg, `${caseId}-picker`, caseId);
+
+    testInfo.annotations.push({
+      type: 'evidence',
+      description: `group: ${groupName} | /repo rendered the project picker card`,
+    });
+  } finally {
+    await disbandGroup(cfg, groupName, chatId, debug);
+  }
+});

--- a/e2e/scenarios/schedule.spec.ts
+++ b/e2e/scenarios/schedule.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * E2E scenario: `/schedule` on a chat with no session yet returns a
+ * deterministic local message.
+ *
+ * The `/schedule` handler returns `no session yet — send a message first.`
+ * when no session is bound to the chat — a freshly-created group has none,
+ * so the assertion is a local rule-based text check that never round-trips
+ * through the LLM (listing reminders needs a real session, which is the
+ * integration suite's job).
+ *
+ * @module e2e/scenarios/schedule
+ */
+
+import { test } from '@playwright/test';
+import { waitForBotReplyContaining } from '../helpers/assert.js';
+import { loadE2eConfig } from '../helpers/config.js';
+import { sendMessage, snapshot } from '../helpers/feishu.js';
+import { caseIdFromTitle } from '../helpers/report.js';
+import { disbandGroup, openCaseGroup, scenarioDebug } from '../helpers/scenario.js';
+
+const cfg = loadE2eConfig();
+const debugEnabled = process.env.E2E_DEBUG === '1';
+const debug = scenarioDebug(debugEnabled);
+
+test('send /schedule → no-session notice', async ({ page }, testInfo) => {
+  const caseId = caseIdFromTitle(testInfo.title);
+  const { groupName, chatId } = await openCaseGroup(page, cfg, caseId, cfg.timeoutMs, debug);
+  try {
+    await sendMessage(page, '/schedule');
+    await snapshot(page, cfg, `${caseId}-sent`, caseId);
+
+    // Fresh group → no session bound → the deterministic local notice.
+    const reply = await waitForBotReplyContaining(
+      page,
+      'no session yet — send a message first.',
+      cfg.timeoutMs,
+    );
+    debug('assert', `schedule reply received (${reply.text.length} chars)`);
+
+    await snapshot(page, cfg, `${caseId}-reply`, caseId);
+
+    testInfo.annotations.push({
+      type: 'evidence',
+      description: `group: ${groupName} | schedule reply (first 200 chars): ${reply.text.slice(0, 200)}`,
+    });
+  } finally {
+    await disbandGroup(cfg, groupName, chatId, debug);
+  }
+});

--- a/e2e/scenarios/status.spec.ts
+++ b/e2e/scenarios/status.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * E2E scenario: `/status` shows this chat's session status as a text block.
+ *
+ * The `/status` handler (src/commands/surface.ts) returns a local text list
+ * (`chat:` / `session:` / `agent:` / `last output:` / `mention mode:`) that
+ * never round-trips through the LLM, so the assertions are deterministic
+ * rule-based text checks on the rendered chat.
+ *
+ * The case runs in its own backend group (see `e2e/helpers/scenario.ts`) and
+ * disbands it afterwards.
+ *
+ * @module e2e/scenarios/status
+ */
+
+import { test } from '@playwright/test';
+import { waitForBotReplyContaining } from '../helpers/assert.js';
+import { loadE2eConfig } from '../helpers/config.js';
+import { sendMessage, snapshot } from '../helpers/feishu.js';
+import { caseIdFromTitle } from '../helpers/report.js';
+import { disbandGroup, openCaseGroup, scenarioDebug } from '../helpers/scenario.js';
+
+const cfg = loadE2eConfig();
+const debugEnabled = process.env.E2E_DEBUG === '1';
+const debug = scenarioDebug(debugEnabled);
+
+test('send /status → session status text', async ({ page }, testInfo) => {
+  const caseId = caseIdFromTitle(testInfo.title);
+  const { groupName, chatId } = await openCaseGroup(page, cfg, caseId, cfg.timeoutMs, debug);
+  try {
+    await sendMessage(page, '/status');
+    await snapshot(page, cfg, `${caseId}-sent`, caseId);
+
+    // The status block opens with `chat:` and includes every line. Two
+    // independent rule-based assertions.
+    await waitForBotReplyContaining(page, 'chat:', cfg.timeoutMs);
+    const reply = await waitForBotReplyContaining(page, 'mention mode:', cfg.timeoutMs);
+    debug('assert', `status reply received (${reply.text.length} chars)`);
+
+    await snapshot(page, cfg, `${caseId}-reply`, caseId);
+
+    testInfo.annotations.push({
+      type: 'evidence',
+      description: `group: ${groupName} | status reply (first 300 chars): ${reply.text.slice(0, 300)}`,
+    });
+  } finally {
+    await disbandGroup(cfg, groupName, chatId, debug);
+  }
+});

--- a/e2e/scripts/e2e-container.mjs
+++ b/e2e/scripts/e2e-container.mjs
@@ -248,12 +248,15 @@ async function main() {
     if (id?.[1] && secret?.[1]) {
       writeFileSync(
         credsFile,
-        `${JSON.stringify({ appId: id[1], appSecret: secret[1] }, null, 2)}\n`,
+        // Include the app name so the setup's search-for-bot step can reuse
+        // this exact app (the name is part of the app identity, not a
+        // per-run throwaway — reusing creds must reuse the same name).
+        `${JSON.stringify({ appId: id[1], appSecret: secret[1], name: env.E2E_BOT_NAME }, null, 2)}\n`,
       );
       console.log(`  [setup] credentials exported to ${credsFile}`);
       process.env.E2E_APP_ID = id[1];
       process.env.E2E_APP_SECRET = secret[1];
-      creds = { appId: id[1], appSecret: secret[1] };
+      creds = { appId: id[1], appSecret: secret[1], name: env.E2E_BOT_NAME };
     } else {
       console.error('✗ setup:feishu succeeded but wrote no appId/appSecret to the profile');
       process.exit(2);

--- a/e2e/scripts/e2e-login.mjs
+++ b/e2e/scripts/e2e-login.mjs
@@ -59,6 +59,22 @@ function debug(...args) {
 }
 debug('login', `state=${stateFile} headed=${headed} baseUrl=${baseUrl}`);
 
+/** True when the login page reports the QR as expired (so we reload). */
+async function isQrExpired(page) {
+  try {
+    return await page.evaluate(() => {
+      const re = /refresh|expired|过期|失效|已过期|刷新二维码/i;
+      const text = document.body.innerText;
+      // The login page body is short; only treat as expired when the QR area
+      // itself shows a renewal prompt (not the whole page chrome).
+      const qrBox = document.querySelector('[class*="scan-QR-code"], canvas');
+      return qrBox ? re.test(qrBox.textContent ?? '') || re.test(text.slice(0, 200)) : false;
+    });
+  } catch {
+    return false;
+  }
+}
+
 const isAppUrl = (u) => /\/(messenger|home|space|contact|drive)([/?#]|$)/.test(u);
 
 mkdirSync(dirname(stateFile), { recursive: true });
@@ -88,19 +104,23 @@ if (!isAppUrl(page.url())) {
   let loggedIn = false;
   let lastRefresh = 0;
   let capturedOnce = false;
-  console.log(`⏳ login required — scan ${qrPath} (refreshed every 5 s) with the Feishu app`);
+  console.log(`⏳ login required — scan ${qrPath} with the Feishu app`);
   while (Date.now() < deadline) {
     if (Date.now() - lastRefresh > 5_000) {
       lastRefresh = Date.now();
-      // The feishu login QR does NOT auto-rotate: when it expires the page
-      // shows a greyed QR with a "Refresh QR Code" overlay until clicked.
-      // Reloading the login page always renders a fresh QR — bulletproof,
-      // so reload every cycle instead of guessing when the QR went stale
-      // (the stale-overlay text is not reliably discoverable in the DOM).
-      if (capturedOnce) {
+      // The login QR does NOT auto-rotate and is valid for a few minutes, so
+      // we must NOT reload every cycle — reloading swaps the QR out from
+      // under the user mid-scan, so their scan never confirms (a 5s reload
+      // race). Only reload when the page clearly reports the QR as expired
+      // (its text changes) or when no QR element can be captured at all.
+      const expired = await isQrExpired(page);
+      if (expired || !capturedOnce) {
         await page.reload({ waitUntil: 'commit', timeout: 30_000 }).catch(() => {});
         await page.waitForTimeout(6_000);
-        debug('qr', 'reloaded for a fresh QR');
+        debug(
+          'qr',
+          expired ? 'QR expired — reloaded for a fresh one' : 'first capture — loaded login page',
+        );
       }
       let captured = false;
       for (const sel of [

--- a/e2e/scripts/e2e-user-id.mjs
+++ b/e2e/scripts/e2e-user-id.mjs
@@ -60,15 +60,19 @@ if (!existsSync(sessionState)) {
   process.exit(2);
 }
 
-// The bot app name (unique per setup run, persisted in the state dir).
+// The bot app name (unique per setup run, persisted in the state dir). It is
+// part of the app identity: creds.json now carries the `name` it was created
+// with, so reusing creds reuses the SAME name the search-for-bot step must
+// match (a per-run throwaway name never matches a reused app).
 const stateDir = process.env.E2E_STATE ?? join(ROOT, 'e2e', '.state');
+const credsFile = join(stateDir, 'creds.json');
 const botNameFile = join(stateDir, 'bot-name');
 const botName =
+  (existsSync(credsFile) ? JSON.parse(readFileSync(credsFile, 'utf8')).name : undefined) ??
   process.env.E2E_BOT_NAME ??
   (existsSync(botNameFile) ? readFileSync(botNameFile, 'utf8').trim() : 'DSH-E2E-TESTBOT');
 
 // App credentials: env first, then creds.json in the state dir.
-const credsFile = join(stateDir, 'creds.json');
 const appId =
   process.env.E2E_APP_ID ??
   (existsSync(credsFile) ? JSON.parse(readFileSync(credsFile, 'utf8')).appId : undefined);
@@ -196,12 +200,19 @@ try {
 
   // The bot appears as a `.bot-result-card` (cursor:pointer) in the search
   // results; clicking it opens the p2p chat. The bot name is unique per
-  // setup run, so exactly one card carries it.
-  const botCard = page.locator('.bot-result-card:visible').filter({ hasText: botName }).first();
-  if ((await botCard.count().catch(() => 0)) === 0) {
-    throw new Error(`no bot result card found for "${botName}" in the search results`);
+  // setup run, so exactly one card carries it. Poll for the card — search
+  // results can take a moment to render after typing, and the card text may
+  // truncate the long name, so match the stable `DSH-E2E-TESTBOT` prefix.
+  const prefix = botName.slice(0, Math.min(botName.length, 15));
+  const deadline = Date.now() + 30_000;
+  const botCard = page.locator('.bot-result-card:visible').filter({ hasText: prefix }).first();
+  while ((await botCard.count().catch(() => 0)) === 0) {
+    if (Date.now() > deadline) {
+      throw new Error(`no bot result card found for "${botName}" in the search results`);
+    }
+    await page.waitForTimeout(1_000);
   }
-  debug('browser', 'bot result card found — opening the p2p chat');
+  debug('browser', `bot result card found (prefix "${prefix}") — opening the p2p chat`);
   await botCard.click();
   await page.waitForTimeout(5_000);
 

--- a/tests/e2e-report.spec.ts
+++ b/tests/e2e-report.spec.ts
@@ -226,7 +226,14 @@ describe('e2e run report generator', () => {
                         duration: 10,
                         startTime: '2026-08-21T00:00:00.000Z',
                         retry: 0,
-                        errors: [{ message: 'boom failed', location: 'e2e/helpers/x.ts:1' }],
+                        errors: [
+                          {
+                            message: 'boom failed',
+                            // Real Playwright error.location is an OBJECT; the
+                            // generator normalizes it to "file:line".
+                            location: { file: 'e2e/helpers/x.ts', line: 1, column: 19 },
+                          },
+                        ],
                         annotations: [],
                         stdout: [],
                         stderr: [],


### PR DESCRIPTION
## What

- Add six real-client E2E smoke scenarios (status, feishu-status, schedule, panel, repo-picker, model-picker) alongside the existing help scenario, each in its own backend group that is disbanded afterwards.
- Add shared scenario scaffolding (e2e/helpers/scenario.ts) and the helpers waitForCardContaining / clickCardButton.
- Fix the browser-login QR race (no longer reloads over a live scan) and persist the bot app name into creds.json so a reused app resolves by name; fix failed-case location rendering in the run report.
- Update e2e-testing.md(.zh) and the CHANGELOG.

## Why

The real-client suite had only a /help scenario. These smoke scenarios prove the locally-resolving surface commands (no LLM in the loop) render their cards and that panel buttons fire. The QR-login race made the one-time login unreliable; the creds-name fix lets a reused bot app be found by name so subsequent runs stay hands-free.

## Docs

e2e-testing.md / e2e-testing.zh.md (Scenarios, helpers and selectors tables), CHANGELOG.md.

## Verification

- pnpm run e2e:ui — 7 scenarios pass (7/7), report generated.
- pnpm run lint, pnpm run typecheck, pnpm run build all pass.
- pnpm run test — 516 unit tests pass (integration suites require FEISHU_INT_REQUIRED=1 and run in CI).
- pnpm run check — all convention checks pass.