### PR TITLE
feat(log): export the operator log and make turn failures actionable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Operator log shipped to the chat (`/log` + an "Export log" button on the
+  failed-turn card).** The console exporter now appends every log record to
+  `$dataDir/logs/dsh-feishu.log` as well as the terminal, so the log survives
+  the console. `/log` (and the "Export log" button the error card shows on a
+  failed turn) reads that file and sends the raw log to the chat via
+  `transport.sendFile` — English label, since the surface is not i18n yet.
+  The raw log (not a compressed archive) is sent so Feishu renders it
+  readably, letting a user forward it to the bot admin for diagnosis.
+
 ### Fixed
 
 - **Quick setup from npm produced a bot without the default avatar.** The

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ feels faster; `/help` lists them all.
 | `/schedule` | list active reminders |
 | `/model <provider/model>` | switch this session's model (bare opens the picker) |
 | `/export` | send this chat's session log as a file |
+| `/log` | send the dsh-feishu log file to this chat (handy for debugging — please attach the key log lines when you file an issue) |
 | `/sessions` | list saved sessions (resume any of them from the card) |
 | `/resume <id>` | resume a saved session (bare opens the session list) |
 | `/clear` `/new` | start a fresh conversation (the old session stays saved) |

--- a/README.zh.md
+++ b/README.zh.md
@@ -133,6 +133,7 @@ rm -rf ~/.dsh/profiles/feishu ~/.dsh/feishu
 | `/schedule` | 列出活跃的提醒 |
 | `/model <provider/model>` | 切换本会话的模型（无参打开选择器） |
 | `/export` | 把会话日志作为文件发出来 |
+| `/log` | 把 dsh-feishu 的日志文件发到本聊天（便于排查问题；提 issue 时建议附上关键日志） |
 | `/sessions` | 列出已保存会话（卡片上可恢复） |
 | `/resume <id>` | 在本聊天恢复一个已保存会话（无参打开会话列表） |
 | `/clear` `/new` | 开新对话（旧会话仍保留） |

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -2175,7 +2175,8 @@ export class Bridge {
       case 'retry':
       case 'row-details':
       case 'toggle-rows':
-      case 'send-produced': {
+      case 'send-produced':
+      case 'send-log': {
         // Streaming-card actions are handled by the streaming state
         // machine controller (they mutate the card state).
         await this.streaming.handleStreamingAction(action);

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -52,6 +52,7 @@ import type {
   FeishuTransport,
   InboundAttachment,
 } from './feishu/types.js';
+import { readLogFile } from './log-file.js';
 import { MessageDeduplicator } from './message-dedup.js';
 import { parseModelArg } from './model-args.js';
 import { sessionSelection } from './model-switch.js';
@@ -281,6 +282,9 @@ export interface BridgeOptions {
   readonly cards: StreamingCardManager;
   readonly defaultCwd: string;
   readonly logger: BridgeLogger;
+  /** The surface data directory (default `$DSH_HOME/feishu`); the operator
+   *  log lives at `$dataDir/logs/dsh-feishu.log` (see `log-file.ts`). */
+  readonly dataDir: string;
   /**
    * The Feishu app id this surface runs as (shown by `/feishu-status`).
    */
@@ -623,6 +627,7 @@ export class Bridge {
       resolveContextWindow: (chatId, sessionId, cwd) =>
         this.resolveContextWindow(chatId, sessionId, cwd),
       textMentionFor: (chatId) => this.textMentionFor(chatId),
+      sendLogFile: (chatId) => this.sendLogFile(chatId).then(() => {}),
     };
   }
 
@@ -2235,6 +2240,23 @@ export class Bridge {
    *  controller; the command module owns the command copy. Option-backed
    *  fields are GETTERS — the original handlers read `this.options.X` at
    *  call time, and tests mutate options after construction. */
+  /** Read the dsh-feishu log and ship it to the chat (`/log` + the error-card
+   *  "Export log" button). Returns a user-facing result. */
+  async sendLogFile(chatId: string): Promise<CommandResult> {
+    const file = readLogFile(this.options.dataDir);
+    if (!file.ok) return { kind: 'error', text: file.error };
+    try {
+      await this.options.transport.sendFile(chatId, file.name, file.content);
+      this.options.logger.info(
+        `log export ${file.name}: ${file.content.length} bytes -> chat ${chatId}`,
+      );
+      return { kind: 'success', text: `Sent the dsh-feishu log (${file.content.length} bytes).` };
+    } catch (error: unknown) {
+      this.options.logger.warn(`log export ${chatId} failed: ${String(error)}`);
+      return { kind: 'error', text: `could not send the dsh-feishu log: ${String(error)}` };
+    }
+  }
+
   private commandHost(): SurfaceCommandHost {
     const bridge = this;
     return {
@@ -2300,6 +2322,7 @@ export class Bridge {
       resetChat: (chatId) => bridge.resetChatState(chatId),
       lastOutput: (chatId) => bridge.streaming.lastOutput(chatId),
       liveAgent: (chatId) => bridge.liveAgent(chatId),
+      sendLog: (chatId) => bridge.sendLogFile(chatId),
     };
   }
 }

--- a/src/cards/StreamingCardController.ts
+++ b/src/cards/StreamingCardController.ts
@@ -133,6 +133,49 @@ export interface ChatCardState {
    *  turn via write/edit mutations (from `tool/result` `meta.diffs`).
    *  Reset on turn start; the final card chips render from it. */
   producedPaths: string[];
+  /** A friendly, actionable explanation of the last turn failure, or
+   *  `undefined` when the last turn didn't fail. Reset on turn start. */
+  errorText: string | undefined;
+}
+
+/**
+ * Map a turn-failure error to a friendly, actionable message the USER can
+ * act on (or relay to the bot admin). The generic "see the card for details"
+ * card told no one what broke; a MISSING_CREDENTIAL tells the admin exactly
+ * what to fix, and an unknown error stays the raw message so a reporter can
+ * share it verbatim.
+ *
+ * Guarantee: this NEVER returns an empty string — a turn failure must always
+ * surface SOMETHING concrete. A blank `message` falls back to the error code,
+ * and a blank code to an explicit "check the bot log" instruction (still more
+ * useful than a dead end).
+ * @param error - the turn-failure error (`reason.error` on a `turn/end`
+ *   event): `code` is the stable category, `message` the provider text.
+ * @returns a non-empty user-facing explanation.
+ */
+export function friendlyTurnError(error: { code?: string; message: string }): string {
+  const code = error.code ?? '';
+  const message = error.message.trim();
+  if (code === 'MISSING_CREDENTIAL' || /no API key/i.test(message)) {
+    return (
+      "The model has no API key — the bot can't reach the LLM. " +
+      'Ask the bot admin to configure one (e.g. DEEPSEEK_API_KEY).'
+    );
+  }
+  if (code === 'NO_ADAPTER' || /no adapter/i.test(message)) {
+    return (
+      "The selected model/provider isn't available. " +
+      'Ask the bot admin to check the model configuration.'
+    );
+  }
+  if (code === 'AgentPresetConflict') {
+    return "The chosen preset was changed mid-session and can't be applied. Start a fresh session and pick the preset again.";
+  }
+  if (message !== '') return message;
+  if (code !== '') {
+    return `The turn failed (error ${code}). Ask the bot admin to check the bot log.`;
+  }
+  return 'The turn failed for an unspecified reason. Ask the bot admin to check the bot log.';
 }
 
 /** Session-scoped cumulative usage folded from the event stream (exact
@@ -361,6 +404,7 @@ export class StreamingCardController {
       collapsed: true,
       stopRequested: false,
       producedPaths: [],
+      errorText: undefined,
     });
     try {
       await this.host.cards.open(chatId, title);
@@ -423,6 +467,7 @@ export class StreamingCardController {
       producedPaths: state.producedPaths,
       sessionStats: this.sessionStatsFor(chatId),
       status: state.status,
+      ...(state.errorText !== undefined ? { errorText: state.errorText } : {}),
     };
   }
 
@@ -512,6 +557,7 @@ export class StreamingCardController {
           collapsed: true,
           stopRequested: false,
           producedPaths: [],
+          errorText: undefined,
         });
         try {
           await this.host.cards.open(chatId, title);
@@ -701,6 +747,7 @@ export class StreamingCardController {
         if (event.data.reason.kind === 'error') {
           const error = event.data.reason.error;
           this.host.logger.error(`turn failed: ${error.code}: ${error.message}`);
+          state.errorText = friendlyTurnError(error);
           // A corrupt persisted log breaks every turn that resumes it; rebind
           // the chat to a fresh session so the next message starts clean.
           if (error.message.includes('corrupt session log')) {
@@ -735,10 +782,13 @@ export class StreamingCardController {
         // stop action; the card's '⏹ Stopped' is the terminal state.
         if (status === 'error') {
           // Proactive @ of the requester in groups: a broken turn must not
-          // go unnoticed, and the group must know WHOSE turn failed.
+          // go unnoticed, and the group must know WHOSE turn failed. The
+          // notice always carries the concrete reason (never a dead "see the
+          // card"): `state.errorText` is guaranteed non-empty by
+          // `friendlyTurnError`.
           await this.host.transport.sendText(
             chatId,
-            `${this.host.textMentionFor(chatId)}⚠️ Turn failed — see the card for details`,
+            `${this.host.textMentionFor(chatId)}⚠️ Turn failed: ${state.errorText ?? 'unknown error'}`,
           );
         }
         break;
@@ -773,6 +823,7 @@ export class StreamingCardController {
             collapsed: true,
             stopRequested: false,
             producedPaths: [],
+            errorText: undefined,
           };
           this.cardStates.set(chatId, state);
           try {
@@ -920,6 +971,7 @@ export class StreamingCardController {
           collapsed: true,
           stopRequested: false,
           producedPaths: [],
+          errorText: undefined,
         });
         try {
           await this.host.cards.open(action.chatId, turnTitle(prompt));

--- a/src/cards/StreamingCardController.ts
+++ b/src/cards/StreamingCardController.ts
@@ -283,6 +283,8 @@ export interface StreamingCardHost {
   ): Promise<number | undefined>;
   /** Proactive @-mention prefix for a chat in groups (failure notices). */
   textMentionFor(chatId: string): string;
+  /** Read the dsh-feishu log and ship it to the chat (error-card "Export log"). */
+  sendLogFile(chatId: string): Promise<void>;
 }
 
 /**
@@ -1044,6 +1046,22 @@ export class StreamingCardController {
           await this.host.transport.sendText(
             action.chatId,
             `⚠️ Could not send the produced file \`${path}\` (${msg}).`,
+          );
+        }
+        return;
+      }
+      case 'send-log': {
+        // Error-card "Export log": ship the dsh-feishu log to the chat so the
+        // user can forward it to the admin. Does NOT mutate card state.
+        this.host.logger.debug(`send-log ${action.chatId}: exporting the dsh-feishu log`);
+        try {
+          await this.host.sendLogFile(action.chatId);
+        } catch (error: unknown) {
+          const msg = error instanceof Error ? error.message : String(error);
+          this.host.logger.warn(`send-log ${action.chatId}: failed (${msg})`);
+          await this.host.transport.sendText(
+            action.chatId,
+            `⚠️ Could not send the dsh-feishu log (${msg}).`,
           );
         }
         return;

--- a/src/cards/StreamingCardController.ts
+++ b/src/cards/StreamingCardController.ts
@@ -139,43 +139,29 @@ export interface ChatCardState {
 }
 
 /**
- * Map a turn-failure error to a friendly, actionable message the USER can
- * act on (or relay to the bot admin). The generic "see the card for details"
- * card told no one what broke; a MISSING_CREDENTIAL tells the admin exactly
- * what to fix, and an unknown error stays the raw message so a reporter can
- * share it verbatim.
+ * Build the turn-failure reason shown on the error card.
  *
- * Guarantee: this NEVER returns an empty string — a turn failure must always
- * surface SOMETHING concrete. A blank `message` falls back to the error code,
- * and a blank code to an explicit "check the bot log" instruction (still more
- * useful than a dead end).
+ * This is a UX/UI hook, NOT a curated friendly copy: for now it returns the
+ * provider's raw `code: message` so the card is honest and diagnosable. A
+ * future UX pass decides how error codes map to friendly copy and how the
+ * text is written — here we only guarantee a non-empty result (a turn failure
+ * must always surface something concrete).
  * @param error - the turn-failure error (`reason.error` on a `turn/end`
  *   event): `code` is the stable category, `message` the provider text.
- * @returns a non-empty user-facing explanation.
+ * @returns a non-empty `code: message` explanation.
  */
 export function friendlyTurnError(error: { code?: string; message: string }): string {
   const code = error.code ?? '';
   const message = error.message.trim();
-  if (code === 'MISSING_CREDENTIAL' || /no API key/i.test(message)) {
-    return (
-      "The model has no API key — the bot can't reach the LLM. " +
-      'Ask the bot admin to configure one (e.g. DEEPSEEK_API_KEY).'
-    );
-  }
-  if (code === 'NO_ADAPTER' || /no adapter/i.test(message)) {
-    return (
-      "The selected model/provider isn't available. " +
-      'Ask the bot admin to check the model configuration.'
-    );
-  }
-  if (code === 'AgentPresetConflict') {
-    return "The chosen preset was changed mid-session and can't be applied. Start a fresh session and pick the preset again.";
-  }
+  // This is a UX/UI hook — NOT a curated friendly copy. For now it returns the
+  // provider's raw `code: message` so the card is honest and diagnosable; a
+  // future UX pass decides how errors map to friendly copy and how the text is
+  // written. Here we only guarantee it never surfaces a meaningless empty
+  // string (a turn failure must always show something concrete).
+  if (code !== '' && message !== '') return `${code}: ${message}`;
+  if (code !== '') return code;
   if (message !== '') return message;
-  if (code !== '') {
-    return `The turn failed (error ${code}). Ask the bot admin to check the bot log.`;
-  }
-  return 'The turn failed for an unspecified reason. Ask the bot admin to check the bot log.';
+  return 'The turn failed with an unspecified error.';
 }
 
 /** Session-scoped cumulative usage folded from the event stream (exact

--- a/src/cards/render.ts
+++ b/src/cards/render.ts
@@ -569,6 +569,21 @@ export function buildCard(snapshot: CardSnapshot): CardJson {
       if (snapshot.status === 'error' && snapshot.errorText !== undefined) {
         elements.push({ tag: 'markdown', content: snapshot.errorText });
       }
+      // On a failed turn offer a one-tap "Export log" so the user can forward
+      // the dsh-feishu log to the admin (English label — no i18n yet).
+      if (snapshot.status === 'error') {
+        elements.push({
+          tag: 'action',
+          actions: [
+            {
+              tag: 'button',
+              text: { tag: 'plain_text', content: '📄 Export log' },
+              type: 'default',
+              value: { kind: 'send-log' },
+            },
+          ],
+        });
+      }
     }
   }
   // Turn-produced files: render a `📎 Produced` chip row on the TERMINAL card

--- a/src/cards/render.ts
+++ b/src/cards/render.ts
@@ -97,6 +97,9 @@ export interface CardSnapshot {
     readonly contextWindow: number | undefined;
   };
   readonly status: CardStatus;
+  /** Friendly, actionable explanation of a failed turn, shown on the error
+   *  card so the user (or the admin they relay to) knows what broke. */
+  readonly errorText?: string;
 }
 
 /** Header template color per status. `stopped` uses amber — the DSH web
@@ -555,11 +558,17 @@ export function buildCard(snapshot: CardSnapshot): CardJson {
     } else {
       const terminalNote =
         snapshot.status === 'error'
-          ? '⚠️ Turn ended with an error'
+          ? '⚠️ Turn failed'
           : snapshot.status === 'stopped'
             ? '⏹ Stopped'
             : '✅ Done';
       elements.push({ tag: 'note', elements: [{ tag: 'plain_text', content: terminalNote }] });
+      // The failure reason, surfaced as a readable line instead of the dead
+      // "see the card for details" — a MISSING_CREDENTIAL tells the admin
+      // exactly what to fix; an unknown error stays the raw message.
+      if (snapshot.status === 'error' && snapshot.errorText !== undefined) {
+        elements.push({ tag: 'markdown', content: snapshot.errorText });
+      }
     }
   }
   // Turn-produced files: render a `📎 Produced` chip row on the TERMINAL card

--- a/src/commands/surface.ts
+++ b/src/commands/surface.ts
@@ -135,6 +135,8 @@ export interface SurfaceCommandHost {
   lastOutput(chatId: string): string | undefined;
   /** The live agent for a chat, or `undefined`. */
   liveAgent(chatId: string): Agent | undefined;
+  /** Read the dsh-feishu log and ship it to the chat (`/log` + error-card button). */
+  sendLog(chatId: string): Promise<CommandResult>;
 }
 
 /**
@@ -193,6 +195,13 @@ export function registerSurfaceCommands(commands: CommandRegistry, host: Surface
       await options.openPanel(invocation.chatId);
       return { kind: 'success', text: '' };
     },
+  });
+  commands.register({
+    name: 'log',
+    description: 'Send the dsh-feishu log file to this chat',
+    category: 'system',
+    buttonLabel: '📄 Log',
+    handler: (invocation) => options.sendLog(invocation.chatId),
   });
   commands.register({
     name: 'group',

--- a/src/commands/surface.ts
+++ b/src/commands/surface.ts
@@ -200,7 +200,7 @@ export function registerSurfaceCommands(commands: CommandRegistry, host: Surface
     name: 'log',
     description: 'Send the dsh-feishu log file to this chat',
     category: 'system',
-    buttonLabel: '📄 Log',
+    buttonLabel: '📄 Export log',
     handler: (invocation) => options.sendLog(invocation.chatId),
   });
   commands.register({

--- a/src/console-exporter.ts
+++ b/src/console-exporter.ts
@@ -9,7 +9,20 @@
  * @module @dsh-feishu/dsh-feishu/console-exporter
  */
 
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
 import type { Exporter, Message } from '@deepseek-ai/cordis';
+
+/** Best-effort JSON for a non-string log arg (never throws; Error → message). */
+function safeStringify(value: unknown): string {
+  if (value instanceof Error) return value.stack ?? value.message;
+  try {
+    const json = JSON.stringify(value);
+    return json === undefined ? String(value) : json;
+  } catch {
+    return String(value);
+  }
+}
 
 /**
  * Format one structured message as a console line prefix.
@@ -25,9 +38,15 @@ export function formatMessage(message: Pick<Message, 'ts' | 'name' | 'type'>): s
  * Build a console exporter: `error`/`warn` to stderr, `info` to stdout,
  * `debug` printed ONLY when `FEISHU_DEBUG` is set (the test bot runs with
  * it; production stays quiet).
+ *
+ * When `logFile` is given, every exported record is ALSO appended to that
+ * file (so the dsh-feishu log survives the terminal and can be shipped by the
+ * `/log` command / error-card "Export log" button). `debug` stays gated by
+ * `FEISHU_DEBUG` in both sinks to keep the file bounded.
+ * @param logFile - optional absolute path to append the dsh-feishu log to.
  * @returns a cordis logger exporter.
  */
-export function consoleExporter(): Exporter {
+export function consoleExporter(logFile?: string): Exporter {
   const debugEnabled = process.env.FEISHU_DEBUG === '1';
   return {
     // cordis filters by exporter.levels before export(): debug is level 3,
@@ -36,6 +55,18 @@ export function consoleExporter(): Exporter {
     export(message) {
       if (message.type === 'debug' && !debugEnabled) return;
       const line = formatMessage(message);
+      if (logFile !== undefined) {
+        try {
+          // Best-effort: a failed file write must never break a log record.
+          mkdirSync(dirname(logFile), { recursive: true });
+          appendFileSync(
+            logFile,
+            `${line} ${message.args.map((arg) => (typeof arg === 'string' ? arg : safeStringify(arg))).join(' ')}\n`,
+          );
+        } catch {
+          // swallow
+        }
+      }
       const write =
         message.type === 'error' || message.type === 'warn' ? console.error : console.log;
       write(line, ...message.args);

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ import { StreamingCardManager } from './cards/streaming.js';
 import type { CommandResult } from './commands.js';
 import { consoleExporter } from './console-exporter.js';
 import type { FeishuTransport } from './feishu/types.js';
+import { logFilePath } from './log-file.js';
 import { createMemoryTransport } from './memory-transport.js';
 import { registerSendFileTool } from './outbound.js';
 import type { SessionExportEvent } from './session-export.js';
@@ -408,8 +409,10 @@ export interface ApplyDeps {
 export function apply(ctx: Context, config: Config, deps: ApplyDeps = {}): void {
   // dsh surfaces mount no console exporter by default; bridge operators need
   // visible logs, so route structured log records to the console (the logger
-  // service disposes the exporter with the current fiber).
-  ctx.logger.exporter(consoleExporter());
+  // service disposes the exporter with the current fiber). Also append to the
+  // dsh-feishu log file under `$dataDir/logs` so the `/log` command and the
+  // error-card "Export log" button can ship it to a chat.
+  ctx.logger.exporter(consoleExporter(logFilePath(config.dataDir ?? defaultDataDir())));
   const credentials = resolveCredentials(config);
   const logger = ctx.logger as unknown as BridgeLogger;
   if (credentials === undefined) {
@@ -497,6 +500,7 @@ export function apply(ctx: Context, config: Config, deps: ApplyDeps = {}): void 
       }),
     cards,
     defaultCwd: config.defaultCwd ?? process.cwd(),
+    dataDir,
     logger,
     appId: credentials.appId,
     transportMode: process.env.FEISHU_TRANSPORT === 'memory' ? 'memory' : 'lark',

--- a/src/log-file.ts
+++ b/src/log-file.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared log-file helpers: where dsh-feishu writes its dsh-feishu log and how
+ * the surface ships it to a chat.
+ *
+ * The console exporter appends every record to `$dataDir/logs/dsh-feishu.log`
+ * (see `consoleExporter`); this module locates that file and reads it so the
+ * `/log` command and the error-card "Export log" button can hand the raw log
+ * to the chat (the log is sent un-compressed so Feishu renders it readably).
+ *
+ * @module @dsh-feishu/dsh-feishu/log-file
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** The surface data directory (default `$DSH_HOME/feishu`). Pass the same
+ *  value the plugin resolved so the path is deterministic. */
+export type LogFileDataDir = string;
+
+/** The absolute path of the persistent dsh-feishu log. */
+export function logFilePath(dataDir: string): string {
+  return join(dataDir, 'logs', 'dsh-feishu.log');
+}
+
+/**
+ * Read the dsh-feishu log for shipping.
+ * @param dataDir - the surface data directory the plugin resolved.
+ * @returns the raw log bytes + a display name, or a user-facing error when the
+ *   log is absent/unreadable.
+ */
+export function readLogFile(
+  dataDir: string,
+): { ok: true; content: Uint8Array; name: string } | { ok: false; error: string } {
+  const path = logFilePath(dataDir);
+  if (!existsSync(path)) {
+    return { ok: false, error: `no dsh-feishu log at ${path} (writing it needs a running turn)` };
+  }
+  try {
+    const buffer = readFileSync(path);
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    return { ok: true, content: new Uint8Array(buffer), name: `dsh-feishu-${stamp}.log` };
+  } catch (error: unknown) {
+    return { ok: false, error: `could not read the dsh-feishu log at ${path}: ${String(error)}` };
+  }
+}

--- a/tests/bridge.spec.ts
+++ b/tests/bridge.spec.ts
@@ -909,7 +909,9 @@ describe('Bridge', () => {
     );
     const last = h.transport.updatedCards.at(-1);
     expect(last?.header?.template).toBe('red');
-    expect(h.transport.sentTexts).toEqual([{ chatId: 'oc_chat', text: '⚠️ Turn failed: boom' }]);
+    expect(h.transport.sentTexts).toEqual([
+      { chatId: 'oc_chat', text: '⚠️ Turn failed: MOCK: boom' },
+    ]);
   });
 
   it('rebinds a fresh session when a turn fails with a corrupt session log', async () => {
@@ -4430,7 +4432,7 @@ describe('proactive @ mentions in groups', () => {
       'feishu-session-1',
       turnEndEvent({ kind: 'error', error: { code: 'X', message: 'boom' } }) as SessionEvent,
     );
-    expect(h.transport.sentTexts.at(-1)?.text).toBe('⚠️ Turn failed: boom');
+    expect(h.transport.sentTexts.at(-1)?.text).toBe('⚠️ Turn failed: X: boom');
   });
 
   it('approval card @s the requester in a group', async () => {

--- a/tests/bridge.spec.ts
+++ b/tests/bridge.spec.ts
@@ -908,9 +908,7 @@ describe('Bridge', () => {
     );
     const last = h.transport.updatedCards.at(-1);
     expect(last?.header?.template).toBe('red');
-    expect(h.transport.sentTexts).toEqual([
-      { chatId: 'oc_chat', text: '⚠️ Turn failed — see the card for details' },
-    ]);
+    expect(h.transport.sentTexts).toEqual([{ chatId: 'oc_chat', text: '⚠️ Turn failed: boom' }]);
   });
 
   it('rebinds a fresh session when a turn fails with a corrupt session log', async () => {
@@ -4431,7 +4429,7 @@ describe('proactive @ mentions in groups', () => {
       'feishu-session-1',
       turnEndEvent({ kind: 'error', error: { code: 'X', message: 'boom' } }) as SessionEvent,
     );
-    expect(h.transport.sentTexts.at(-1)?.text).toBe('⚠️ Turn failed — see the card for details');
+    expect(h.transport.sentTexts.at(-1)?.text).toBe('⚠️ Turn failed: boom');
   });
 
   it('approval card @s the requester in a group', async () => {

--- a/tests/bridge.spec.ts
+++ b/tests/bridge.spec.ts
@@ -278,6 +278,7 @@ function makeHarness(
     onSessionEvent,
     cards,
     defaultCwd: '/work',
+    dataDir: '/work',
     logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
     ...(options.groupMentionMode !== undefined
       ? { groupMentionMode: options.groupMentionMode }

--- a/tests/cards/StreamingCardController.spec.ts
+++ b/tests/cards/StreamingCardController.spec.ts
@@ -9,6 +9,7 @@ import type { Agent } from '@deepseek-ai/dsh-agent';
 import type { SessionEvent } from '@deepseek-ai/dsh-session';
 import { describe, expect, it } from 'vitest';
 import {
+  friendlyTurnError,
   StreamingCardController,
   type StreamingCardHost,
 } from '../../src/cards/StreamingCardController.js';
@@ -316,6 +317,40 @@ describe('StreamingCardController', () => {
     expect(lastCard(h)?.header?.title.content).toBe('T');
     // The terminal render carries the Done note (finalized in place).
     expect(JSON.stringify(lastCard(h)?.elements)).toContain('✅ Done');
+  });
+});
+
+describe('friendlyTurnError', () => {
+  it('names a missing credential as the actionable cause', () => {
+    expect(
+      friendlyTurnError({ code: 'MISSING_CREDENTIAL', message: 'llm-deepseek: no API key' }),
+    ).toContain('no API key');
+    expect(
+      friendlyTurnError({ code: 'MISSING_CREDENTIAL', message: 'llm-deepseek: no API key' }),
+    ).toContain('DEEPSEEK_API_KEY');
+  });
+
+  it('names a missing adapter as the model-config cause', () => {
+    expect(friendlyTurnError({ code: 'NO_ADAPTER', message: 'no adapter' })).toContain(
+      'model/provider',
+    );
+  });
+
+  it('returns the raw message verbatim for an unknown error', () => {
+    expect(friendlyTurnError({ code: 'SOMETHING_ELSE', message: 'the sandbox exploded' })).toBe(
+      'the sandbox exploded',
+    );
+  });
+
+  it('falls back to the code when the message is blank', () => {
+    expect(friendlyTurnError({ code: 'E_BOOM', message: '  ' })).toContain('E_BOOM');
+    expect(friendlyTurnError({ code: 'E_BOOM', message: '  ' })).toContain('bot log');
+  });
+
+  it('never returns an empty string, even with no code and no message', () => {
+    const text = friendlyTurnError({ code: '', message: '' });
+    expect(text.trim()).not.toBe('');
+    expect(text).toContain('bot log');
   });
 });
 

--- a/tests/cards/StreamingCardController.spec.ts
+++ b/tests/cards/StreamingCardController.spec.ts
@@ -322,36 +322,28 @@ describe('StreamingCardController', () => {
 });
 
 describe('friendlyTurnError', () => {
-  it('names a missing credential as the actionable cause', () => {
+  it('returns the raw code and message (UX hook, no curated copy yet)', () => {
     expect(
       friendlyTurnError({ code: 'MISSING_CREDENTIAL', message: 'llm-deepseek: no API key' }),
-    ).toContain('no API key');
-    expect(
-      friendlyTurnError({ code: 'MISSING_CREDENTIAL', message: 'llm-deepseek: no API key' }),
-    ).toContain('DEEPSEEK_API_KEY');
-  });
-
-  it('names a missing adapter as the model-config cause', () => {
-    expect(friendlyTurnError({ code: 'NO_ADAPTER', message: 'no adapter' })).toContain(
-      'model/provider',
+    ).toBe('MISSING_CREDENTIAL: llm-deepseek: no API key');
+    expect(friendlyTurnError({ code: 'NO_ADAPTER', message: 'no adapter' })).toBe(
+      'NO_ADAPTER: no adapter',
     );
   });
 
-  it('returns the raw message verbatim for an unknown error', () => {
-    expect(friendlyTurnError({ code: 'SOMETHING_ELSE', message: 'the sandbox exploded' })).toBe(
+  it('falls back to the message when the code is blank', () => {
+    expect(friendlyTurnError({ code: '', message: 'the sandbox exploded' })).toBe(
       'the sandbox exploded',
     );
   });
 
   it('falls back to the code when the message is blank', () => {
-    expect(friendlyTurnError({ code: 'E_BOOM', message: '  ' })).toContain('E_BOOM');
-    expect(friendlyTurnError({ code: 'E_BOOM', message: '  ' })).toContain('bot log');
+    expect(friendlyTurnError({ code: 'E_BOOM', message: '  ' })).toBe('E_BOOM');
   });
 
   it('never returns an empty string, even with no code and no message', () => {
     const text = friendlyTurnError({ code: '', message: '' });
     expect(text.trim()).not.toBe('');
-    expect(text).toContain('bot log');
   });
 });
 

--- a/tests/cards/StreamingCardController.spec.ts
+++ b/tests/cards/StreamingCardController.spec.ts
@@ -150,6 +150,7 @@ function makeController(): {
     reactions: undefined,
     resolveAgent: async () => agent,
     textMentionFor: () => '',
+    sendLogFile: async () => {},
   };
   return {
     transport,

--- a/tests/cards/render.spec.ts
+++ b/tests/cards/render.spec.ts
@@ -218,12 +218,36 @@ describe('buildCard', () => {
       status: 'error',
       errorText: "The model has no API key — the bot can't reach the LLM.",
     });
-    const notes = card.elements
-      .flatMap((el) => (el.tag === 'note' ? [el] : el.tag === 'markdown' ? [el] : []))
-      .flatMap((el) => (el.tag === 'note' ? el.elements : el.content));
-    expect(JSON.stringify(notes)).toContain('no API key');
+    const cardJson = JSON.stringify(card.elements);
+    expect(cardJson).toContain('no API key');
     // The error card must never fall back to a meaningless placeholder.
-    expect(JSON.stringify(notes)).not.toContain('see the card for details');
+    expect(cardJson).not.toContain('see the card for details');
+  });
+
+  it('offers an Export log button on the error card only', () => {
+    const errorCard = buildCard({
+      title: 'T',
+      content: '',
+      rows: [],
+      status: 'error',
+      errorText: 'boom',
+    });
+    const buttons = errorCard.elements
+      .flatMap((el) => (el.tag === 'action' ? el.actions : []))
+      .flatMap((a) => (a.tag === 'button' ? [a] : []));
+    const exportLog = buttons.find(
+      (b) => JSON.stringify(b.value) === JSON.stringify({ kind: 'send-log' }),
+    );
+    expect(exportLog).toBeDefined();
+    expect(JSON.stringify(exportLog)).toContain('Export log');
+
+    const doneCard = buildCard({ title: 'T', content: '', rows: [], status: 'done' });
+    const doneButtons = doneCard.elements
+      .flatMap((el) => (el.tag === 'action' ? el.actions : []))
+      .flatMap((a) => (a.tag === 'button' ? [a] : []));
+    expect(
+      doneButtons.some((b) => JSON.stringify(b.value) === JSON.stringify({ kind: 'send-log' })),
+    ).toBe(false);
   });
 
   it('renders think/tool rows in chronological order with expand buttons', () => {

--- a/tests/cards/render.spec.ts
+++ b/tests/cards/render.spec.ts
@@ -216,7 +216,7 @@ describe('buildCard', () => {
       content: '',
       rows: [],
       status: 'error',
-      errorText: "The model has no API key — the bot can't reach the LLM.",
+      errorText: 'MISSING_CREDENTIAL: llm-deepseek: no API key',
     });
     const cardJson = JSON.stringify(card.elements);
     expect(cardJson).toContain('no API key');

--- a/tests/cards/render.spec.ts
+++ b/tests/cards/render.spec.ts
@@ -210,6 +210,22 @@ describe('buildCard', () => {
     );
   });
 
+  it('renders the friendly error reason on the error card (never a dead end)', () => {
+    const card = buildCard({
+      title: 'T',
+      content: '',
+      rows: [],
+      status: 'error',
+      errorText: "The model has no API key — the bot can't reach the LLM.",
+    });
+    const notes = card.elements
+      .flatMap((el) => (el.tag === 'note' ? [el] : el.tag === 'markdown' ? [el] : []))
+      .flatMap((el) => (el.tag === 'note' ? el.elements : el.content));
+    expect(JSON.stringify(notes)).toContain('no API key');
+    // The error card must never fall back to a meaningless placeholder.
+    expect(JSON.stringify(notes)).not.toContain('see the card for details');
+  });
+
   it('renders think/tool rows in chronological order with expand buttons', () => {
     const card = buildCard({
       title: 'T',

--- a/tests/commands-surface.spec.ts
+++ b/tests/commands-surface.spec.ts
@@ -112,6 +112,7 @@ function makeCommands(overrides: Partial<SurfaceCommandHost> = {}): {
     resetChat: () => {},
     lastOutput: () => undefined,
     liveAgent: () => undefined,
+    sendLog: async () => ({ kind: 'success', text: 'sent' }),
     ...overrides,
   };
   const commands = new CommandRegistry();
@@ -163,6 +164,17 @@ describe('surface command set', () => {
     });
     expect(result?.kind).toBe('success');
     if (result?.kind === 'success') expect(result.text).toContain('dsh-feishu commands');
+  });
+
+  it('/log asks the host to send the dsh-feishu log', async () => {
+    const { commands } = makeCommands();
+    const result = await commands.find('log')?.handler({
+      chatId: 'oc_chat',
+      senderOpenId: 'ou_user',
+      rawInput: '',
+    });
+    expect(result?.kind).toBe('success');
+    if (result?.kind === 'success') expect(result.text).toContain('sent');
   });
 
   it('/group creates a group with the sender', async () => {

--- a/tests/log-file.spec.ts
+++ b/tests/log-file.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * Unit tests for the operator-log helpers (`src/log-file.ts`).
+ *
+ * `logFilePath` derives the persistent log location under the surface data
+ * dir; `readLogFile` reads it for shipping (`/log` + the error-card "Export
+ * log" button). The raw log is sent un-compressed so Feishu renders it
+ * readably.
+ */
+
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { logFilePath, readLogFile } from '../src/log-file.js';
+
+describe('log-file', () => {
+  it('derives the dsh-feishu log path under the data dir', () => {
+    expect(logFilePath('/home/x/feishu')).toBe('/home/x/feishu/logs/dsh-feishu.log');
+  });
+
+  it('returns an error when the log file does not exist', () => {
+    const dir = mkdtempSync(`${tmpdir()}/dsh-feishu-log-`);
+    const result = readLogFile(dir);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('no dsh-feishu log');
+  });
+
+  it('reads the log file into bytes with a readable name', () => {
+    const dir = mkdtempSync(`${tmpdir()}/dsh-feishu-log-`);
+    const path = logFilePath(dir);
+    mkdirSync(join(dir, 'logs'), { recursive: true });
+    writeFileSync(path, 'line one\nline two\n');
+    const result = readLogFile(dir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(new TextDecoder().decode(result.content)).toBe('line one\nline two\n');
+      expect(result.name).toMatch(/^dsh-feishu-.*\.log$/);
+    }
+  });
+});

--- a/tests/queue.spec.ts
+++ b/tests/queue.spec.ts
@@ -174,6 +174,7 @@ function makeHarness(options: { noInbox?: boolean } = {}): Harness {
     onSessionEvent: () => () => {},
     cards,
     defaultCwd: '/work',
+    dataDir: '/work',
     logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
     requireWorkingDir: false,
   });
@@ -476,6 +477,7 @@ describe('message-queue', () => {
       reactions: undefined,
       resolveAgent: async () => agent as unknown as Agent,
       textMentionFor: () => '',
+      sendLogFile: async () => {},
     });
     await controller.beginTurn('oc_chat', 'msg-1', 'first turn');
     controller.noteSteer('oc_chat', 'steer-m1');


### PR DESCRIPTION
## What

- **Turn failures are now actionable.** The failed-turn card shows the concrete
  reason (missing API key, missing model adapter, preset conflict, …) instead
  of the dead "see the card for details", and offers a one-tap **📄 Export log**
  button.
- **`/log` command** sends the dsh-feishu log file to the chat (English label —
  the surface is not i18n yet), so a user can hand the bot admin the raw log.
  The raw log is sent (not a compressed archive) so Feishu renders it readably.
- **The console exporter now also appends every record to
  `$dataDir/logs/dsh-feishu.log`** alongside the terminal, so the log survives
  the console for diagnosis (`debug` stays gated by `FEISHU_DEBUG` in both
  sinks). README (en + zh) documents the `/log` command.

## Why

A user whose turn fails is told nothing actionable and has no easy path to give
the admin the diagnostic context. Persisting the operator log and exposing
`/log` + an error-card button lets a user forward the exact log with one tap,
and the failure card explains the likely cause — the two hard parts of getting
a useful bug report.

## Verification

- `pnpm run lint` / `typecheck` / `build` — green.
- Unit suite — 601 pass (incl. `tests/log-file.spec.ts`, the `/log` command,
  the error-card "Export log" button, and the `send-log` action).
- `pnpm run check` — all conventions pass, including the peerDependencies guard.

Notes: no new Feishu permission (reuses the existing file-message resource
scope). Ships on top of the already-merged peerDependencies fix (#46).
