### PR TITLE
fix: ship the default avatar in the npm package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Quick setup from npm produced a bot without the default avatar.** The
+  bundled avatar lives at `docs/assets/default-avatar.png`, but the package
+  `files` whitelist only published `lib/` + manifests — so in an npm install
+  the avatar path did not exist and `resolveAvatarBuffer` silently fell back
+  to the solid-color placeholder (a source checkout worked, masking it). The
+  avatar file is now listed individually in `files` (not the whole `docs/`
+  directory), with a pack-shape regression test guarding the whitelist.
 - **Tool calls crashed ("Cannot read properties of undefined (reading
   'prepare')") when installed from npm.** dsh-feishu listed harness core
   packages (`@deepseek-ai/dsh-llm`, `dsh-storage` ×3, `dsh-tools`,

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "files": [
     "lib/",
     "cordis.patch.yml",
+    "docs/assets/default-avatar.png",
     "README.md",
     "README.zh.md",
     "LICENSE"

--- a/src/setup/create-app.ts
+++ b/src/setup/create-app.ts
@@ -94,8 +94,11 @@ export function makePlaceholderIconPng(
 /**
  * The bundled default avatar (serif "dsh" wordmark on the Feishu blue
  * gradient card). Resolved relative to the built lib/ so it works both from
- * a checkout and from an installed npm package (the `docs` directory ships
- * in the package `files`).
+ * a checkout and from an installed npm package — the file is listed
+ * individually in the package `files` (NOT the whole `docs/` directory).
+ * If it is ever dropped from `files`, `resolveAvatarBuffer` silently falls
+ * back to the solid-color placeholder — the pack test in tests/setup.spec.ts
+ * guards this.
  */
 export const DEFAULT_AVATAR_PATH = fileURLToPath(
   new URL('../../docs/assets/default-avatar.png', import.meta.url),

--- a/tests/setup.spec.ts
+++ b/tests/setup.spec.ts
@@ -6,9 +6,10 @@
  * console is never exercised here.
  */
 
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 import { mergeBotProfile, promptBotProfile } from '../src/setup/bot-profile.js';
 import { parseArgs, startHint } from '../src/setup/cli.js';
@@ -68,6 +69,9 @@ import {
   readStoredCookiesFromSessionFile,
   writeStoredCookiesToSessionFile,
 } from '../src/setup/session.js';
+
+/** Repo root, for reading tracked files (package.json) in pack-shape tests. */
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
 const tmpDirs: string[] = [];
 afterEach(() => {
@@ -755,6 +759,19 @@ describe('avatar resolution', () => {
   it('falls back to the bundled avatar for a missing path', () => {
     const src = resolveAvatarBuffer('/nonexistent/avatar.png');
     expect(src.width).toBe(1024);
+  });
+
+  it('ships the default avatar in the published package (files whitelist)', () => {
+    // Regression (user report): an npm install produced a bot with the
+    // solid-color placeholder instead of the bundled default avatar —
+    // `docs/` was not in the package `files`, so DEFAULT_AVATAR_PATH did
+    // not exist there and resolveAvatarBuffer silently degraded. The
+    // whitelist must list the file individually, and the file must exist.
+    const manifest = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8')) as {
+      files?: string[];
+    };
+    expect(manifest.files).toContain('docs/assets/default-avatar.png');
+    expect(existsSync(DEFAULT_AVATAR_PATH)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What

The quick-setup wizard now finds the bundled default avatar in an **npm install**: `docs/assets/default-avatar.png` is listed individually in the package `files` whitelist (previously only `lib/`, `cordis.patch.yml`, READMEs and LICENSE shipped).

- `package.json`: `files` += `"docs/assets/default-avatar.png"` (the file, not the whole `docs/` directory)
- `src/setup/create-app.ts`: the comment now states the real contract (file listed individually; if dropped, resolution silently degrades to the placeholder) and points at the guard test
- `tests/setup.spec.ts`: regression test — the whitelist must contain the avatar path AND the file must exist at `DEFAULT_AVATAR_PATH`
- `CHANGELOG.md`: entry under `[Unreleased] → Fixed`

## Why (user report)

Installing per the README (`npx … dsh plugin --profile feishu add @dsh-feishu/dsh-feishu@latest`) created a bot **without the default avatar** — it got the solid-color placeholder.

Root cause: `DEFAULT_AVATAR_PATH` resolves to `<pkg>/docs/assets/default-avatar.png` relative to the built `lib/`, but `docs/` was never in the package `files`. In an npm install that path did not exist, so `resolveAvatarBuffer` silently fell back to `makePlaceholderIconPng()`. A source checkout has `docs/`, which masked the bug. The code comment even claimed "the docs directory ships in the package files" — it did not.

## Docs

- `CHANGELOG.md` updated in the same change.
- No behavior/UX doc change needed (avatar branding is already documented in `docs/features.md`; the fix restores the documented behavior for the npm track).

## Verification

- Regression test added; full unit suite green (591 passed).
- `npm pack --dry-run` now lists `docs/assets/default-avatar.png` (25.3 kB) in the tarball — before the fix it was absent from the published 0.2.2 tarball (confirmed by downloading it).
- lint / typecheck / build / unit tests all exit 0 locally; integration matrix runs in CI with `FEISHU_INT_REQUIRED=1`.