### PR TITLE
docs: include --allow-build=protobufjs in the npm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ node --version
 npm install -g pnpm
 
 # 3. install the plugin
-#    (pnpm ≥ 11 blocks the protobufjs build script by default — if this
-#     fails with ERR_PNPM_IGNORED_BUILDS, append --allow-build=protobufjs)
-npx @deepseek-ai/dsh plugin --profile feishu add @dsh-feishu/dsh-feishu@latest
+#    (pnpm ≥ 11 blocks the protobufjs build script by default, so
+#     --allow-build=protobufjs lets pnpm run it)
+npx @deepseek-ai/dsh plugin --profile feishu add @dsh-feishu/dsh-feishu@latest --allow-build=protobufjs
 
 # 4. one QR scan — create + configure the Feishu app
 npx --yes --package @dsh-feishu/dsh-feishu dsh-feishu-setup --new --profile feishu

--- a/README.zh.md
+++ b/README.zh.md
@@ -33,9 +33,9 @@ node --version
 npm install -g pnpm
 
 # 3. 安装插件
-#    （pnpm ≥ 11 默认拦截 protobufjs 的构建脚本——若报
-#     ERR_PNPM_IGNORED_BUILDS，在命令后追加 --allow-build=protobufjs）
-npx @deepseek-ai/dsh plugin --profile feishu add @dsh-feishu/dsh-feishu@latest
+#    （pnpm ≥ 11 默认拦截 protobufjs 的构建脚本，所以加上
+#     --allow-build=protobufjs 让它执行）
+npx @deepseek-ai/dsh plugin --profile feishu add @dsh-feishu/dsh-feishu@latest --allow-build=protobufjs
 
 # 4. 扫一次二维码：创建并配置飞书应用
 npx --yes --package @dsh-feishu/dsh-feishu dsh-feishu-setup --new --profile feishu


### PR DESCRIPTION
## What

Adds `--allow-build=protobufjs` to the README's "Install from npm" command (EN + 中文).

```diff
- npx @deepseek-ai/dsh plugin --profile feishu add @dsh-feishu/dsh-feishu@latest
+ npx @deepseek-ai/dsh plugin --profile feishu add @dsh-feishu/dsh-feishu@latest --allow-build=protobufjs
```

The comment no longer says "append the flag if it fails" — it's already in the command.

## Why

The README told users the install may fail with `ERR_PNPM_IGNORED_BUILDS` and to re-run with `--allow-build=protobufjs`. pnpm ≥ 11 (what `npm install -g pnpm` gives) blocks protobufjs's build script by default, so the plain command fails on the common path. Verify: `dsh plugin` forwards remaining args verbatim to pnpm (`allowUnknownOption`), and `pnpm add` accepts `--allow-build=<pkg>` — so the flag reaches pnpm and fixes the build at the source instead of a failed first attempt.

## Docs

README.md / README.zh.md are maintainer-gated — PR held for maintainer review.

## Verification

- Bilingual pair updated together.
- `pnpm add --help` shows `--allow-build` (tested on pnpm 11.21.0).