### PR TITLE
test(integration): de-flake the /model picker options assertion

### DIFF
--- a/tests/integration/real-composition.spec.ts
+++ b/tests/integration/real-composition.spec.ts
@@ -1631,24 +1631,34 @@ describe.skipIf(!integrationReady)('real-composition integration', () => {
       const chatId = `oc_model_${Date.now()}`;
       sendMessage(chatId, '/model');
       // Bare /model opens the picker card with the real deepseek catalog
-      // (loading placeholder posts first, the real picker is a patch).
-      await waitFor(
-        'the model picker card',
-        () =>
-          readOutbox().some(
+      // (loading placeholder posts first, the real picker is a patch). The
+      // picker's `select_static` options are populated asynchronously from the
+      // model catalog, so wait for a card whose options are NON-EMPTY: a
+      // title-only match can read the placeholder or an unfilled picker and
+      // flake on an empty options list.
+      const pickerSelectOptions = (record: MemoryOutboxRecord): string[] => {
+        const action = record.card?.elements.find((el) => el.tag === 'action');
+        const select =
+          action && 'actions' in action
+            ? action.actions.find((a) => a.tag === 'select_static')
+            : undefined;
+        return select && 'options' in select ? select.options.map((o) => o.value) : [];
+      };
+      const findModelPicker = (): MemoryOutboxRecord | undefined =>
+        [...readOutbox()]
+          .reverse()
+          .find(
             (r) =>
               (r.kind === 'card' || r.kind === 'patch') &&
-              r.card?.header?.title.content === '🤖 Model',
-          ),
+              r.card?.header?.title.content === '🤖 Model' &&
+              pickerSelectOptions(r).length > 0,
+          );
+      await waitFor(
+        'the model picker card with a filled catalog',
+        () => findModelPicker() !== undefined,
         60_000,
       );
-      const pickerRecord = [...readOutbox()]
-        .reverse()
-        .find(
-          (r) =>
-            (r.kind === 'card' || r.kind === 'patch') &&
-            r.card?.header?.title.content === '🤖 Model',
-        );
+      const pickerRecord = findModelPicker();
       const pickerAction = pickerRecord?.card?.elements.find((el) => el.tag === 'action');
       const pickerSelect =
         pickerAction && 'actions' in pickerAction


### PR DESCRIPTION
## What

- In `tests/integration/real-composition.spec.ts`, wait for a `/model` picker card whose `select_static` options are NON-EMPTY before asserting the catalog contents, instead of matching any card titled "🤖 Model".

## Why

The test previously matched a card by title only. `/model` posts a loading placeholder first and patches in the real picker, and the picker's options are filled asynchronously from the model catalog — so a title-only match could read the placeholder or an unfilled picker and flake with "expected [] to include 'deepseek-official/deepseek-v4-flash'" (this intermittently reddened the main branch CI).

## Docs

none — no doc surface affected (test-only change).

## Verification

- pnpm run typecheck — pass.
- pnpm run lint — pass (only pre-existing warnings).
- pnpm run test — 541 unit tests pass; the integration suite (which exercises this change) runs in CI.