### PR TITLE
fix: attach new sessions to the workspace owning their cwd

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@
 
 import { createWriteStream, existsSync, mkdirSync, readdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import type { Context } from '@deepseek-ai/cordis';
 // Empty type imports carry the Context merges (`ctx.commands`, `ctx.agents`,
@@ -201,9 +201,13 @@ export function defaultDataDir(): string {
 type SessionTitleLike = {
   rename(session: unknown, title: string): unknown;
 };
+type WorkspaceEntityLike = {
+  attachSession(sessionId: string): Promise<unknown>;
+};
 type WorkspaceRegistryLike = {
   archiveSession(sessionId: string): Promise<unknown>;
   readonly archivedSessionIds: readonly string[];
+  create(path: string, title?: string): Promise<WorkspaceEntityLike>;
 };
 
 /**
@@ -466,6 +470,20 @@ export function apply(ctx: Context, config: Config, deps: ApplyDeps = {}): void 
         meta: { cwd },
         ...(resolvedAgentOptions !== undefined ? { agentOptions: resolvedAgentOptions } : {}),
       });
+      // Attach the new session to the workspace owning `cwd` (dsh web parity),
+      // creating the workspace record when the directory is not yet
+      // registered. Best-effort: a failure here must never block the turn.
+      const registry = ctx.get('workspaceRegistry');
+      if (registry !== undefined) {
+        try {
+          const workspace = await (registry as WorkspaceRegistryLike).create(cwd, basename(cwd));
+          await workspace.attachSession(sessionId);
+        } catch (error) {
+          logger.warn(
+            `[feishu] attach session ${String(sessionId)} to workspace failed: ${String(error)}`,
+          );
+        }
+      }
       return agent;
     },
   };

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -7,6 +7,8 @@
  * without any network.
  */
 
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import type { Context } from '@deepseek-ai/cordis';
 import type { CommandExecution, CommandId, CommandRuntime } from '@deepseek-ai/dsh-commands';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -45,7 +47,13 @@ class FakeTransport implements FeishuTransport {
     this.started = true;
   }
   async stop(): Promise<void> {}
-  onMessage(_handler: (message: FeishuMessage) => void): void {}
+  private messageHandler: ((message: FeishuMessage) => void) | undefined;
+  onMessage(handler: (message: FeishuMessage) => void): void {
+    this.messageHandler = handler;
+  }
+  emitMessage(message: FeishuMessage): void {
+    this.messageHandler?.(message);
+  }
   onCardAction(_handler: (action: CardAction) => void): void {}
   getBotOpenId(): string | undefined {
     return undefined;
@@ -87,6 +95,8 @@ function makeFakeContext(
   options: {
     withCommands?: boolean;
     credentials?: { resolve: () => Promise<unknown>; set: () => unknown };
+    agents?: unknown;
+    workspaceRegistry?: unknown;
   } = {},
 ): {
   ctx: Context;
@@ -111,6 +121,8 @@ function makeFakeContext(
   const get = (service: string): unknown => {
     if (service === 'commands' && options.withCommands !== false) return commands;
     if (service === 'credentials') return options.credentials;
+    if (service === 'agents') return options.agents;
+    if (service === 'workspaceRegistry') return options.workspaceRegistry;
     return undefined;
   };
   const on = vi.fn(() => () => {});
@@ -244,6 +256,7 @@ describe('apply', () => {
   afterEach(() => {
     delete process.env.FEISHU_APP_ID;
     delete process.env.FEISHU_APP_SECRET;
+    delete process.env.DSH_HOME;
   });
 
   it('registers a console log exporter on boot', () => {
@@ -293,6 +306,54 @@ describe('apply', () => {
     await Promise.resolve();
     expect(set).not.toHaveBeenCalled();
     delete process.env.DEEPSEEK_API_KEY;
+  });
+
+  it('attaches a newly created session to the workspace owning its cwd', async () => {
+    process.env.FEISHU_APP_ID = 'env_app';
+    process.env.FEISHU_APP_SECRET = 'env_secret';
+    const attachSession = vi.fn(async () => {});
+    const workspaceCreate = vi.fn(async () => ({ attachSession }));
+    const followup = vi.fn();
+    const create = vi.fn(async ({ sessionId }: { sessionId: string }) => ({
+      agent: { id: sessionId, followup },
+    }));
+    const agents = {
+      get: () => undefined,
+      resume: vi.fn(async () => {
+        throw new Error('not found');
+      }),
+      create,
+    };
+    const { ctx } = makeFakeContext({
+      agents,
+      workspaceRegistry: {
+        create: workspaceCreate,
+        archivedSessionIds: [],
+        archiveSession: vi.fn(),
+      },
+    });
+    // The surface persists its session map under `$DSH_HOME/feishu`; point it
+    // at a scratch dir so the test never touches the real `~/.dsh`.
+    process.env.DSH_HOME = mkdtempSync(`${tmpdir()}/dsh-feishu-`);
+    const transport = new FakeTransport();
+    apply(ctx, { requireWorkingDir: false }, { createTransport: () => transport });
+    transport.emitMessage({
+      messageId: 'om_1',
+      chatId: 'oc_1',
+      chatType: 'p2p',
+      senderOpenId: 'ou_1',
+      text: 'hi',
+      mentions: [],
+      attachments: [],
+      createdAt: 1_700_000_000_000,
+    });
+    await vi.waitFor(() => expect(attachSession).toHaveBeenCalled());
+    // The workspace record was resolved/created for the session's cwd
+    // (process.cwd(), since the test config omits defaultCwd) under a
+    // title derived from that directory's basename.
+    expect(workspaceCreate).toHaveBeenCalledWith(process.cwd(), expect.any(String));
+    // And the freshly minted `feishu-…` session id was attached to it.
+    expect(attachSession).toHaveBeenCalledWith(expect.stringMatching(/^feishu-/));
   });
 
   it('registers the feishu-status command when the commands service exists', () => {


### PR DESCRIPTION
## Summary / 概述

`agentStore.create` only passed `meta.cwd` to `agents.create`, so Feishu-created sessions never joined the workspace registry — they landed under **未分组 (ungrouped)** in the dsh web UI even when the working directory was already a registered workspace.

`agentStore.create` 只把 `meta.cwd` 传给 `agents.create`，飞书创建的会话从未加入 workspace 注册表——即使工作目录已是注册过的工作区，它们在 dsh web UI 里仍归「未分组」。

## Fix / 修复

After creating the agent, resolve the workspace for the session's `cwd` via `workspaceRegistry.create(cwd, basename(cwd))` (idempotent — creates the workspace record when the directory isn't registered yet) and call `attachSession(sessionId)`. Best-effort: a failure logs a warning and never blocks the turn.

创建 agent 后，通过 `workspaceRegistry.create(cwd, basename(cwd))`（幂等——目录未注册时自动创建工作区记录）解析出会话 cwd 对应的工作区，并调用 `attachSession(sessionId)`。best-effort：失败只记 warning，绝不阻塞本轮对话。

## ⚠️ Important: restart `dsh web` to see the effect / 重要：需重启 dsh web 才能看到效果

When the Feishu bridge runs in its own process (`dsh --profile feishu`, separate from `dsh web`), the attach writes to the **on-disk** `workspace.json`, but the `dsh web` process keeps its workspace view **in memory** and does not re-read the disk. Therefore:

- ✅ With this fix the session **is** attached (it appears in the workspace's `sessionIds` in `workspace.json`).
- ⚠️ The `dsh web` side still shows it under **未分组** until `dsh web` is **restarted** — a browser refresh is **not** enough.

当飞书桥以独立进程运行时（`dsh --profile feishu`，与 `dsh web` 分开），attach 写的是**磁盘** `workspace.json`，但 `dsh web` 进程的 workspace 视图是**内存**里的、不会重读磁盘。因此：

- ✅ 本修复后，会话**确实**已挂载（出现在 `workspace.json` 里对应工作区的 `sessionIds` 中）。
- ⚠️ 但 `dsh web` 侧在**重启之前**仍显示「未分组」——只刷新浏览器是**不够**的。

## Test / 测试

Added a unit test in `tests/index.spec.ts` asserting `attachSession` is invoked with the freshly minted `feishu-…` session id (with a scratch `DSH_HOME`).

在 `tests/index.spec.ts` 新增单元测试，断言 `attachSession` 被调用并传入新 mint 的 `feishu-…` 会话 id（使用临时 `DSH_HOME`）。

Verified with：`pnpm lint` ✅ `pnpm typecheck` ✅ `pnpm vitest run`（542 passed）✅

验证通过：`pnpm lint` ✅ `pnpm typecheck` ✅ `pnpm vitest run`（542 passed）✅

Manual verification：both Feishu sessions appeared under the Remote workspace in `workspace.json`; restarting `dsh web` groups them correctly.

实测：两个飞书会话都出现在 `workspace.json` 的 Remote 工作区 `sessionIds` 里；重启 `dsh web` 后侧边栏正确分组。