### PR TITLE
chore: release v0.3.0

### DIFF
--- a/dsh-version.json
+++ b/dsh-version.json
@@ -5,7 +5,7 @@
     "next": "0.1.1-rc.2"
   },
   "dshFeishu": {
-    "npmLatest": "0.2.1"
+    "npmLatest": "0.3.0"
   },
   "lastAdapted": {
     "track": "bundle",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsh-feishu/dsh-feishu",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "The Feishu UI for DeepSeek Harness (dsh) — a dsh-native plugin: live streaming cards, in-card questions & approvals, one-QR setup.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## What

Sync main to the v0.3.0 release that was published from the `v0.3.0` tag.

## Why

The branch-based release model cuts a frozen `release/*` branch and publishes from its tag, but the version-bump commit is never merged back into main. This left main stuck at `0.2.0` since v0.2.1. The next release is cut FROM main, so main must carry the current released version (`0.3.0`) or the next `patch`/`minor` would re-derive a wrong version.

## Verification

- `package.json` `0.2.0 -> 0.3.0`
- `dsh-version.json` `npmLatest 0.2.1 -> 0.3.0`
- The `v0.3.0` tag’s Release workflow (gates + npm publish) already completed success.