### PR TITLE
fix(stats): show the real context occupancy, not the cumulative token sum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Context-occupancy group shown 100% after a few messages.** The occupancy
+  percentage used the CUMULATIVE session token sum (input + output billed
+  across every step) as "used context"; each step re-sends the growing
+  context, so the sum over-counts and hits 100% after only a few messages.
+  It now uses the CURRENT context size (the latest request's input +
+  cache-read tokens), tracked per step, so the `context N%` group reflects the
+  real fill of the model's window.
 - **Quick setup from npm produced a bot without the default avatar.** The
   bundled avatar lives at `docs/assets/default-avatar.png`, but the package
   `files` whitelist only published `lib/` + manifests — so in an npm install

--- a/src/cards/StreamingCardController.ts
+++ b/src/cards/StreamingCardController.ts
@@ -82,6 +82,7 @@ function emptySessionStats(): SessionStatsView {
       cacheWriteTokens: 0,
     },
     contextWindow: undefined,
+    currentContextTokens: undefined,
   };
 }
 
@@ -102,6 +103,12 @@ function accumulateTokenUsage(stats: SessionStatsView, usage: unknown): void {
   stats.tokenUsage.outputTokens += num(u.outputTokens);
   stats.tokenUsage.cacheReadTokens += num(u.cacheReadTokens);
   stats.tokenUsage.cacheWriteTokens += num(u.cacheWriteTokens);
+  // Track the CURRENT context size (the latest request's full input) for the
+  // context-occupancy group. `inputTokens` + `cacheReadTokens` is the context
+  // THAT request carried (un-cached + cached prefix), unlike the cumulative
+  // sum above.
+  const context = num(u.inputTokens) + num(u.cacheReadTokens);
+  if (context > 0) stats.currentContextTokens = context;
 }
 
 /**
@@ -182,6 +189,11 @@ export interface SessionStatsView {
   };
   /** The chat's current model context window (tokens), or undefined. */
   contextWindow: number | undefined;
+  /** The CURRENT context size (the latest request's input + cache-read
+   *  tokens), tracked for the context-occupancy group. Using the cumulative
+   *  tokenUsage sum here would over-count (each request re-sends the growing
+   *  context) and drive the percentage to 100% after a few messages. */
+  currentContextTokens: number | undefined;
 }
 
 const MAX_TITLE_CHARS = 40;

--- a/src/cards/render.ts
+++ b/src/cards/render.ts
@@ -95,6 +95,9 @@ export interface CardSnapshot {
       readonly cacheWriteTokens: number;
     };
     readonly contextWindow: number | undefined;
+    /** The current context size (latest request input + cache-read tokens);
+     *  feeds the context-occupancy group. */
+    readonly currentContextTokens: number | undefined;
   };
   readonly status: CardStatus;
   /** Friendly, actionable explanation of a failed turn, shown on the error
@@ -511,9 +514,15 @@ export function statsGrouperText(stats: CardSnapshot['sessionStats']): string {
     const tokenGroup = `input ${formatTokenCount(billedInput)} · output ${formatTokenCount(usage.outputTokens)}`;
     groups.push(cacheHit > 0 ? `cache ${cacheHit}% · ${tokenGroup}` : tokenGroup);
   }
-  if (stats.contextWindow !== undefined && billedInput + usage.outputTokens > 0) {
-    const usedTokens = billedInput + usage.outputTokens;
-    const percent = Math.min(100, Math.round((usedTokens / stats.contextWindow) * 100));
+  if (
+    stats.contextWindow !== undefined &&
+    stats.currentContextTokens !== undefined &&
+    stats.currentContextTokens > 0
+  ) {
+    const percent = Math.min(
+      100,
+      Math.round((stats.currentContextTokens / stats.contextWindow) * 100),
+    );
     groups.push(`context ${percent}%`);
   }
   return groups.join(' | ');

--- a/tests/session-stats.spec.ts
+++ b/tests/session-stats.spec.ts
@@ -91,6 +91,7 @@ function makeController(cwd: string): {
       cacheWriteTokens: number;
     };
     contextWindow: number | undefined;
+    currentContextTokens: number | undefined;
   };
 } {
   const transport = new RecordingTransport();
@@ -129,6 +130,7 @@ function makeController(cwd: string): {
             cacheWriteTokens: number;
           };
           contextWindow: number | undefined;
+          currentContextTokens: number | undefined;
         };
       }
     ).sessionStatsFor(chatId);
@@ -179,6 +181,7 @@ describe('statsGrouperText', () => {
         cacheWriteTokens: 0,
       },
       contextWindow: 128_000,
+      currentContextTokens: 800,
     });
     expect(text).toContain('2 turns · 3 steps · 1 tools');
     expect(text).toContain('cache 38%');
@@ -194,6 +197,7 @@ describe('statsGrouperText', () => {
         toolCount: 0,
         tokenUsage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 },
         contextWindow: 128_000,
+        currentContextTokens: undefined,
       }),
     ).toBe('');
   });
@@ -205,6 +209,7 @@ describe('statsGrouperText', () => {
       toolCount: 0,
       tokenUsage: { inputTokens: 100, outputTokens: 50, cacheReadTokens: 0, cacheWriteTokens: 0 },
       contextWindow: undefined,
+      currentContextTokens: 100,
     });
     expect(text).not.toContain('context');
     expect(text).toContain('1 turns · 1 steps');
@@ -217,6 +222,7 @@ describe('statsGrouperText', () => {
       toolCount: 0,
       tokenUsage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 },
       contextWindow: 128_000,
+      currentContextTokens: undefined,
     });
     expect(text).toBe('1 turns · 1 steps');
   });
@@ -233,6 +239,7 @@ describe('statsGrouperText', () => {
         cacheWriteTokens: 0,
       },
       contextWindow: undefined,
+      currentContextTokens: undefined,
     });
     expect(text).toContain('input 12.2K · output 1.2M');
   });
@@ -265,6 +272,9 @@ describe('StreamingCardController session stats accumulation', () => {
     expect(stats.tokenUsage.inputTokens).toBe(300);
     expect(stats.tokenUsage.outputTokens).toBe(80);
     expect(stats.tokenUsage.cacheReadTokens).toBe(40);
+    // The CURRENT context size is the LAST request's input+cacheRead (240),
+    // not the cumulative sum (would over-count and hit 100% early).
+    expect(stats.currentContextTokens).toBe(240);
   });
 
   it('a step with no usage contributes no tokens', async () => {


### PR DESCRIPTION
## What

Fix the terminal stats line's `context N%` group, which showed 100% after only
a few messages.

## Why

The occupancy used the **cumulative** session token sum (`billed input + output`
across every step) as "used context". Each step re-sends the growing context, so
that sum over-counts the current context size and drives the percentage to 100%
very early — exactly the symptom reported.

## How

Track the **current context size** (the latest request's `inputTokens +
cacheReadTokens`, which is the context that request actually carried) per step,
and divide that by the model's context window for the `context N%` group.

## Verification

- `pnpm run lint` / `typecheck` / `build` — green.
- Unit suite — 607 pass (incl. a new regression assertion that the current
  context follows the LAST usage, not the cumulative sum).
- `pnpm run check` — all conventions pass.
