### PR TITLE
ci(release): prepare all integration homes before the test gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,31 @@ jobs:
         run: pnpm run typecheck
       - name: Build
         run: pnpm run build
-      # The integration suite needs the same prepared profiles as CI.
-      - name: Prepare integration-test profile
+      # The integration suite needs the same prepared profiles as CI — one
+      # dsh home per suite (each suite writes its own session-map state).
+      - name: Prepare integration-test profile (attachments)
         env:
-          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home
+          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-attachments
+        run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
+      - name: Prepare integration-test profile (rich-text)
+        env:
+          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-rich-text
+        run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
+      - name: Prepare integration-test profile (wait-instruction)
+        env:
+          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-wait-instruction
+        run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
+      - name: Prepare integration-test profile (real-composition)
+        env:
+          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-real
+        run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
+      - name: Prepare integration-test profile (outbound)
+        env:
+          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-outbound
+        run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
+      - name: Prepare integration-test profile (turn-produced-files)
+        env:
+          DSH_HOME: ${{ github.workspace }}/_dev/dsh-home-turn-produced-files
         run: pnpm exec dsh plugin --profile feishu-dev add "link:${{ github.workspace }}"
       - name: Prepare scenario integration-test profile
         env:


### PR DESCRIPTION
## What

The `Release` workflow's test gate runs the integration suite (`FEISHU_INT_REQUIRED=1`) but only prepared TWO integration profiles — a bogus `_dev/dsh-home` (no suite uses it) and `_dev/dsh-home-scenarios` — while the seven integration suites each need their OWN dsh home. The other six (`real`, `attachments`, `rich-text`, `wait-instruction`, `outbound`, `turn-produced-files`) threw "FEISHU_INT_REQUIRED=1 but integration prerequisites are missing", aborting the release before publish.

Align `release.yml` with `ci.yml`: prepare all seven per-suite integration homes before the test gate.

## Why

Every integration suite writes its own session-map state and needs its own prepared profile; `release.yml` was out of sync with the suite set, so any release after the suite expansion would fail its test gate. The `v0.2.2` release hit this.

## Docs

none — no doc surface affected (CI workflow only).

## Verification

The fix is the identical profile-prep set `ci.yml` already uses; the gate matrix (lint/typecheck/build + the 7 integration suites) is what these preps enable, and it passes locally (34 files / 614 tests).