### PR TITLE
fix: settle the approval card before re-asserting the streaming card

### DIFF
--- a/src/cards/InteractionCardController.ts
+++ b/src/cards/InteractionCardController.ts
@@ -130,11 +130,12 @@ export class InteractionCardController {
         setTimeout(() => {
           void this.host.transport
             .updateCard(messageId, buildApprovalDecidedCard(settled))
+            .then(() => this.host.syncCard(chatId))
             .catch((error: unknown) => {
               this.host.logger.warn(`approval card settle update failed: ${String(error)}`);
+              this.host.syncCard(chatId);
             });
         }, 0);
-        this.host.syncCard(chatId);
         resolve(settled);
       });
       if (request.signal !== undefined) {

--- a/tests/cards/InteractionCardController.spec.ts
+++ b/tests/cards/InteractionCardController.spec.ts
@@ -131,6 +131,8 @@ describe('InteractionCardController', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     h.controller.handleCardAction(action('approval', { id: 'approval-1', decision: 'reject' }));
     await expect(pending).resolves.toBe('rejected');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(h.transport.updatedCards).toHaveLength(1);
     const pending2 = h.controller.handleApprovalRequest({
       agent: h.agent,
       toolName: 'bash',


### PR DESCRIPTION
## Summary / 概述

On **Reject** the approval card stayed at "🔐 Approval needed" — the two buttons remained and were still tappable — even though DSH correctly received the rejection.

点 **Reject** 后，审批卡片一直停在「🔐 Approval needed」——两个按钮仍在且可点击——尽管 DSH 已正确收到拒绝指令。

## Root cause / 根因

The settle callback re-asserted the streaming card (`syncCard`) **synchronously**, before the deferred `updateCard` that turns the approval card into its decided state ran. Lark's post-callback "restore pre-click card" behaviour then raced the approval-card update, leaving the card stuck at its pre-click state. Allow happened to look correct because the continuing turn kept re-rendering the streaming card, masking the same race.

settle 回调**同步**地重新断言 streaming card（`syncCard`），而把审批卡片改成 decided 状态的 `updateCard` 是延迟执行的。飞书在回调后的「恢复点击前卡片」行为随后与审批卡更新竞争，导致卡片停在点击前状态。Allow 之所以看起来正常，是因为 turn 继续时 streaming card 持续重绘，掩盖了同样的竞争。

## Fix / 修复

Reorder the settle callback so the decided-card update lands **first**, and the streaming-card re-assert (`syncCard`) follows it — both still deferred out of the card-callback ACK (botmux rule).

调整 settle 回调顺序：先落地 decided 卡片更新，再 re-assert streaming card（`syncCard`）——两者仍都延迟到卡片回调 ACK 之后（botmux rule）。

## Test / 测试

Strengthened the Reject test to also assert the card is updated to its decided state (it previously only asserted the promise resolved).

加强了 Reject 测试，额外断言卡片被更新为 decided 状态（之前只断言 promise 决议）。

Verified with：`pnpm lint` ✅ `pnpm typecheck` ✅ `pnpm vitest run`（542 passed）✅

验证通过：`pnpm lint` ✅ `pnpm typecheck` ✅ `pnpm vitest run`（542 passed）✅

Manual verification：After the fix, tapping ❌ Reject turns the approval card into "❌ Rejected" and removes its buttons, instead of leaving it stuck at "Approval needed"。

实测：修复后，点 ❌ Reject 后审批卡片正确变为「❌ Rejected」且按钮消失，不再卡在「Approval needed」