### PR TITLE
feat: turn produced files as clickable streaming-card chips

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -81,6 +81,10 @@ jobs:
         env:
           DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-outbound
         run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
+      - name: Prepare integration-test profile (turn-produced-files)
+        env:
+          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-turn-produced-files
+        run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
       - name: Prepare scenario integration-test profile
         env:
           DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-scenarios

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,10 @@ jobs:
         env:
           DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-outbound
         run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
+      - name: Prepare integration-test profile (turn-produced-files)
+        env:
+          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-turn-produced-files
+        run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
 
       # The scenario suite boots its own dsh home too.
       - name: Prepare scenario integration-test profile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   image/file message, and shows a `📤 Sent` receipt card. Feature-detects
   the `tools` service (absent → loud log, tool not registered). Depends on
   `@deepseek-ai/dsh-tools` (new runtime dep).
+- **Turn produced files (`turn-produced-files` chips).** After a turn ends,
+  the streaming card lists the files the agent produced (write/edit
+  mutations) as clickable `📎 Produced` chips (label = basename) under the
+  last tool/message row; tapping a chip sends that file to the chat via
+  `sendImage` (image extension) or `sendFile` (other) — no separate receipt
+  card. Path-level parity with the DSH web "Turn produced files" row: the
+  host derives the mutation path from `tool/result` `meta.diffs` (the fs
+  write/edit tools' presentation payload, present even as an empty array for
+  a new-file CREATE), falling back to the correlated `tool/call` arguments'
+  `file_path` when `diffs` is empty. Reads (no `diffs` key), deletes and
+  terminals are excluded. Paths are turn-scoped, deduped, and resolved
+  against the chat's pinned cwd.
 - **Bare attachment messages wait for the user's instruction
   (inbound-wait-instruction).** A file/image message without text no longer
   starts a turn by itself: the bytes land in the workspace, a NEW receipt

--- a/docs/development.md
+++ b/docs/development.md
@@ -101,7 +101,8 @@ unless the prerequisites are met:
   the bundle" section below). Deliberately independent of the ambient
   `DSH_HOME` so the test never touches another dsh home. **Each integration
   suite uses its OWN home** (`dsh-home-attachments`, `dsh-home-rich-text`,
-  `dsh-home-wait-instruction`, `dsh-home-real`, `dsh-home-scenarios`):
+  `dsh-home-wait-instruction`, `dsh-home-real`, `dsh-home-scenarios`,
+  `dsh-home-outbound`, `dsh-home-turn-produced-files`):
   vitest runs the suites in parallel, and sharing one
   `_dev/dsh-home/feishu/session-map.json` made concurrent dsh processes
   race their writes and silently drop one suite's chat→session binding

--- a/docs/features.md
+++ b/docs/features.md
@@ -23,7 +23,7 @@ Feature list and TODO tracker for dsh-feishu. ✅ = shipped, 📋 = planned
 | Agent preset selection | Pick an agent preset (e.g. PTC mode) when choosing a working directory | Mode dropdown on the `/repo` / `/cd` picker card; preset binds to the new session | 📋 |
 | Subagent manager | Tree view of subagents (parent→child, status, tokens, duration), open or cancel one | Panel tree view | 📋 |
 | Settings panel | View models/providers, manage API keys, review default cwd/preset | Panel settings view | 📋 |
-| Turn produced files | Files a turn produced surface at the end of the turn | Chips row at the card bottom; tap a chip to receive the file | 📋 |
+| Turn produced files | Files a turn produced surface at the end of the turn | Chips row at the card bottom; tap a chip to receive the file | ✅ |
 | Message queue | Messages sent while a turn runs queue visibly; edit / delete / steer them | Collapsed "N queued" row on the streaming card; expand to edit/delete/steer | 📋 |
 | Model retry line | Model auto-retries surface instead of staying silent | Card status line "retrying (2/3) · 3s", expand for delay/reason | 📋 |
 | Session stats line | Durable per-session usage: turns, steps, LLM/tool time, TTFT, tok/s, cache hit, tokens | One small line at the card bottom, refreshed per turn; details in `/status` | 📋 |
@@ -32,3 +32,4 @@ Feature list and TODO tracker for dsh-feishu. ✅ = shipped, 📋 = planned
 | inbound-wait-instruction | Bare file/image messages register as pending — a receipt card posts and the agent waits for the user's instruction before working | 📎 File received receipt (counts pending files); follow-up text drains them into one turn | ✅ |
 | inbound-rich-text | Feishu rich-text (post) and video messages are no longer dropped: a post is serialized into ordered rich text + attachments (formatting and intra-bubble order preserved), a video is a plain file | Rich-text-with-text posts turn immediately; attachment-only posts / videos register as pending | ✅ |
 | outbound-files-images | agent sends files/images to Feishu via a send_file tool | — | 📋 |
+| turn-produced-files | list a turn's produced files as clickable chips on the streaming card; tapping a chip sends it to the chat | — | ✅ |

--- a/docs/features.zh.md
+++ b/docs/features.zh.md
@@ -23,7 +23,7 @@ dsh-feishu 的功能列表与 TODO 追踪表。✅ = 已实现，📋 = 计划�
 | agent 预设选择 | 选择工作目录时一并选 agent 预设（如 PTC mode） | `/repo` / `/cd` 选择卡加 Mode 下拉；预设绑定新会话 | 📋 |
 | 子代理管理 | 子代理树形视图（父→子、状态、token、时长），打开或取消 | 面板树形视图 | 📋 |
 | 设置面板 | 查看模型/provider、管理 API key、查看默认 cwd/preset | 面板设置视图 | 📋 |
-| turn 产出文件 | turn 产出的文件在 turn 结束时呈现 | 卡底部 chips 行；点 chip 收到文件 | 📋 |
+| turn 产出文件 | turn 产出的文件在 turn 结束时呈现 | 卡底部 chips 行；点 chip 收到文件 | ✅ |
 | 消息队列 | turn 运行期间发送的消息排队可见；可编辑/删除/插话 | 流式卡底部『排队中 N 条』折叠行；展开编辑/删除/steer | 📋 |
 | 模型重试行 | 模型自动重试不再静默 | 卡内状态行『重试中 (2/3) · 3s』，展开看延迟/原因 | 📋 |
 | 会话统计行 | 持久化的会话用量：轮数、步数、LLM/工具时长、TTFT、tok/s、缓存命中、token | 卡底部一行小字，随 turn 刷新；详情在 `/status` | 📋 |
@@ -32,3 +32,4 @@ dsh-feishu 的功能列表与 TODO 追踪表。✅ = 已实现，📋 = 计划�
 | inbound-wait-instruction | 裸文件/图片消息登记为 pending——发回执卡并等用户指令后才开始工作 | 📎 File received 回执（计数 pending 文件）；补发文字把它们带进一个 turn | ✅ |
 | inbound-rich-text | 飞书富文本（post）和视频消息不再被丢弃：post 序列化为有序富文本 + 附件（保留格式与气泡内顺序），视频按普通文件处理 | 带文字的富文本立即 turn；纯附件 post / 视频登记为 pending | ✅ |
 | outbound-files-images | agent sends files/images to Feishu via a send_file tool | — | 📋 |
+| turn-produced-files | list a turn's produced files as clickable chips on the streaming card; tapping a chip sends it to the chat | — | ✅ |

--- a/docs/ux-specification.md
+++ b/docs/ux-specification.md
@@ -1205,3 +1205,108 @@ turn's tokens). No new panel views, no buttons.
 - The surface's existing `transport.sendFile(chatId, fileName, content)`
   (`src/transport.ts`) already uploads + posts a file; `send_file` extends it
   to images and to reading real workspace bytes (not just a string).
+
+## Part: turn-produced-files
+
+> After a turn ends, the streaming card lists the files the agent produced
+> (write/edit mutations) as clickable chips; tapping a chip sends that file
+> to the chat as a native Feishu image/file message. Mirrors the DSH web
+> "Turn produced files" row (same paths, path-level parity).
+
+### Intended behavior
+
+**Why path-level parity, not render-intent parity** — the DSH web UI derives
+produced files from the tool-result card's render intent
+(`card === 'diff'` or `generic + edit` → `locations[].path`), built by the
+browser-only `client-runtime` from each tool's `presentCall`/`presentResult`.
+That render-intent data is NOT in the host session event stream — the
+surface (a plugin) cannot see `card`/`locations`. The host CAN see
+`tool/result`'s `meta` (the tool's private presentation payload) and the
+correlated `tool/call` row. So the surface reproduces the SAME *set of
+produced paths* (write/edit mutations) by combining both host-visible
+sources — path-level parity, same paths the web row lists.
+
+**Host-visible mutation signal** — the fs write/edit mutation tools persist a
+`meta.diffs` KEY on `tool/result`: a non-empty `{path, oldText, newText}[]`
+for an update/overwrite, an empty list for a new-file CREATE (there is no
+before-image to diff). Reads carry a window/snippet meta (NO `diffs` key),
+deletes and plain terminal tools carry none — so the presence of a `meta.diffs`
+KEY (even an empty array) is the mutation signal, exactly the web's
+render-intent rule ("a read looked, a delete removed, a terminal ran").
+
+**Trigger** — a `tool/result` session event whose `meta` has a `diffs` array
+key. For a non-empty `diffs`, the FIRST entry's `path` is taken (a mutation
+tool touches one file; the row is the file). For an empty `diffs` (a create),
+the path is not in meta, so it is derived from the correlated `tool/call`
+arguments' `file_path` (the fs write/edit tools name the target there,
+matching the web's `presentCall.locations`). No correlated `tool/call` row
+and an empty `diffs` → nothing added (never a broken chip).
+
+**State** — `ChatCardState` gains `producedPaths: string[]` (the authoritative
+turn-scoped produced-file paths, deduped, in arrival order). It is reset when
+a new turn starts (`turn/start`) and filled as `tool/result` events arrive.
+`CardSnapshot`/the one render path (`syncCard`) carry it.
+
+**Card/panel shape** — the streaming card's FINAL state (done / stopped /
+error) renders a `📎 Produced` row under the last tool/message row: one
+button per produced path (label = basename). Tapping a chip sends that file
+to the chat via the existing outbound transport (`sendImage` for image
+extensions, `sendFile` otherwise — the #29 `send_file` foundation). The chip
+is a card action (`value.kind: 'send-produced'`, `value.path`); it does NOT
+mutate card state (only sends + a debug log), and the card stays in its
+terminal state. Sends a file message only — no extra receipt card (the chips
+row IS the affordance).
+
+**Ordering/cleanup** — `producedPaths` is turn-scoped: `turn/start` resets it,
+`turn/end` freezes the chip row (the card finalizes with it). A subsequent
+turn's mutations replace the previous list. Paths are relative to the chat's
+pinned cwd (what the tools' `meta.diffs[].path` carry), so resolving against
+`cwd` reproduces the file.
+
+**Failure modes**:
+- `meta` absent / `diffs` empty: nothing added (reads, deletes, terminals —
+  correct exclusion).
+- `meta.diffs` present but malformed (no path): skipped with a debug log
+  (never a broken chip).
+- Chip click while the file is gone (deleted between turn and click): the
+  send fails loudly (tool error surfaced), no partial send, card unchanged.
+- Chip click on an unsupported type: `sendFile` handles it (the resource API
+  serves arbitrary bytes incl. audio/video).
+- No produced paths: no `📎 Produced` row renders (the card looks as today).
+
+**Acceptance checklist**:
+- [ ] A `tool/result` with a non-empty `meta.diffs` adds the first path to
+      `ChatCardState.producedPaths` (unit).
+- [ ] A `tool/result` with an EMPTY `meta.diffs` (a new-file create) adds the
+      path from the correlated `tool/call` arguments' `file_path` (unit).
+- [ ] A `tool/result` from a read (meta without a `diffs` key) does NOT add a
+      path (unit).
+- [ ] `turn/start` resets `producedPaths`; `turn/end` keeps the accumulated
+      list for the final chip row (unit).
+- [ ] The final card renders one `📎 Produced` chip per produced path
+      (label = basename) (unit + integration).
+- [ ] Tapping a chip sends the file to the chat (image path → image message,
+      other → file message) (integration).
+- [ ] A chip click never mutates card state (the card stays terminal) (unit).
+- [ ] No produced paths → no `📎 Produced` row (unit).
+- [ ] Malformed `meta.diffs` / an empty `meta.diffs` without a correlating
+      `file_path` skips with a debug log (unit).
+
+### Reference
+
+- DSH web `packages/client/ui-deliverables/src/client/turn-deliverables.ts`:
+  `producedPaths(view)` returns `locations[].path` only for
+  `card === 'diff'` or `generic + edit` — the render-intent rule this part
+  mirrors at path level (client-only per its header, so the host replicates
+  the path set from `meta.diffs`).
+- dsh agent-loop `packages/core/agent-loop/src/tool-calls.ts`:
+  `session.append('tool/result', { ..., meta })` — `meta` is the tool's
+  private presentation payload persisted on the session event, carrying the
+  fs mutation diffs (write/edit) the surface reads.
+- fs tools `packages/fs/tool-fs/src/write.ts` / `edit.ts`: presentCall /
+  presentResult return `{ card:'diff', locations:[{path}] }`; `result.meta`
+  carries `diffs` (write/edit). read.ts persists a window/snippet meta (NOT
+  diffs) — the exclusion signal.
+- Surface `src/cards/StreamingCardController.ts` (ChatCardState, `snapshot`,
+  `syncCard`) — the single authoritative state + render path this feature
+  extends; the `#29` outbound `sendImage`/`sendFile` transport is reused.

--- a/docs/ux-specification.zh.md
+++ b/docs/ux-specification.zh.md
@@ -593,3 +593,83 @@ print(1)
   的有序占位符序列化是我们自己的设计，保留用户要求的气泡内顺序。
 - pending 路由复用兄弟特性 inbound-wait-instruction part（跟进文字排空；
   附件消息绕过群 mention gate，因为飞书无法从附件里 @）。
+
+## Part: turn-produced-files
+
+> turn 结束后，流式卡列出 agent 产出的文件（write/edit 变更）为可点击 chips；
+> 点一个 chip 把该文件以原生飞书图片/文件消息发给聊天。镜像 DSH web
+> 的「Turn produced files」行（相同路径，路径级一致）。
+
+### 预期行为
+
+**为什么是路径级一致、不是渲染意图一致** — DSH web 从工具结果卡的渲染意图
+（`card === 'diff'` 或 `generic + edit` → `locations[].path`）派生产出文件，
+由浏览器端的 `client-runtime` 从每个工具的 `presentCall`/`presentResult` 构建。
+该渲染意图数据不在宿主会话事件流里 — surface（插件）看不到 `card`/`locations`。
+宿主能看到 `tool/result` 的 `meta`（工具私有展示载荷）与关联的 `tool/call`
+行。因此 surface 组合这两个宿主可见来源，复现同一组产出路径（write/edit
+变更）——路径级一致，与 web 行同路径。
+
+**宿主侧的变更信号** — fs write/edit 工具在 `tool/result` 上持久化一个
+`meta.diffs` KEY：update/overwrite 是非空 `{path, oldText, newText}[]`，
+新建文件 CREATE 是空列表（没有 before 镜像可 diff）。read 带窗口/摘要 meta
+（无 `diffs` key），delete 与纯 terminal 工具不带任何 meta —— 所以
+`meta.diffs` KEY（哪怕空数组）即变更信号，正是 web 的渲染意图规则
+（「read 只是看，delete 是移除，terminal 是运行」）。
+
+**触发** — `tool/result` 事件的 `meta` 带 `diffs` 数组 key。非空 `diffs` 取
+第一条的 `path`（变更工具一次改一个文件；行即该文件）。空 `diffs`（新建）
+路径不在 meta —— 从关联的 `tool/call` 参数的 `file_path` 派生（fs write/edit
+工具在此命名目标，匹配 web 的 `presentCall.locations`）。无关联 `tool/call`
+行且 `diffs` 为空 → 不加任何路径（绝不出现坏 chip）。
+
+**状态** — `ChatCardState` 增 `producedPaths: string[]`（权威的 turn 内产出文件
+路径，去重，按到达顺序）。新 turn 开始（`turn/start`）时重置，随 `tool/result`
+事件填充。`CardSnapshot`/单一渲染路径（`syncCard`）携带它。
+
+**卡/面板形态** — 流式卡的最终状态（done / stopped / error）在最后一条
+tool/message 行下渲染 `📎 Produced` 行：每个产出路径一个按钮（label =
+basename）。点一个 chip 通过既有 outbound transport 把文件发给聊天
+（图片扩展名 → `sendImage`，否则 `sendFile` — #29 `send_file` 基建）。
+chip 是卡片动作（`value.kind: 'send-produced'`、`value.path`）；它不改卡片
+状态（只发送 + 一条 debug 日志），卡片保持终态。只发送文件消息 — 不额外
+发回执卡（chips 行本身就是提示）。
+
+**排序/清理** — `producedPaths` 是 turn 内作用域：`turn/start` 重置，
+`turn/end` 冻结 chips 行（卡片随它定稿）。后续 turn 的变更替换上一份列表。
+路径相对 chat 固定的 cwd（正是工具 `meta.diffs[].path` 携带的），因此相对
+`cwd` 解析即可复现文件。
+
+**失败模式**：
+- `meta` 缺失 / `diffs` 空：什么都不加（read、delete、terminal —— 正确的排除）。
+- `meta.diffs` 存在但畸形（无 path）：跳过并 debug 日志（绝不出现坏 chip）。
+- 点 chip 时文件已丢失（turn 与点击之间删了）：发送响亮失败（工具错误浮出），
+  无部分发送，卡片不变。
+- 点不支持的类型的 chip：`sendFile` 兜底（资源 API 服务任意字节，含音频/视频）。
+- 无产出路径：不渲染 `📎 Produced` 行（卡片同今日）。
+
+**验收清单**：
+- [ ] `tool/result` 带非空 `meta.diffs` 把第一条 path 加入
+      `ChatCardState.producedPaths`（单测）。
+- [ ] `tool/result` 带空 `meta.diffs`（新建文件）把关联 `tool/call` 参数的
+      `file_path` 加入 `producedPaths`（单测）。
+- [ ] `tool/result` 来自 read（meta 无 `diffs` key）不加路径（单测）。
+- [ ] `turn/start` 重置 `producedPaths`；`turn/end` 保留累计列表用于最终 chips
+      行（单测）。
+- [ ] 最终卡每个产出路径渲染一个 `📎 Produced` chip（label = basename）
+      （单测 + 集成）。
+- [ ] 点 chip 把文件发给聊天（图片路径 → 图片消息，其他 → 文件消息）（集成）。
+- [ ] 点 chip 不改卡片状态（卡片保持终态）（单测）。
+- [ ] 无产出路径 → 无 `📎 Produced` 行（单测）。
+- [ ] 畸形 `meta.diffs` / 空 `meta.diffs` 且无关联 `file_path` 跳过并 debug 日志
+      （单测）。
+
+### Reference
+
+- DSH web `packages/client/ui-deliverables/src/client/turn-deliverables.ts`：
+  `producedPaths(view)` 只对 `card === 'diff'` 或 `generic + edit` 返回
+  `locations[].path` — 本 part 在路径级镜像的渲染意图规则（按其头部说明仅客户端，
+  因此宿主按 `meta` 复刻）。
+- `@deepseek-ai/dsh-tool-fs` write/edit 工具：`presentationMeta` 输出
+  `{diffs}`（新建 create 为 `[]`），`presentCall` 的 `locations`
+  `[{path: file_path}]` — 两个宿主信号来源。

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1675,7 +1675,8 @@ export class Bridge {
       case 'copy':
       case 'retry':
       case 'row-details':
-      case 'toggle-rows': {
+      case 'toggle-rows':
+      case 'send-produced': {
         // Streaming-card actions are handled by the streaming state
         // machine controller (they mutate the card state).
         await this.streaming.handleStreamingAction(action);

--- a/src/cards/StreamingCardController.ts
+++ b/src/cards/StreamingCardController.ts
@@ -11,10 +11,13 @@
  * @module @dsh-feishu/dsh-feishu/cards/StreamingCardController
  */
 
+import { readFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
 import type { Agent } from '@deepseek-ai/dsh-agent';
 import { createUserMessage } from '@deepseek-ai/dsh-llm';
 import type { SessionEvent } from '@deepseek-ai/dsh-session';
 import type { CardAction, FeishuTransport } from '../feishu/types.js';
+import { isImagePath } from '../outbound.js';
 import type { SessionMap } from '../session-map.js';
 import {
   assistantText,
@@ -47,6 +50,25 @@ function isCompactionLifecycleEvent(event: SessionEvent): boolean {
 }
 
 /**
+ * The `file_path` of a mutation tool call, parsed from its raw arguments JSON.
+ * The fs write/edit tools name the target in `file_path` (the schema key the
+ * model emits); a read also carries `file_path`, but callers gate on a
+ * `meta.diffs` mutation signal, so only write/edit reach this. Returns
+ * undefined when the field is absent or the arguments are not JSON.
+ */
+function filePathFromArguments(args: string | undefined): string | undefined {
+  if (args === undefined || args === '') return undefined;
+  try {
+    const parsed = JSON.parse(args) as { file_path?: unknown };
+    return typeof parsed.file_path === 'string' && parsed.file_path !== ''
+      ? parsed.file_path
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * One chat's streaming-card state — the single authoritative source for the
  * card. The controller renders the card from THIS state and nothing else;
  * card actions mutate it (or not) and then always call {@link
@@ -71,6 +93,10 @@ export interface ChatCardState {
   /** The user pressed Stop; the card shows an in-progress Stopping state
    *  until turn/end(aborted) settles it to `stopped`. */
   stopRequested: boolean;
+  /** Paths (relative to the pinned cwd) of files the agent produced this
+   *  turn via write/edit mutations (from `tool/result` `meta.diffs`).
+   *  Reset on turn start; the final card chips render from it. */
+  producedPaths: string[];
 }
 
 const MAX_TITLE_CHARS = 40;
@@ -233,6 +259,7 @@ export class StreamingCardController {
       status: 'working',
       collapsed: true,
       stopRequested: false,
+      producedPaths: [],
     });
     try {
       await this.host.cards.open(chatId, title);
@@ -292,6 +319,7 @@ export class StreamingCardController {
       cwd: this.host.sessionMap.cwdFor(chatId) ?? this.host.defaultCwd,
       collapsed: state.collapsed,
       stopRequested: state.stopRequested,
+      producedPaths: state.producedPaths,
       status: state.status,
     };
   }
@@ -381,6 +409,7 @@ export class StreamingCardController {
           status: 'working',
           collapsed: true,
           stopRequested: false,
+          producedPaths: [],
         });
         try {
           await this.host.cards.open(chatId, title);
@@ -444,6 +473,7 @@ export class StreamingCardController {
         this.host.logger.debug(
           `streaming tool/result ${chatId}: call ${event.data.message.content[0]?.toolCallId ?? '(unknown)'} -> ${status}`,
         );
+        // Find the correlated tool row (also the create-fallback path source).
         const index = state.rows.findIndex(
           (row): row is ToolRow =>
             row.kind === 'tool' && row.id === event.data.message.content[0]?.toolCallId,
@@ -460,6 +490,36 @@ export class StreamingCardController {
                 }
                 return -1;
               })();
+        const callRow = target >= 0 ? (state.rows[target] as ToolRow | undefined) : undefined;
+        // Turn-produced files (path-level parity with the DSH web row). The
+        // web derives produced paths from a mutation tool's render intent
+        // (diff / generic+edit → `locations[].path`), which is browser-only.
+        // The host-visible analogue: the fs write/edit mutation tools persist
+        // a `meta.diffs` KEY on `tool/result` — a non-empty array for an
+        // update/overwrite, an empty one for a new-file CREATE. Reads carry a
+        // window/snippet meta (NO diffs key) and deletes/terminals carry none,
+        // so a `meta.diffs` key (even empty) is the mutation signal. For an
+        // empty `diffs` (a create) the path is not in meta, so derive it from
+        // the correlated `tool/call` arguments' `file_path` — matching the
+        // web's `presentCall.locations` exactly.
+        const meta = (event.data as { meta?: { diffs?: unknown[] } }).meta;
+        if (meta !== undefined && Array.isArray(meta.diffs)) {
+          let path: string | undefined;
+          if (meta.diffs.length > 0) {
+            const first = meta.diffs[0] as { path?: unknown };
+            if (typeof first?.path === 'string' && first.path !== '') path = first.path;
+          } else {
+            // New-file create: no diff basis, so `meta.diffs` is empty. The
+            // path rides the tool/call arguments (`file_path`).
+            path = filePathFromArguments(callRow?.args);
+          }
+          if (path !== undefined && path !== '' && !state.producedPaths.includes(path)) {
+            state.producedPaths.push(path);
+            this.host.logger.debug(
+              `streaming produced-file ${chatId}: ${path} (${state.producedPaths.length} total)`,
+            );
+          }
+        }
         if (target >= 0 && state.rows[target]?.kind === 'tool') {
           const row = state.rows[target] as ToolRow;
           state.rows[target] = {
@@ -558,6 +618,7 @@ export class StreamingCardController {
             status: 'working',
             collapsed: true,
             stopRequested: false,
+            producedPaths: [],
           };
           this.cardStates.set(chatId, state);
           try {
@@ -704,6 +765,7 @@ export class StreamingCardController {
           status: 'working',
           collapsed: true,
           stopRequested: false,
+          producedPaths: [],
         });
         try {
           await this.host.cards.open(action.chatId, turnTitle(prompt));
@@ -741,6 +803,40 @@ export class StreamingCardController {
         if (state !== undefined) {
           state.collapsed = !state.collapsed;
           this.syncCard(action.chatId);
+        }
+        return;
+      }
+      case 'send-produced': {
+        // A produced-file chip: send the file to the chat via the outbound
+        // transport (image extension -> image message, otherwise file). This
+        // does NOT mutate card state — the card stays terminal. Best-effort;
+        // an unreadable file fails loud to the user. `path` is cwd-relative.
+        const path = action.value.path;
+        if (typeof path !== 'string' || path === '') {
+          this.host.logger.warn(`send-produced ${action.chatId}: missing path`);
+          return;
+        }
+        const filePath = join(
+          this.host.sessionMap.cwdFor(action.chatId) ?? this.host.defaultCwd,
+          path,
+        );
+        try {
+          const bytes = new Uint8Array(await readFile(filePath));
+          const name = basename(filePath);
+          if (isImagePath(path)) {
+            await this.host.transport.sendImage(action.chatId, name, bytes);
+            this.host.logger.debug(`send-produced ${action.chatId}: sent image ${path}`);
+          } else {
+            await this.host.transport.sendFile(action.chatId, name, bytes);
+            this.host.logger.debug(`send-produced ${action.chatId}: sent file ${path}`);
+          }
+        } catch (error: unknown) {
+          const msg = error instanceof Error ? error.message : String(error);
+          this.host.logger.warn(`send-produced ${action.chatId} ${path}: failed (${msg})`);
+          await this.host.transport.sendText(
+            action.chatId,
+            `⚠️ Could not send the produced file \`${path}\` (${msg}).`,
+          );
         }
         return;
       }

--- a/src/cards/render.ts
+++ b/src/cards/render.ts
@@ -12,6 +12,7 @@
  * @module @dsh-feishu/dsh-feishu/cards/render
  */
 
+import { basename } from 'node:path';
 import type { ContentBlock } from '@deepseek-ai/dsh-llm';
 import type { CardElement, CardJson } from '../feishu/types.js';
 import type { ProjectInfo } from '../projects.js';
@@ -68,6 +69,9 @@ export interface CardSnapshot {
   readonly collapsed?: boolean;
   /** The user pressed Stop; show an in-progress Stopping state. */
   readonly stopRequested?: boolean;
+  /** Paths (relative to cwd) of files produced this turn — rendered as
+   *  clickable `📎 Produced` chips on the terminal card. */
+  readonly producedPaths?: readonly string[];
   readonly status: CardStatus;
 }
 
@@ -484,6 +488,26 @@ export function buildCard(snapshot: CardSnapshot): CardJson {
             : '✅ Done';
       elements.push({ tag: 'note', elements: [{ tag: 'plain_text', content: terminalNote }] });
     }
+  }
+  // Turn-produced files: render a `📎 Produced` chip row on the TERMINAL card
+  // (done/stopped/error — after the content, once the turn has settled). Each
+  // chip is a button that sends the file to the chat (send-produced action).
+  const produced = snapshot.producedPaths ?? [];
+  if (snapshot.status !== 'working' && produced.length > 0) {
+    elements.push({ tag: 'hr' });
+    elements.push({
+      tag: 'markdown',
+      content: '**📎 Produced**',
+    });
+    elements.push({
+      tag: 'action',
+      actions: produced.map((path) => ({
+        tag: 'button',
+        text: { tag: 'plain_text', content: basename(path) },
+        type: 'primary',
+        value: { kind: 'send-produced', path },
+      })),
+    });
   }
   // Two button rows: row 1 = state actions (Stop / Copy·Retry·Panel), row 2
   // = the row view toggle — one row of 4 wrapped awkwardly on mobile.

--- a/src/outbound.ts
+++ b/src/outbound.ts
@@ -50,7 +50,7 @@ function chatForSession(sessionMap: SessionMap, sessionId: string): string | und
 }
 
 /** Classify a path's extension as an image container (image message) or file. */
-function isImagePath(path: string): boolean {
+export function isImagePath(path: string): boolean {
   const ext = basename(path).split('.').pop()?.toLowerCase() ?? '';
   return IMAGE_EXTENSIONS.has(ext);
 }

--- a/tests/integration/turn-produced-files.spec.ts
+++ b/tests/integration/turn-produced-files.spec.ts
@@ -1,0 +1,352 @@
+/**
+ * Real-composition integration tests for turn-produced-files: the agent
+ * produces a file during a turn (a `write`/`edit` mutation), the streaming
+ * card's FINAL state lists it as a `📎 Produced` chip, and tapping the chip
+ * sends the file to the Feishu chat (memory transport records the outbound
+ * message). Covers the new-file CREATE path (where `tool/result` `meta.diffs`
+ * is empty and the path comes from the correlated `tool/call` `file_path`)
+ * and the file-vs-image send dispatch.
+ *
+ * The LLM is mocked (it scripts the agent to call `write`); the Feishu
+ * transport is the memory seam, which records `{kind:'file'|'image'}` outbox
+ * records instead of hitting the real API — the real upload paths
+ * (`im.v1.image.create` / `im.v1.file.create`) are covered by transport unit
+ * tests. A real dsh process boots from the real profile.
+ *
+ * Self-skips when the environment lacks a prepared profile or the dsh CLI.
+ */
+
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { MemoryOutboxRecord } from '../../src/memory-transport.js';
+import { type MockLlmServer, startMockLlmServer } from './mock-llm-server.js';
+
+const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+const DSH_HOME =
+  process.env.FEISHU_INT_TURN_PRODUCED_DSH_HOME ??
+  join(REPO_ROOT, '_dev', 'dsh-home-turn-produced-files');
+const PROFILE_DIR = join(DSH_HOME, 'profiles', 'feishu-dev');
+const MEMORY_DIR = join(REPO_ROOT, '_dev', 'int-memory-turn-produced');
+const INBOX_DIR = join(MEMORY_DIR, 'inbox');
+const OUTBOX_DIR = join(MEMORY_DIR, 'outbox');
+const ACTIONS_DIR = join(MEMORY_DIR, 'actions');
+const INT_CWD = join(REPO_ROOT, '_dev', 'int-cwd-turn-produced');
+
+function resolveDshBin(): string | undefined {
+  if (process.env.DSH_BIN !== undefined && process.env.DSH_BIN !== '') return process.env.DSH_BIN;
+  const probe = spawnSync('sh', ['-c', 'command -v dsh'], { encoding: 'utf8' });
+  if (probe.status === 0 && probe.stdout.trim() !== '') return probe.stdout.trim();
+  return undefined;
+}
+
+function readOutbox(): MemoryOutboxRecord[] {
+  let files: string[];
+  try {
+    files = readdirSync(OUTBOX_DIR).filter((file) => file.endsWith('.json'));
+  } catch {
+    return [];
+  }
+  return files
+    .map((file) => {
+      try {
+        return JSON.parse(readFileSync(join(OUTBOX_DIR, file), 'utf8')) as MemoryOutboxRecord;
+      } catch {
+        return undefined;
+      }
+    })
+    .filter((record): record is MemoryOutboxRecord => record !== undefined)
+    .sort((a, b) => a.seq - b.seq);
+}
+
+async function waitFor(
+  description: string,
+  predicate: () => boolean,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (predicate()) return;
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${description}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+}
+
+const dshBin = resolveDshBin();
+const profileReady = existsSync(join(PROFILE_DIR, 'package.json'));
+const built = existsSync(join(REPO_ROOT, 'lib', 'index.js'));
+const integrationRequired = process.env.FEISHU_INT_REQUIRED === '1';
+const integrationReady = dshBin !== undefined && profileReady && built;
+if (integrationRequired && !integrationReady) {
+  throw new Error(
+    `FEISHU_INT_REQUIRED=1 but integration prerequisites are missing ` +
+      `(dsh CLI=${dshBin !== undefined} profile=${profileReady} built=${built})`,
+  );
+}
+
+/** Drop one inbound message into the message channel. */
+function sendMessage(chatId: string, text: string, fixedMessageId?: string): void {
+  const messageId = fixedMessageId ?? `om-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  writeFileSync(
+    join(INBOX_DIR, `${messageId}.json`),
+    JSON.stringify({
+      messageId,
+      chatId,
+      chatType: 'p2p',
+      senderOpenId: 'ou_mock',
+      text,
+      mentions: [],
+      createdAt: Date.now(),
+    }),
+    'utf8',
+  );
+}
+
+/** Write one card action into the actions channel for the spawned process. */
+function writeAction(action: unknown): void {
+  writeFileSync(
+    join(ACTIONS_DIR, `act-${Date.now()}-${Math.random().toString(36).slice(2)}.json`),
+    JSON.stringify(action),
+    'utf8',
+  );
+}
+
+/** Pin the chat's working directory via /cd (the gate refuses turns until
+ *  an explicit directory is chosen). */
+async function pinWorkingDir(chatId: string): Promise<void> {
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    sendMessage(chatId, `/cd ${INT_CWD}`);
+    try {
+      await waitFor(
+        'the /cd confirmation',
+        () =>
+          readOutbox().some(
+            (r) =>
+              r.kind === 'text' &&
+              r.chatId === chatId &&
+              r.text?.includes('Working directory set to'),
+          ),
+        20_000,
+      );
+      return;
+    } catch (error) {
+      if (attempt === 3) throw error;
+    }
+  }
+}
+
+describe.skipIf(!integrationReady)('integration > turn-produced-files', () => {
+  let mock: MockLlmServer | undefined;
+  let child: ReturnType<typeof spawn> | undefined;
+  let stdout = '';
+  let stderr = '';
+  let bridgeReady = false;
+
+  async function stopChild(): Promise<void> {
+    const proc = child;
+    child = undefined;
+    if (proc === undefined || proc.exitCode !== null) return;
+    proc.kill('SIGTERM');
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        if (proc.exitCode === null) proc.kill('SIGKILL');
+        resolve();
+      }, 5_000);
+      proc.once('exit', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  }
+
+  beforeEach(async () => {
+    if (mock !== undefined) await mock.close();
+    await stopChild();
+    rmSync(MEMORY_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    rmSync(INT_CWD, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    mkdirSync(INT_CWD, { recursive: true });
+    mkdirSync(INBOX_DIR, { recursive: true });
+    mkdirSync(OUTBOX_DIR, { recursive: true });
+    mkdirSync(ACTIONS_DIR, { recursive: true });
+    mock = await startMockLlmServer();
+    bridgeReady = false;
+    stdout = '';
+    stderr = '';
+  });
+
+  afterEach(async () => {
+    await stopChild();
+    if (mock !== undefined) await mock.close();
+  });
+
+  async function boot(): Promise<{ chatId: string }> {
+    const bin = dshBin;
+    if (bin === undefined) throw new Error('dsh CLI unavailable');
+    const server = mock;
+    if (server === undefined) throw new Error('mock LLM server unavailable');
+    child = spawn(bin, ['--profile', 'feishu-dev'], {
+      env: {
+        ...process.env,
+        DSH_HOME,
+        FEISHU_APP_ID: 'cli_mock_app',
+        FEISHU_APP_SECRET: 'mock_secret',
+        FEISHU_TRANSPORT: 'memory',
+        FEISHU_MEMORY_DIR: MEMORY_DIR,
+        FEISHU_MOCK_BOT_OPEN_ID: 'ou_bot',
+        DEEPSEEK_API_KEY: 'mock_key',
+        DEEPSEEK_BASE_URL: server.url,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+      if (stdout.includes('[feishu] bridge ready')) bridgeReady = true;
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    await waitFor('the bridge to report ready', () => bridgeReady, 30_000);
+    const chatId = `oc_tp_${Date.now()}`;
+    await pinWorkingDir(chatId);
+    return { chatId };
+  }
+
+  it('a NEW-file write shows a Produced chip and a chip tap sends the file', async () => {
+    // Script the agent to CREATE a file with `write`. `before === null`, so the
+    // `tool/result` `meta.diffs` is EMPTY — the path comes from the correlated
+    // `tool/call` `file_path` (the create parity path).
+    mock?.setScripts([
+      [
+        {
+          toolCall: {
+            index: 0,
+            id: 'call-write-1',
+            name: 'write',
+            arguments: '{"file_path":"report.txt","content":"the report body\\n"}',
+          },
+        },
+      ],
+      [{ content: 'Done — I wrote the report.' }],
+    ]);
+    const { chatId } = await boot();
+    sendMessage(chatId, 'write the report');
+
+    // Turn completes: green final card patch.
+    try {
+      await waitFor(
+        'the green final card patch',
+        () => readOutbox().some((r) => r.kind === 'patch' && r.card?.header?.template === 'green'),
+        90_000,
+      );
+    } catch (error) {
+      throw new Error(
+        `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}\n--- outbox ---\n${JSON.stringify(readOutbox())}`,
+      );
+    }
+
+    // The final card lists the produced file as a chip — the basename label.
+    const finalCard = readOutbox()
+      .filter((r) => r.kind === 'patch')
+      .at(-1)?.card;
+    expect(
+      finalCard?.elements.some(
+        (el) => el.tag === 'markdown' && 'content' in el && el.content === '**📎 Produced**',
+      ),
+    ).toBe(true);
+    const chip = finalCard?.elements.some(
+      (el) =>
+        el.tag === 'action' &&
+        'actions' in el &&
+        (el.actions as unknown[]).some(
+          (a) =>
+            Object.hasOwn(a as object, 'text') &&
+            (a as { text: { tag: string; content: string } }).text.content === 'report.txt' &&
+            (a as { value?: { kind?: string; path?: string } }).value?.kind === 'send-produced' &&
+            (a as { value?: { path?: string } }).value?.path === 'report.txt',
+        ),
+    );
+    expect(chip).toBe(true);
+
+    // Tap the chip -> the file is sent to the chat (cwd-relative resolved).
+    writeAction({
+      messageId: 'mem-1',
+      chatId,
+      operatorOpenId: 'ou_mock',
+      value: { kind: 'send-produced', path: 'report.txt' },
+    });
+    await waitFor(
+      'the outbound file message',
+      () => readOutbox().some((r) => r.kind === 'file' && r.chatId === chatId),
+      60_000,
+    );
+  }, 150_000);
+
+  it('a chip tap on an image path sends a native image message', async () => {
+    mock?.setScripts([
+      [
+        {
+          toolCall: {
+            index: 0,
+            id: 'call-write-2',
+            name: 'write',
+            arguments: '{"file_path":"plot.png","content":"not-a-real-png-body"}',
+          },
+        },
+      ],
+      [{ content: 'Done — I made the plot.' }],
+    ]);
+    const { chatId } = await boot();
+    sendMessage(chatId, 'make the plot');
+    try {
+      await waitFor(
+        'the green final card patch',
+        () => readOutbox().some((r) => r.kind === 'patch' && r.card?.header?.template === 'green'),
+        90_000,
+      );
+    } catch (error) {
+      throw new Error(
+        `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}\n--- outbox ---\n${JSON.stringify(readOutbox())}`,
+      );
+    }
+
+    // The final card shows the chip (image filename).
+    const finalCard = readOutbox()
+      .filter((r) => r.kind === 'patch')
+      .at(-1)?.card;
+    expect(
+      finalCard?.elements.some(
+        (el) =>
+          el.tag === 'action' &&
+          'actions' in el &&
+          (el.actions as unknown[]).some(
+            (a) =>
+              (a as { text?: { content?: string } }).text?.content === 'plot.png' &&
+              (a as { value?: { kind?: string } }).value?.kind === 'send-produced',
+          ),
+      ),
+    ).toBe(true);
+
+    // Tap the chip -> the image is sent (isImagePath('plot.png') is true).
+    writeAction({
+      messageId: 'mem-1',
+      chatId,
+      operatorOpenId: 'ou_mock',
+      value: { kind: 'send-produced', path: 'plot.png' },
+    });
+    try {
+      await waitFor(
+        'the outbound image message',
+        () => readOutbox().some((r) => r.kind === 'image' && r.chatId === chatId),
+        60_000,
+      );
+    } catch (error) {
+      throw new Error(
+        `${String(error)}\n--- dsh stdout ---\n${stdout}\n--- dsh stderr ---\n${stderr}\n--- outbox ---\n${JSON.stringify(readOutbox())}`,
+      );
+    }
+  }, 150_000);
+});

--- a/tests/turn-produced.spec.ts
+++ b/tests/turn-produced.spec.ts
@@ -1,0 +1,266 @@
+/**
+ * Unit tests for turn-produced-files: the StreamingCardController collects
+ * write/edit mutation paths from `tool/result` meta.diffs into the card
+ * state, the terminal card renders `📎 Produced` chips, and a chip tap
+ * (`send-produced` action) sends the file to the chat.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { SessionEvent } from '@deepseek-ai/dsh-session';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildCard } from '../src/cards/render.js';
+import {
+  StreamingCardController,
+  type StreamingCardHost,
+} from '../src/cards/StreamingCardController.js';
+import { StreamingCardManager } from '../src/cards/streaming.js';
+import type { CardAction, CardJson, FeishuTransport } from '../src/feishu/types.js';
+import { SessionMap } from '../src/session-map.js';
+
+class RecordingTransport implements FeishuTransport {
+  sentCards: CardJson[] = [];
+  updatedCards: CardJson[] = [];
+  sentImages: Array<{ chatId: string; fileName: string; bytes: Uint8Array }> = [];
+  sentFiles: Array<{ chatId: string; fileName: string; content: Uint8Array }> = [];
+  sentTexts: Array<{ chatId: string; text: string }> = [];
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  onMessage(_handler: unknown): void {}
+  onCardAction(_handler: unknown): void {}
+  getBotOpenId(): string | undefined {
+    return undefined;
+  }
+  async chatStats(_chatId: string) {
+    return undefined;
+  }
+  async createGroup(_name: string, _members: readonly string[]) {
+    return { chatId: 'oc_g' };
+  }
+  async sendText(chatId: string, text: string): Promise<void> {
+    this.sentTexts.push({ chatId, text });
+  }
+  async sendFile(chatId: string, fileName: string, content: Uint8Array): Promise<void> {
+    this.sentFiles.push({ chatId, fileName, content });
+  }
+  async sendImage(chatId: string, fileName: string, bytes: Uint8Array): Promise<void> {
+    this.sentImages.push({ chatId, fileName, bytes });
+  }
+  async addReaction(_messageId: string, _emojiType: string): Promise<string | undefined> {
+    return undefined;
+  }
+  async removeReaction(_messageId: string, _reactionId: string): Promise<void> {}
+  async sendCard(chatId: string, card: CardJson): Promise<{ messageId: string }> {
+    this.sentCards.push({ ...card, chatId } as CardJson);
+    return { messageId: `m-${this.sentCards.length}` };
+  }
+  async updateCard(_messageId: string, card: CardJson): Promise<void> {
+    this.updatedCards.push(card);
+  }
+  async deleteMessage(_messageId: string): Promise<void> {}
+  async downloadImage(
+    _messageId: string,
+    _key: string,
+  ): Promise<{ data: Uint8Array; mediaType: string }> {
+    throw new Error('downloadImage not implemented in this fake');
+  }
+  async downloadFile(
+    _messageId: string,
+    _key: string,
+  ): Promise<{ stream: NodeJS.ReadableStream; head: Uint8Array }> {
+    throw new Error('downloadFile not implemented in this fake');
+  }
+}
+
+function makeController(cwd: string): {
+  controller: StreamingCardController;
+  transport: RecordingTransport;
+} {
+  const transport = new RecordingTransport();
+  const sessionMap = new SessionMap(join(cwd, 'session-map.json'));
+  sessionMap.set('oc_chat', 's1');
+  sessionMap.setCwd('oc_chat', cwd);
+  const cards = new StreamingCardManager(transport);
+  const host = {
+    transport,
+    cards,
+    logger: { debug: () => {}, warn: () => {}, info: () => {}, error: () => {} },
+    sessionMap,
+    agentStore: {
+      get: () => undefined,
+      resume: async () => undefined,
+      create: async () => undefined,
+    },
+    defaultCwd: cwd,
+    reactions: undefined,
+    resolveAgent: async () => undefined,
+    textMentionFor: () => '',
+  } as unknown as StreamingCardHost;
+  const controller = new StreamingCardController(host);
+  return { controller, transport };
+}
+
+function toolCallEvent(name: string, args: string, callId = 'c1'): SessionEvent {
+  return {
+    type: 'tool/call',
+    seq: 1,
+    time: 0,
+    data: { turn: 1, step: 1, callId, name, arguments: args },
+  } as unknown as SessionEvent;
+}
+
+function toolResultEvent(diffs?: { path: string }[], callId = 'c1'): SessionEvent {
+  return {
+    type: 'tool/result',
+    seq: 1,
+    time: 0,
+    data: {
+      turn: 1,
+      step: 1,
+      message: {
+        content: [{ text: 'ok', type: 'tool-result', toolCallId: callId }],
+        source: { callId },
+      },
+      ...(diffs !== undefined ? { meta: { diffs } } : {}),
+    },
+  } as unknown as SessionEvent;
+}
+
+describe('turn-produced-files', () => {
+  let dir: string;
+  afterEach(() => {
+    if (dir !== undefined) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('collects write/edit mutation paths from tool/result meta.diffs', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'tpf-'));
+    const { controller } = makeController(dir);
+    await controller.beginTurn('oc_chat', 'om-1', 'do work');
+    expect(controller.state('oc_chat')?.producedPaths).toEqual([]);
+    await controller.handleEvent('s1', toolResultEvent([{ path: 'report.md' }]));
+    await controller.handleEvent('s1', toolResultEvent([{ path: 'plot.png' }]));
+    expect(controller.state('oc_chat')?.producedPaths).toEqual(['report.md', 'plot.png']);
+  });
+
+  it('does NOT collect a read tool (meta without diffs)', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'tpf-'));
+    const { controller } = makeController(dir);
+    await controller.beginTurn('oc_chat', 'om-1', 'do work');
+    // A read carries a window/snippet meta, NOT diffs.
+    await controller.handleEvent('s1', {
+      type: 'tool/result',
+      seq: 1,
+      time: 0,
+      data: {
+        turn: 1,
+        step: 1,
+        message: { content: [], source: { callId: 'r1' } },
+        meta: { snippet: 'abc' },
+      },
+    } as unknown as SessionEvent);
+    expect(controller.state('oc_chat')?.producedPaths).toEqual([]);
+  });
+
+  it('collects a NEW-file create path from the correlate tool/call file_path (empty meta.diffs)', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'tpf-'));
+    const { controller } = makeController(dir);
+    await controller.beginTurn('oc_chat', 'om-1', 'do work');
+    // A `write` CREATE carries `meta.diffs: []` (no before-image to diff), so
+    // the path is derived from the correlated tool/call arguments' file_path.
+    await controller.handleEvent(
+      's1',
+      toolCallEvent('write', '{"file_path":"report.md","content":"x"}'),
+    );
+    await controller.handleEvent('s1', toolResultEvent([], 'c1'));
+    expect(controller.state('oc_chat')?.producedPaths).toEqual(['report.md']);
+  });
+
+  it('ignores an empty meta.diffs without a correlating file_path', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'tpf-'));
+    const { controller } = makeController(dir);
+    await controller.beginTurn('oc_chat', 'om-1', 'do work');
+    // No tool/call row to correlate to -> no path (never a broken chip).
+    await controller.handleEvent('s1', toolResultEvent([]));
+    expect(controller.state('oc_chat')?.producedPaths).toEqual([]);
+  });
+
+  it('resets producedPaths on a new turn (beginTurn)', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'tpf-'));
+    const { controller } = makeController(dir);
+    await controller.beginTurn('oc_chat', 'om-1', 'first');
+    await controller.handleEvent('s1', toolResultEvent([{ path: 'a.md' }]));
+    expect(controller.state('oc_chat')?.producedPaths).toEqual(['a.md']);
+    await controller.beginTurn('oc_chat', 'om-2', 'second');
+    expect(controller.state('oc_chat')?.producedPaths).toEqual([]);
+  });
+
+  it('renders 📎 Produced chips on the terminal card only when there are produced paths', () => {
+    const withProduced = buildCard({
+      title: 't',
+      content: 'done',
+      rows: [],
+      status: 'done',
+      producedPaths: ['report.md', 'plot.png'],
+    });
+    const json = JSON.stringify(withProduced.elements);
+    expect(json).toContain('📎 Produced');
+    expect(json).toContain('report.md');
+    expect(json).toContain('plot.png');
+    // No produced paths -> no chips row.
+    const noneProduced = buildCard({ title: 't', content: 'x', rows: [], status: 'done' });
+    expect(JSON.stringify(noneProduced.elements)).not.toContain('📎 Produced');
+    // Working card never renders chips.
+    const working = buildCard({
+      title: 't',
+      content: 'x',
+      rows: [],
+      status: 'working',
+      producedPaths: ['a.md'],
+    });
+    expect(JSON.stringify(working.elements)).not.toContain('📎 Produced');
+  });
+
+  it('a send-produced action sends an image for an image path', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'tpf-'));
+    writeFileSync(join(dir, 'plot.png'), new Uint8Array([137, 80, 78, 71]));
+    const { controller, transport } = makeController(dir);
+    await controller.handleStreamingAction({
+      chatId: 'oc_chat',
+      messageId: 'm1',
+      operatorOpenId: 'u1',
+      value: { kind: 'send-produced', path: 'plot.png' },
+    } as CardAction);
+    expect(transport.sentImages).toHaveLength(1);
+    expect(transport.sentImages[0]?.fileName).toBe('plot.png');
+    expect(transport.sentFiles).toHaveLength(0);
+  });
+
+  it('a send-produced action sends a file for a non-image path', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'tpf-'));
+    writeFileSync(join(dir, 'report.md'), 'content');
+    const { controller, transport } = makeController(dir);
+    await controller.handleStreamingAction({
+      chatId: 'oc_chat',
+      messageId: 'm1',
+      operatorOpenId: 'u1',
+      value: { kind: 'send-produced', path: 'report.md' },
+    } as CardAction);
+    expect(transport.sentFiles).toHaveLength(1);
+    expect(transport.sentFiles[0]?.fileName).toBe('report.md');
+    expect(transport.sentImages).toHaveLength(0);
+  });
+
+  it('a send-produced action with a missing file fails loud and sends a notice', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'tpf-'));
+    const { controller, transport } = makeController(dir);
+    await controller.handleStreamingAction({
+      chatId: 'oc_chat',
+      messageId: 'm1',
+      operatorOpenId: 'u1',
+      value: { kind: 'send-produced', path: 'nope.md' },
+    } as CardAction);
+    expect(transport.sentFiles).toHaveLength(0);
+    expect(transport.sentTexts.some((t) => t.text.includes('Could not send'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

- After a turn ends, the streaming card lists the files the agent produced (write/edit mutations) as clickable `📎 Produced` chips (label = basename) under the last tool/message row.
- Tapping a chip sends that file to the chat as a native Feishu image (image extension) or file message (`sendImage`/`sendFile`, the #29 outbound transport); no separate receipt card.
- Path-level parity with the DSH web "Turn produced files" row: the host derives the mutation path from `tool/result` `meta.diffs` (the fs write/edit tools presentation payload, empty for a new-file CREATE), falling back to the correlated `tool/call` `file_path` when `diffs` is empty.
- Reads (no `diffs` key), deletes and terminals are excluded. Paths are turn-scoped, deduped, resolved against the pinned cwd.

## Why

dsh has no host-level "agent produced a file" event. The web derives produced files from a mutation tool render intent (browser-only `presentCall`/`presentResult` `locations`). The surface can only see the session event stream, so it reproduces the same path set from the host-visible `meta.diffs` key — and, for creates (where the web lists the file but `meta.diffs` is empty), from the correlated `tool/call` `file_path`. This closes a real parity gap where a newly-created file would not appear.

## Docs

- `docs/ux-specification.md` + `.zh.md`: new `turn-produced-files` part (why path-level parity, host-visible mutation signal, card shape, failure modes, acceptance checklist).
- `docs/features.md` + `.zh.md`: `Turn produced files` row flips to ✅.
- `CHANGELOG.md`: Added entry.
- `docs/development.md`: add `dsh-home-turn-produced-files` to the per-suite integration homes list.
- `.github/workflows/ci.yml` + `canary.yml`: prepare the new integration-test profile.

## Verification

- `pnpm run lint`, `pnpm run typecheck`, `pnpm run build` — pass (exit 0).
- `pnpm run test` with `FEISHU_INT_REQUIRED=1` (all 7 integration homes prepared): 33 files / 605 tests pass — incl. new unit tests (9) and the real-process `turn-produced-files` integration suite (2: create + image send).
- `node scripts/check-conventions.mjs --commits=2` — all conventions pass.