### PR TITLE
chore(infra): add the dsh-version-track skill and A/B version source of truth

### DIFF
--- a/.dsh/skills/dsh-version-track/SKILL.md
+++ b/.dsh/skills/dsh-version-track/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: dsh-version-track
+description: Keep dsh-feishu adapted to the newest DeepSeek Harness releases and keep the A/B version labels honest. Diagnoses whether the stable release track (dsh `@latest`) and the `main` track (dsh `@next`) are still compatible, adapts code when a run is red, and refreshes the labels when a run is green. Use when a `canary` or `release-compat` workflow is red, when a new dsh `@next`/`@latest` landed, or when `dsh-version.json` looks stale.
+when-to-use: A dsh-family version update landed (a new `@deepseek-ai/*@next` or `@latest`), the Canary or Release-compat CI is red, or the maintainer asks to "adapt to the new dsh version" / "bump the version track".
+---
+
+# dsh-version-track
+
+The dsh-feishu repository tracks **two** DeepSeek Harness (dsh) versions and keeps a
+single source of truth for them:
+
+```json
+// dsh-version.json  (repo root)
+{
+  "schema": "dsh-feishu-version-track/v1",
+  "dsh": { "stable": "0.1.0-rc.7", "next": "0.1.0-rc.8" },
+  "dshFeishu": { "npmLatest": "0.2.1" },
+  "lastAdapted": { "track": null, "by": null, "at": null }
+}
+```
+
+- **A = `dsh.stable`** — the dsh `@latest` the stable `release/*` track is verified against. Guarded by the `Release compat (npm latest vs dsh@latest)` workflow.
+- **B = `dsh.next`** — the dsh `@next` the `main` branch is verified against. Guarded by the `Canary (main vs dsh@next)` workflow.
+- `dshFeishu.npmLatest` — the dsh-feishu version published as npm `@latest` (the live npm badge shows it; keep this field as the last known value).
+
+README.md / README.zh.md carry a "Note" showing A and B. Do not edit that Note by hand — it is generated from `dsh-version.json` (run `node scripts/render-version-note.mjs`), and `pnpm run check` fails if it drifts.
+
+## The one rule that matters
+
+**Compatibility is empirical, not a number.** The two workflows run the suite against
+the newest dsh and are the truth. The A/B labels are just a record of the last version
+verified green.
+
+- **Red run → adapt the code** (real compatibility break).
+- **Green run on a newer dsh → refresh the label** (bump A or B in `dsh-version.json`; no code change).
+- Neither adapt code nor refresh a label merely because a number in the JSON is "old": a green run already proves compatibility. Do not chase version numbers.
+
+## Steps
+
+### 1. Read the current state
+- Read `dsh-version.json` (current A, B, `npmLatest`).
+- Read the latest conclusions of the two workflows (GitHub API, no token needed for public read):
+  - `Release compat (npm latest vs dsh@latest)` → the A / stable track.
+  - `Canary (main vs dsh@next)` → the B / `main` track.
+  - Also read the current npm dist-tags for `@deepseek-ai/dsh`: `dsh@next` and `dsh@latest`
+    (via `npm view @deepseek-ai/dsh dist-tags`, or the registry HTTP API).
+- Note whether each tracked label (A, B) equals the corresponding current dist-tag.
+
+### 2. Decide the needed work (green/red)
+Build a table: per track (stable for A, `main` for B), is the latest run **green** or **red**,
+and is the tracked label behind the current dist-tag?
+
+| Track | Run | Label vs dist-tag | Action |
+| --- | --- | --- | --- |
+| stable (A) | green | behind | refresh A label |
+| stable (A) | red | any | adapt the release branch code |
+| main (B) | green | behind | refresh B label |
+| main (B) | red | any | adapt `main` code |
+
+**Ordering** — when **both** tracks need a real code adaptation, do the **stable (A)
+track first**, then `main` (B): npm stable users must never get a package that is
+incompatible with dsh `@latest`; `main` is not shipped on npm, so it can trail.
+
+### 3. Adapt a track (code change, red run)
+Do this in a worktree (never on `main`; release work never on `main` either) and land it as a PR.
+
+For the **B / `main`** track:
+1. `git worktree add -b feat/dsh-adapt-<next> _dev/dsh-feishu-adapt-<next> main`.
+2. Lift the dsh family to the new `@next`: `@deepseek-ai/dsh` pinned EXACT to the new
+   pre-release, the rest caret, and add any **new peer packages** the fresh CLI requires
+   (e.g. `@deepseek-ai/dsh-invariants`, `dsh-scope`, `dsh-timeout`) to dev/peer deps.
+3. Refresh the lockfile against the official registry (`pnpm install`, never frozen).
+4. Read the **installed** `.d.ts` for the services the plugin uses (`ctx.agents`,
+   `sessionPersistence`, `ctx.llm`, `ctx.commands`, …). Getters vs methods and renamed
+   services are the usual breakers; a wrong shape typechecks and explodes at runtime.
+5. Adjust `src/` seams so the real shape matches. Grep for renamed modes / commands
+   (rc line moves, e.g. `commands.execute` gaining a parameter) and update card labels,
+   snapshots, tests accordingly.
+6. Run the gates exactly as CI does and check every exit code: `pnpm run lint`,
+   `pnpm run typecheck`, `pnpm run build`, and `pnpm run test` with
+   `FEISHU_INT_REQUIRED=1`.
+7. If the run still fails, keep adapting; the `canary` workflow is the oracle. Never relax
+   a test to force green.
+
+For the **A / stable** track: cut a `release/*` branch from a commit adapted to the new dsh
+`@latest`, apply the same adaptation, bump the version, and open a "ready to release" PR.
+The actual `scripts/release.mjs` run (which pushes the branch and the `v*` tag → npm publish)
+is a **human-gated** action — do not trigger it; just prepare the branch and PR.
+
+### 4. Refresh a label (green run, no code change)
+Update only `dsh-version.json`, e.g. set `dsh.next` to the current dsh `@next` / `dsh.stable`
+to the current `@latest`. This is a tiny `chore:` or `docs:` change in a worktree PR.
+
+### 5. Update the source of truth + README (after any adaptation)
+- Set `dsh-version.json`'s A/B to the now-verified versions.
+- Record provenance in `lastAdapted` (`track`, `by`, `at`).
+- Run `node scripts/render-version-note.mjs` to regenerate the README Notes from the JSON.
+- Commit the JSON, the README Notes, and any code/test changes **in the same PR** so the
+  curated README stays human-reviewed and never drifts from the JSON.
+
+## Limits and safety
+- Working tree + PR only; never commit to `main`, never push to `main`.
+- **Merge** of the adaptation PR and the **npm publish** (`v*` tag) are human decisions —
+  present the PR and stop. Only the diagnosis and the prepared work are yours.
+- A green canary / release-compat is proof of compatibility; a PR that merely bumps a
+  version is not. Never claim a track is "verified" unless the run is green.
+- If a run is red but looks like a **flake** (a one-off that passes on re-run), re-run it
+  once before treating it as a real break.
+
+## Reference
+- `dsh-version.json` — the A/B + provenance source of truth.
+- `scripts/version-track-lib.mjs` — load / validate / README-sync helpers.
+- `scripts/render-version-note.mjs` — regenerate README Notes from the JSON.
+- `scripts/check-conventions.mjs` → `checkVersionTrack()` — fails when the JSON is missing,
+  malformed, or the README Notes drift.
+- `.github/workflows/canary.yml`, `release-compat.yml`, `release.yml` — the verifiers and
+  the publish gate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`dsh-version-track` infra: a structured A/B source of truth + a
+  diagnosis/adaptation skill.** `dsh-version.json` (repo root) records the
+  dsh versions the repo tracks — `dsh.stable` (A) = the dsh `@latest` the
+  stable release tracks, `dsh.next` (B) = the dsh `@next` `main` tracks —
+  plus `dshFeishu.npmLatest` and `lastAdapted` provenance. The README Notes
+  are regenerated from it (`scripts/render-version-note.mjs`) and `pnpm run
+  check` (`checkVersionTrack()`) fails if they drift. The `dsh-version-track`
+  skill (`.dsh/skills/dsh-version-track/`) diagnoses the canary /
+  release-compat runs, adapts the code on a red run or refreshes a label on a
+  green one, and lands as a worktree PR (merge and npm publish stay
+  human-gated). See `docs/development.md` → "Version tracks".
+
 ### Changed
 
 - **More E2E smoke scenarios for the real-client suite.** The E2E suite

--- a/docs/development.md
+++ b/docs/development.md
@@ -425,6 +425,16 @@ dsh `@latest`), and the two tracks are verified separately:
 - the `Release compat (npm latest vs dsh@latest)` workflow lifts the repo
   to dsh `@latest` — the combination the next release must ship against.
 
+The two adapted-for-DSH versions (the `@next` for `main`, the `@latest` for
+the npm release) are recorded declaratively in `dsh-version.json` at the repo
+root (`dsh.stable` = A, `dsh.next` = B). It is the single source of truth:
+the README Note is regenerated from it (`node scripts/render-version-note.mjs`)
+and `pnpm run check` (`checkVersionTrack()`) fails if the README Notes drift
+from it. The `dsh-version-track` skill (`.dsh/skills/dsh-version-track/`)
+diagnoses the canary / release-compat runs and adapts the code on a red run or
+refreshes a label on a green one, landing as a worktree PR (merge and npm
+publish stay human-gated).
+
 ### Releasing
 
 ```sh

--- a/dsh-version.json
+++ b/dsh-version.json
@@ -1,0 +1,15 @@
+{
+  "schema": "dsh-feishu-version-track/v1",
+  "dsh": {
+    "stable": "0.1.0-rc.7",
+    "next": "0.1.0-rc.8"
+  },
+  "dshFeishu": {
+    "npmLatest": "0.2.1"
+  },
+  "lastAdapted": {
+    "track": null,
+    "by": null,
+    "at": null
+  }
+}

--- a/scripts/check-conventions.mjs
+++ b/scripts/check-conventions.mjs
@@ -18,6 +18,7 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
 import { relative, join } from 'node:path';
+import { checkReadmeSync, loadTrack } from './version-track-lib.mjs';
 
 const ROOT = new URL('..', import.meta.url).pathname;
 let failures = 0;
@@ -184,6 +185,19 @@ function checkMinimumReleaseAge() {
   }
 }
 
+function checkVersionTrack() {
+  const track = loadTrack(ROOT);
+  if (track.error) {
+    fail(track.error);
+    return;
+  }
+  const errors = checkReadmeSync(ROOT, track);
+  for (const error of errors) fail(error);
+  if (errors.length === 0) {
+    pass(`dsh-version.json tracks dsh @latest=${track.stable} / @next=${track.next} and the README Notes match`);
+  }
+}
+
 const args = process.argv.slice(2);
 const commitFlag = args.find((a) => a.startsWith('--commits='));
 const commitCount = commitFlag ? Number(commitFlag.split('=')[1]) : 5;
@@ -193,6 +207,7 @@ checkNoMirrorLeaks();
 checkDocPairs();
 checkCommits(commitCount);
 checkMinimumReleaseAge();
+checkVersionTrack();
 checkMainTreeClean();
 
 if (failures > 0) {

--- a/scripts/render-version-note.mjs
+++ b/scripts/render-version-note.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * Regenerate the README "Note" version lines from dsh-version.json.
+ *
+ * README.md and README.zh.md carry a Note that names the two dsh versions the
+ * repo tracks (A = dsh `@latest` the stable release tracks, B = dsh `@next`
+ * the `main` branch tracks). This script rewrites just those two version
+ * tokens from the single source of truth, so the Note never drifts from the
+ * JSON. The `dsh-version-track` skill calls this after it adapts a track; a
+ * convention check (`pnpm run check`) fails if the Notes are stale.
+ *
+ * Usage: node scripts/render-version-note.mjs
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadTrack, setNoteVersions } from './version-track-lib.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const track = loadTrack(ROOT);
+if (track.error) {
+  console.error(`✗ ${track.error}`);
+  process.exit(1);
+}
+
+for (const file of ['README.md', 'README.zh.md']) {
+  const path = join(ROOT, file);
+  const text = readFileSync(path, 'utf8');
+  const updated = setNoteVersions(text, track.stable, track.next);
+  if (updated !== text) {
+    writeFileSync(path, updated);
+    console.log(`✓ ${file} Note updated (dsh @latest=${track.stable}, @next=${track.next})`);
+  } else {
+    console.log(`- ${file} Note already in sync`);
+  }
+}

--- a/scripts/version-track-lib.d.mts
+++ b/scripts/version-track-lib.d.mts
@@ -1,0 +1,23 @@
+/**
+ * Type declarations for scripts/version-track-lib.mjs.
+ *
+ * The library itself is plain JavaScript (no build step); this declaration
+ * lets the TypeScript test suite (and editor) type-check its imports under
+ * `strict` / `NodeNext` without pulling the module into the build.
+ *
+ * @module scripts/version-track-lib
+ */
+
+export const VERSION_TRACK_FILE: string;
+export const VERSION_TRACK_SCHEMA: string;
+
+export function setNoteVersions(text: string, stable: string, next: string): string;
+
+export function loadTrack(
+  root: string,
+): { error?: string; stable?: string; next?: string; raw?: Record<string, unknown> };
+
+export function checkReadmeSync(
+  root: string,
+  track: { stable: string; next: string },
+): string[];

--- a/scripts/version-track-lib.mjs
+++ b/scripts/version-track-lib.mjs
@@ -1,0 +1,107 @@
+/**
+ * Version-track helpers for dsh-feishu.
+ *
+ * `dsh-version.json` is the single source of truth for which dsh versions the
+ * repo tracks and is verified against:
+ *   - `dsh.stable` (A) — the dsh `@latest` the stable `release/*` track is
+ *     verified against;
+ *   - `dsh.next` (B) — the dsh `@next` the `main` branch is verified against.
+ * Compatibility is empirical: the `canary` / `release-compat` workflows run
+ * the suite against the newest `@next` / `@latest`, so a green run proves the
+ * track works and the label should be refreshed; a red run means a real
+ * compatibility fix is due. The labels are record, not trigger.
+ *
+ * README.md / README.zh.md carry a "Note" that shows A and B. These helpers
+ * keep that Note in sync with the JSON (the `dsh-version-track` skill and
+ * `render-version-note.mjs` write it; `check-conventions.mjs` enforces it).
+ *
+ * @module scripts/version-track-lib
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** The version-track source-of-truth file, relative to the repo root. */
+export const VERSION_TRACK_FILE = 'dsh-version.json';
+/** The schema this repo uses for dsh-version.json. */
+export const VERSION_TRACK_SCHEMA = 'dsh-feishu-version-track/v1';
+
+/**
+ * A backtick-wrapped token that starts with a digit — i.e. a version like
+ * `0.1.0-rc.8`. The `@next` / `@latest` tags in the same line start with `@`,
+ * so this never matches them.
+ */
+const VERSION_TOKEN_RE = /`(\d[^`]*?)`/;
+
+/**
+ * Set the A/B version tokens on the README Note lines that name `@next` and
+ * `@latest`. For `@next`, the version becomes `next`; for `@latest` it
+ * becomes `stable`. Every other line is returned untouched.
+ * @param text - the full README / README.zh.md text.
+ * @param stable - the dsh `@latest` version (A).
+ * @param next - the dsh `@next` version (B).
+ * @returns the text with the two Note version tokens updated.
+ */
+export function setNoteVersions(text, stable, next) {
+  return text
+    .split('\n')
+    .map((line) => {
+      if (line.includes('dsh `@next`')) return line.replace(VERSION_TOKEN_RE, `\`${next}\``);
+      if (line.includes('dsh `@latest`')) return line.replace(VERSION_TOKEN_RE, `\`${stable}\``);
+      return line;
+    })
+    .join('\n');
+}
+
+/**
+ * Read and validate dsh-version.json.
+ * @param root - the repo root.
+ * @returns `{ stable, next, raw }` on success, or `{ error }` on any problem.
+ */
+export function loadTrack(root) {
+  const path = join(root, VERSION_TRACK_FILE);
+  if (!existsSync(path)) return { error: `${VERSION_TRACK_FILE} is missing` };
+  let raw;
+  try {
+    raw = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    return { error: `${VERSION_TRACK_FILE} is not valid JSON: ${String(error)}` };
+  }
+  if (raw.schema !== VERSION_TRACK_SCHEMA) {
+    return { error: `${VERSION_TRACK_FILE} schema must be ${VERSION_TRACK_SCHEMA}` };
+  }
+  const stable = raw.dsh?.stable;
+  const next = raw.dsh?.next;
+  if (typeof stable !== 'string' || stable.length === 0) {
+    return { error: `${VERSION_TRACK_FILE} requires dsh.stable (A)` };
+  }
+  if (typeof next !== 'string' || next.length === 0) {
+    return { error: `${VERSION_TRACK_FILE} requires dsh.next (B)` };
+  }
+  return { stable, next, raw };
+}
+
+/**
+ * Verify that the README Notes reflect the A/B values in dsh-version.json.
+ * @param root - the repo root.
+ * @param track - the loaded track (`{ stable, next }`).
+ * @returns a list of errors (empty when the Notes are in sync).
+ */
+export function checkReadmeSync(root, track) {
+  const errors = [];
+  for (const file of ['README.md', 'README.zh.md']) {
+    const path = join(root, file);
+    if (!existsSync(path)) {
+      errors.push(`${file} is missing`);
+      continue;
+    }
+    const text = readFileSync(path, 'utf8');
+    if (setNoteVersions(text, track.stable, track.next) !== text) {
+      errors.push(
+        `${file} version Note is out of sync with ${VERSION_TRACK_FILE} ` +
+          `(@latest=${track.stable}, @next=${track.next}) — run \`node scripts/render-version-note.mjs\``,
+      );
+    }
+  }
+  return errors;
+}

--- a/tests/version-track.spec.ts
+++ b/tests/version-track.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for the dsh version-track helpers.
+ *
+ * The helpers keep `dsh-version.json` (the A/B source of truth) and the README
+ * Notes in sync, and are what both `render-version-note.mjs` and the
+ * `checkVersionTrack()` convention check run on. These tests cover the pure
+ * Note-rewriting logic and the JSON load/validation + README-sync check.
+ *
+ * @module tests/version-track
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  checkReadmeSync,
+  loadTrack,
+  setNoteVersions,
+  VERSION_TRACK_SCHEMA,
+} from '../scripts/version-track-lib.mjs';
+
+const EN_NOTE = [
+  '- the `main` branch (installed from git) tracks **dsh `@next`** — currently **`0.1.0-rc.8`**;',
+  '- the npm `@latest` release tracks **dsh `@latest`** — currently **`0.1.0-rc.7`**.',
+].join('\n');
+
+const ZH_NOTE = [
+  '- `main` 分支（git 安装）跟踪 **dsh `@next`**——当前为 **`0.1.0-rc.8`**；',
+  '- npm `@latest` release 跟踪 **dsh `@latest`**——当前为 **`0.1.0-rc.7`**。',
+].join('\n');
+
+function tempRepo(files: Record<string, string>) {
+  const dir = mkdtempSync(join(tmpdir(), 'vt-'));
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(join(dir, name), content);
+  }
+  return dir;
+}
+
+describe('setNoteVersions', () => {
+  it('rewrites only the @next and @latest version tokens', () => {
+    const out = setNoteVersions(EN_NOTE, '0.2.0-rc.1', '0.1.1-rc.2');
+    expect(out).toContain('dsh `@next`** — currently **`0.1.1-rc.2`**');
+    expect(out).toContain('dsh `@latest`** — currently **`0.2.0-rc.1`**');
+    // The tag name must not be clobbered by the version rewrite.
+    expect(out).not.toContain('dsh `0.1.1-rc.2`');
+  });
+
+  it('rewrites the zh Note the same way', () => {
+    const out = setNoteVersions(ZH_NOTE, '0.2.0-rc.1', '0.1.1-rc.2');
+    expect(out).toContain('当前为 **`0.1.1-rc.2`**');
+    expect(out).toContain('**`0.2.0-rc.1`**');
+  });
+
+  it('leaves lines without the dsh tags untouched', () => {
+    const text = ['# title', EN_NOTE, 'plain line'].join('\n');
+    const out = setNoteVersions(text, '0.2.0-rc.1', '0.1.1-rc.2');
+    expect(out).toContain('# title');
+    expect(out).toContain('plain line');
+  });
+});
+
+describe('loadTrack', () => {
+  it('reads and validates a well-formed dsh-version.json', () => {
+    const dir = tempRepo({
+      'dsh-version.json': JSON.stringify({
+        schema: VERSION_TRACK_SCHEMA,
+        dsh: { stable: '0.1.0-rc.7', next: '0.1.0-rc.8' },
+      }),
+    });
+    try {
+      const track = loadTrack(dir);
+      expect(track.error).toBeUndefined();
+      expect(track.stable).toBe('0.1.0-rc.7');
+      expect(track.next).toBe('0.1.0-rc.8');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('errors on the wrong schema', () => {
+    const dir = tempRepo({
+      'dsh-version.json': '{"schema":"nope","dsh":{"stable":"a","next":"b"}}',
+    });
+    try {
+      expect(loadTrack(dir).error).toMatch(/schema/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('errors when the file is missing', () => {
+    const dir = tempRepo({});
+    try {
+      expect(loadTrack(dir).error).toMatch(/missing/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('checkReadmeSync', () => {
+  it('passes when the README Notes match the JSON', () => {
+    const dir = tempRepo({
+      'dsh-version.json': JSON.stringify({
+        schema: VERSION_TRACK_SCHEMA,
+        dsh: { stable: '0.1.0-rc.7', next: '0.1.0-rc.8' },
+      }),
+      'README.md': EN_NOTE,
+      'README.zh.md': ZH_NOTE,
+    });
+    try {
+      expect(checkReadmeSync(dir, { stable: '0.1.0-rc.7', next: '0.1.0-rc.8' })).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('flags a stale README Note against the JSON', () => {
+    const dir = tempRepo({
+      'dsh-version.json': JSON.stringify({
+        schema: VERSION_TRACK_SCHEMA,
+        dsh: { stable: '0.1.0-rc.7', next: '0.1.0-rc.8' },
+      }),
+      // README still names the older @next version.
+      'README.md': EN_NOTE,
+      'README.zh.md': ZH_NOTE.replace('0.1.0-rc.8', '0.1.0-rc.6'),
+    });
+    try {
+      const errors = checkReadmeSync(dir, { stable: '0.1.0-rc.7', next: '0.1.0-rc.8' });
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatch(/README\.zh\.md/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## What

- Add `dsh-version.json` as the single structured source of truth for the two dsh versions the repo tracks — `dsh.stable` (A, the dsh `@latest` the stable release tracks) and `dsh.next` (B, the dsh `@next` `main` tracks) — plus `dshFeishu.npmLatest` and `lastAdapted` provenance.
- Add `scripts/version-track-lib.mjs` (+ `.d.mts`) with the load/validate and README-Note sync helpers, and `scripts/render-version-note.mjs` to regenerate the README Notes from the JSON.
- Wire `checkVersionTrack()` into `scripts/check-conventions.mjs` so `pnpm run check` fails when the README Notes drift from the JSON.
- Add the `.dsh/skills/dsh-version-track/SKILL.md` — a manual skill that diagnoses the canary / release-compat runs, adapts the code on a red run or refreshes a label on a green one, and lands as a worktree PR (merge and npm publish stay human-gated).
- Add `tests/version-track.spec.ts`, and update `docs/development.md` (Version tracks) + the CHANGELOG.

## Why

The A/B versions were only hard-coded as text in the README Note, so they drifted and had no machine-readable consumer. This pins them to a single source of truth that the skill, the check, and the README all agree on, and gives the repo a reusable, agent-invocable diagnosis/adaptation path for dsh version updates.

## Docs

docs/development.md (Version tracks), CHANGELOG.md. README Note is regenerated from the JSON; no README prose was edited (README stays maintainer-gated).

## Verification

- pnpm run lint — pass (only pre-existing warnings in outbound*.spec.ts, untouched).
- pnpm run typecheck — pass.
- pnpm run build — pass.
- pnpm run test — 541 unit tests pass (incl. 8 new version-track tests); integration suites run in CI (FEISHU_INT_REQUIRED=1), no src/ change.
- pnpm run check — all convention checks pass, incl. the new `dsh-version.json ... README Notes match`.