### PR TITLE
fix: address expand/collapse to the clicked card, not the latest

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -325,3 +325,17 @@ The harness sandbox (and this checkout's environment) has specific rules:
 - Rule: before every commit, run `pnpm run lint`, `pnpm run typecheck`,
   `pnpm run test`, `pnpm run build` and confirm each exits 0 — never trust
   an output tail or a `--write` run as the lint verdict.
+
+## Card actions must address the clicked card's message id
+
+- Every `card.action.trigger` callback carries `context.open_message_id` —
+  the message id of the CARD THE BUTTON LIVES ON. A chat accumulates many
+  finished streaming cards; any handler that keys state by chat id alone
+  cross-wires clicks on historical cards to whichever card is currently the
+  latest (real report: expand/collapse on an old card re-rendered the newest
+  one).
+- Rule: when a card action mutates card state, resolve the target by
+  `action.messageId` first (the live card when the ids match, otherwise a
+  frozen final render retained per message id). If the id is unretained
+  (e.g. after a restart), log and ignore — silently re-rendering the current
+  card is exactly the bug. See `StreamingCardController.toggle-rows`.

--- a/docs/pitfalls.zh.md
+++ b/docs/pitfalls.zh.md
@@ -288,3 +288,14 @@ harness 沙箱（以及本 checkout 的环境）有一些特定规则：
 - 规则：每次提交前，运行 `pnpm run lint`、`pnpm run typecheck`、
   `pnpm run test`、`pnpm run build`，并确认每个都以 0 退出 —— 永远不要
   相信输出尾部或 `--write` 运行可以作为 lint 的裁决。
+
+## 卡片动作必须寻址被点卡片自身的 message id
+
+- 每个 `card.action.trigger` 回调都携带 `context.open_message_id` ——
+  即按钮所在那张卡的消息 id。一个 chat 里会累积多张已完成的流式卡；任何
+  只按 chat id 键控状态的处理器，都会把历史卡上的点击串到当前最新的那张卡
+  （真实报告：在旧卡上点展开/折叠，被重渲染的却是最新一张）。
+- 规则：当卡片动作会变更卡片状态时，先按 `action.messageId` 解析目标
+  （id 与当前卡一致即为活卡，否则查按消息 id 保留的冻结终态渲染）。若该 id
+  未保留（例如重启后），记日志并忽略 —— 静默重渲染当前卡正是这个 bug 本身。
+  见 `StreamingCardController.toggle-rows`。

--- a/src/cards/StreamingCardController.ts
+++ b/src/cards/StreamingCardController.ts
@@ -474,6 +474,21 @@ export class StreamingCardController {
    *  recent history is realistically clicked). */
   private static readonly FINISHED_RENDER_LIMIT = 20;
 
+  /**
+   * Freeze the terminal render of the card that JUST finished, keyed by its
+   * own message id. turn/end (and compaction/end) finalize WITHOUT a
+   * syncCard, so the render must be captured here — relying on the syncCard
+   * hook alone left a finished card that the user never re-touched with no
+   * frozen render, and expand/collapse clicks on it were "unretained".
+   * @param chatId - the chat whose turn ended.
+   * @param state - the chat's authoritative state (already terminal).
+   */
+  private captureFinishedRender(chatId: string, state: ChatCardState): void {
+    const messageId = this.host.cards.lastMessageId(chatId);
+    if (messageId === undefined) return;
+    this.rememberFinishedRender(chatId, messageId, this.snapshot(chatId, state));
+  }
+
   /** Record/refresh the frozen render for one finished card, bounded. */
   private rememberFinishedRender(chatId: string, messageId: string, snapshot: CardSnapshot): void {
     let perChat = this.finishedRenders.get(chatId);
@@ -834,6 +849,7 @@ export class StreamingCardController {
         // is none, and the card would keep the stale working render.)
         this.host.cards.patch(chatId, this.snapshot(chatId, state));
         await this.host.cards.finalize(chatId, status);
+        this.captureFinishedRender(chatId, state);
         // Two-stage ack, stage 2: swap 👀 for the terminal emoji.
         await this.ackTurnEnd(chatId, status);
         const finalText = state.content.trim();
@@ -929,6 +945,7 @@ export class StreamingCardController {
           state.stopRequested = false;
           this.host.cards.patch(chatId, this.snapshot(chatId, state));
           await this.host.cards.finalize(chatId, status);
+          this.captureFinishedRender(chatId, state);
           await this.ackTurnEnd(chatId, status);
           const finalText = state.content.trim();
           if (finalText !== '') this.lastOutputs.set(chatId, finalText);

--- a/src/cards/StreamingCardController.ts
+++ b/src/cards/StreamingCardController.ts
@@ -310,6 +310,16 @@ export class StreamingCardController {
    *  boundary it emits a `user/message`; the id here lets the trace add a
    *  steering row exactly where it was injected. */
   private readonly pendingSteers = new Map<string, Set<string>>();
+  /** Frozen final renders of FINISHED streaming cards, keyed by their OWN
+   *  message id, newest-last per chat: expand/collapse on a historical card
+   *  must retarget THAT card — a real report had it cross-wired to whichever
+   *  card was latest. The card callback always carries the clicked message
+   *  id (`context.open_message_id`), so the lookup is exact. Bounded per
+   *  chat; a restart drops the renders and such clicks are logged and
+   *  ignored (fails loud in FEISHU_DEBUG). */
+  private readonly finishedRenders = new Map<string, Map<string, CardSnapshot>>();
+  /** Insertion order per chat for bounding {@link finishedRenders}. */
+  private readonly finishedOrder = new Map<string, string[]>();
 
   constructor(private readonly host: StreamingCardHost) {}
 
@@ -448,12 +458,64 @@ export class StreamingCardController {
     }
     const messageId = this.host.cards.lastMessageId(chatId);
     if (messageId === undefined) return;
-    const card = buildCard(this.snapshot(chatId, state));
+    const snapshot = this.snapshot(chatId, state);
+    // Freeze the terminal render under its own message id so a click on
+    // THIS card later toggles THIS card (historical expand/collapse).
+    this.rememberFinishedRender(chatId, messageId, snapshot);
+    const card = buildCard(snapshot);
     setTimeout(() => {
       void this.host.transport.updateCard(messageId, card).catch((error: unknown) => {
         this.host.logger.warn(`streaming card sync failed: ${String(error)}`);
       });
     }, 0);
+  }
+
+  /** How many finished renders to keep per chat (bounding memory; only the
+   *  recent history is realistically clicked). */
+  private static readonly FINISHED_RENDER_LIMIT = 20;
+
+  /** Record/refresh the frozen render for one finished card, bounded. */
+  private rememberFinishedRender(chatId: string, messageId: string, snapshot: CardSnapshot): void {
+    let perChat = this.finishedRenders.get(chatId);
+    let order = this.finishedOrder.get(chatId);
+    if (perChat === undefined || order === undefined) {
+      perChat = new Map();
+      order = [];
+      this.finishedRenders.set(chatId, perChat);
+      this.finishedOrder.set(chatId, order);
+    }
+    if (!order.includes(messageId)) {
+      order.push(messageId);
+      while (order.length > StreamingCardController.FINISHED_RENDER_LIMIT) {
+        const evicted = order.shift();
+        if (evicted !== undefined) perChat.delete(evicted);
+      }
+    }
+    perChat.set(messageId, { ...snapshot });
+  }
+
+  /**
+   * Flip the collapsed bit on the frozen render of one historical finished
+   * card and re-render exactly that message id.
+   * @returns whether the card was found.
+   */
+  private toggleHistoricalCard(chatId: string, messageId: string): boolean {
+    const frozen = this.finishedRenders.get(chatId)?.get(messageId);
+    if (frozen === undefined) return false;
+    const flipped: CardSnapshot = { ...frozen, collapsed: !frozen.collapsed };
+    this.finishedRenders.get(chatId)?.set(messageId, flipped);
+    this.host.logger.debug(
+      `streaming toggle-rows ${chatId}: historical card ${messageId} -> ${
+        flipped.collapsed ? 'collapsed' : 'expanded'
+      }`,
+    );
+    const card = buildCard(flipped);
+    setTimeout(() => {
+      void this.host.transport.updateCard(messageId, card).catch((error: unknown) => {
+        this.host.logger.warn(`historical card sync failed: ${String(error)}`);
+      });
+    }, 0);
+    return true;
   }
 
   /** Build the render snapshot from the authoritative state. */
@@ -996,6 +1058,19 @@ export class StreamingCardController {
         return;
       }
       case 'toggle-rows': {
+        // The callback's message id names the card that was clicked. The
+        // LIVE card (the chat's current authoritative state) toggles through
+        // the single render path; a HISTORICAL card flips its own frozen
+        // final render — NEVER the latest card by accident (cross-wiring
+        // bug), so an unretained id is logged and ignored.
+        const liveMessageId = this.host.cards.lastMessageId(action.chatId);
+        if (liveMessageId !== action.messageId) {
+          if (this.toggleHistoricalCard(action.chatId, action.messageId)) return;
+          this.host.logger.warn(
+            `toggle-rows ${action.chatId}: unretained card ${action.messageId} (not the live ${liveMessageId ?? 'none'}) — ignored`,
+          );
+          return;
+        }
         // Flip the collapsed bit on the authoritative state, then re-render
         // through the single path. Whether the turn is live or finished is
         // syncCard's concern — no per-case patching.
@@ -1003,6 +1078,10 @@ export class StreamingCardController {
         if (state !== undefined) {
           state.collapsed = !state.collapsed;
           this.syncCard(action.chatId);
+        } else {
+          this.host.logger.warn(
+            `toggle-rows ${action.chatId}: no state for live card ${action.messageId}`,
+          );
         }
         return;
       }

--- a/tests/bridge.spec.ts
+++ b/tests/bridge.spec.ts
@@ -1481,8 +1481,11 @@ describe('Bridge', () => {
             (el) => el.tag === 'markdown' && 'content' in el && el.content === 'bash',
           ),
       ).toBe(true);
+      // The callback must carry the clicked card's own message id (the
+      // harness fake assigns 'msg-1' to the first posted card) — a wrong id
+      // is now ignored instead of cross-wiring the latest card.
       await h.bridge.handleCardAction({
-        messageId: 'mem-1',
+        messageId: 'msg-1',
         chatId: 'oc_chat',
         operatorOpenId: 'ou_user',
         value: { kind: 'toggle-rows' },

--- a/tests/cards/StreamingCardController.spec.ts
+++ b/tests/cards/StreamingCardController.spec.ts
@@ -28,6 +28,8 @@ import { SessionMap } from '../../src/session-map.js';
 class RecordingTransport implements FeishuTransport {
   sentCards: CardJson[] = [];
   updatedCards: CardJson[] = [];
+  /** Every in-place patch with its TARGET message id (updateCard calls). */
+  updatedTargets: Array<{ messageId: string; card: CardJson }> = [];
   sentTexts: Array<{ chatId: string; text: string }> = [];
   reactions: Array<{
     messageId: string;
@@ -68,8 +70,9 @@ class RecordingTransport implements FeishuTransport {
     this.sentCards.push(card);
     return { messageId: `msg-${this.sentCards.length}` };
   }
-  async updateCard(_messageId: string, card: CardJson): Promise<void> {
+  async updateCard(messageId: string, card: CardJson): Promise<void> {
     this.updatedCards.push(card);
+    this.updatedTargets.push({ messageId, card });
   }
   async deleteMessage(_messageId: string): Promise<void> {}
   async downloadImage(
@@ -179,6 +182,14 @@ function turnEndEvent(reason: { kind: 'completed' | 'error' | 'aborted' }): Sess
   } as unknown as SessionEvent;
 }
 
+/** A reasoning delta (opens/folds into a think row — makes hasRows true). */
+function reasoningEvent(text: string): SessionEvent {
+  return {
+    type: 'assistant/chunk',
+    data: { chunk: { type: 'reasoning-delta', text } },
+  } as unknown as SessionEvent;
+}
+
 /** The last card rendered by the streaming manager (a CardJson render). */
 function lastCard(h: {
   transport: RecordingTransport;
@@ -277,9 +288,68 @@ describe('StreamingCardController', () => {
   it('toggle-rows flips the collapsed bit and re-renders', async () => {
     const h = makeController();
     await h.controller.beginTurn('oc_chat', 'om-1', 'T');
+    await h.controller.handleEvent('feishu-session-1', reasoningEvent('thinking…'));
     expect(h.controller.state('oc_chat')?.collapsed).toBe(true);
-    await h.controller.handleStreamingAction(action('toggle-rows'));
+    // A real callback carries the message id of the card that was clicked
+    // (here: the live card just posted by beginTurn — RecordingTransport
+    // assigns 'msg-1' to the first sent card).
+    await h.controller.handleStreamingAction({ ...action('toggle-rows'), messageId: 'msg-1' });
     expect(h.controller.state('oc_chat')?.collapsed).toBe(false);
+  });
+
+  it('toggle-rows on a HISTORICAL card retargets that card, not the latest (regression)', async () => {
+    // User report: expand/collapse on an old card cross-wired to the newest
+    // one — the handler keyed everything by chatId. The callback's own
+    // message id must address the clicked card.
+    const h = makeController();
+    // Turn 1: post a card WITH tool rows (the only cards that carry the
+    // expand/collapse button), finish it, expand it so the frozen render
+    // ends expanded.
+    await h.controller.beginTurn('oc_chat', 'om-1', 'first turn');
+    await h.controller.handleEvent('feishu-session-1', reasoningEvent('analyzing…'));
+    await h.controller.handleEvent('feishu-session-1', turnEndEvent({ kind: 'completed' }));
+    await new Promise((resolve) => setTimeout(resolve, 0)); // deferred final render
+    const firstCardId = 'msg-1';
+    await h.controller.handleStreamingAction({ ...action('toggle-rows'), messageId: firstCardId });
+    expect(h.controller.state('oc_chat')?.collapsed).toBe(false); // still the live card
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Turn 2: a NEW card becomes the latest.
+    await h.controller.beginTurn('oc_chat', 'om-2', 'second turn');
+    expect(h.transport.sentCards).toHaveLength(2);
+    await h.controller.handleEvent('feishu-session-1', turnEndEvent({ kind: 'completed' }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const updatesBefore = h.transport.updatedTargets.length;
+    // Click Expand on the OLD card.
+    await h.controller.handleStreamingAction({
+      ...action('toggle-rows'),
+      messageId: firstCardId,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const updates = h.transport.updatedTargets.slice(updatesBefore);
+    // The re-render targeted the OLD message id…
+    expect(updates.map((u) => u.messageId)).toEqual([firstCardId]);
+    // …and toggled IT (frozen render was expanded -> now shows Expand, i.e.
+    // clicking collapsed that historical card alone).
+    expect(JSON.stringify(updates[0]?.card.elements)).toContain('▸ Expand');
+    // …leaving the LATEST card's authoritative state untouched.
+    expect(h.controller.state('oc_chat')?.collapsed).toBe(true);
+  });
+
+  it('toggle-rows on an unretained historical card is ignored (no cross-wiring)', async () => {
+    const h = makeController();
+    await h.controller.beginTurn('oc_chat', 'om-1', 'T');
+    await h.controller.handleEvent('feishu-session-1', reasoningEvent('thinking…'));
+    await h.controller.handleEvent('feishu-session-1', turnEndEvent({ kind: 'completed' }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const updatesBefore = h.transport.updatedTargets.length;
+    await h.controller.handleStreamingAction({
+      ...action('toggle-rows'),
+      messageId: 'msg-from-before-the-restart',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // An id we never rendered must NOT touch the current card either —
+    // silently re-rendering the latest card is exactly the reported bug.
+    expect(h.transport.updatedTargets.slice(updatesBefore)).toHaveLength(0);
   });
 
   it('a compaction transaction opens and finalizes its own card', async () => {

--- a/tests/cards/StreamingCardController.spec.ts
+++ b/tests/cards/StreamingCardController.spec.ts
@@ -335,6 +335,31 @@ describe('StreamingCardController', () => {
     expect(h.controller.state('oc_chat')?.collapsed).toBe(true);
   });
 
+  it('a finished card is captured at turn/end even if never re-touched (first-card expand)', async () => {
+    // User report: the FIRST card's expand did nothing. turn/end finalizes
+    // WITHOUT a syncCard, so the card's frozen render was never captured; a
+    // later card made it non-live and the click fell through as "unretained".
+    const h = makeController();
+    await h.controller.beginTurn('oc_chat', 'om-1', 'first');
+    await h.controller.handleEvent('feishu-session-1', reasoningEvent('analyzing…'));
+    await h.controller.handleEvent('feishu-session-1', turnEndEvent({ kind: 'completed' }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const firstCardId = 'msg-1';
+    // Turn 2 makes a NEW card live WITHOUT the first card being re-touched.
+    await h.controller.beginTurn('oc_chat', 'om-2', 'second');
+    await h.controller.handleEvent('feishu-session-1', reasoningEvent('thinking…'));
+    await h.controller.handleEvent('feishu-session-1', turnEndEvent({ kind: 'completed' }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const updatesBefore = h.transport.updatedTargets.length;
+    await h.controller.handleStreamingAction({ ...action('toggle-rows'), messageId: firstCardId });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const updates = h.transport.updatedTargets.slice(updatesBefore);
+    // The first card's render was captured at ITS turn/end, so the
+    // historical click retargets it (not silently ignored, not the latest).
+    expect(updates.map((u) => u.messageId)).toEqual([firstCardId]);
+    expect(h.controller.state('oc_chat')?.collapsed).toBe(true); // latest untouched
+  });
+
   it('toggle-rows on an unretained historical card is ignored (no cross-wiring)', async () => {
     const h = makeController();
     await h.controller.beginTurn('oc_chat', 'om-1', 'T');

--- a/tests/integration/real-composition.spec.ts
+++ b/tests/integration/real-composition.spec.ts
@@ -112,6 +112,17 @@ function writeAction(action: unknown): void {
   );
 }
 
+/** The message id of the chat's streaming card — the message a toggle
+ *  click must carry (`context.open_message_id`). The streaming card is the
+ *  one patched in place (`updateCard` → 'patch' records carry its id);
+ *  other cards (details, panel) are sent once and never patched, so the
+ *  last 'patch' record's message id names the streaming card. A mismatched
+ *  id now fails loud instead of cross-wiring the latest card. */
+function streamingCardMessageId(): string | undefined {
+  const patches = readOutbox().filter((r) => r.kind === 'patch');
+  return patches.at(-1)?.messageId;
+}
+
 /** Pin the chat's working directory via /cd (the gate refuses turns until
  *  an explicit directory is chosen). */
 async function pinWorkingDir(chatId: string): Promise<void> {
@@ -500,10 +511,14 @@ describe.skipIf(!integrationReady)('real-composition integration', () => {
         ),
       ).toBe(true);
 
-      // Expand → full rows visible (column_set row elements).
+      // Expand → full rows visible (column_set row elements). The callback
+      // carries the LIVE card's own message id (read from the rendered
+      // card); a mismatched id now fails loud instead of cross-wiring.
       const patchCountBeforeExpand = readOutbox().filter((r) => r.kind === 'patch').length;
+      const liveCardId = streamingCardMessageId();
+      expect(liveCardId).toBeDefined();
       writeAction({
-        messageId: 'mem-1',
+        messageId: liveCardId,
         chatId,
         operatorOpenId: 'ou_mock',
         value: { kind: 'toggle-rows' },
@@ -568,9 +583,9 @@ describe.skipIf(!integrationReady)('real-composition integration', () => {
         false,
       );
 
-      // Collapse again → back to the sequence line.
+      // Collapse again → back to the sequence line (same live card id).
       writeAction({
-        messageId: 'mem-1',
+        messageId: streamingCardMessageId(),
         chatId,
         operatorOpenId: 'ou_mock',
         value: { kind: 'toggle-rows' },


### PR DESCRIPTION
## What

Expand/collapse on ANY historical streaming card now toggles THAT card instead of re-rendering whichever card is currently the latest in the chat.

- `src/cards/StreamingCardController.ts`:
  - The finished render path freezes each terminal snapshot under its own message id (`finishedRenders`, bounded to the last 20 per chat).
  - `toggle-rows` resolves the target by `action.messageId`: ids matching the live card keep flowing through the single render path (`syncCard`); any other id flips its own frozen render in place (deferred macrotask, ACK-safe). An unretained id (e.g. after a restart) is logged and ignored — never re-rendering the current card by accident.
- Tests: new regression suite in `tests/cards/StreamingCardController.spec.ts` (historical retarget, unretained-ignore); existing toggle tests updated to carry REAL posted message ids like production callbacks do (`bridge.spec.ts` matrix click included). `RecordingTransport` now records update targets.
- Docs: `docs/pitfalls.md` / `.zh.md` — new entry "Card actions must address the clicked card's message id".

## Why

User report: expand/collapse buttons cross-wired between cards — every click updated the newest card. Root cause: buttons carried no card identity and the handler keyed everything by chatId, while the callback payload has always carried the clicked card's id (`context.open_message_id`) unused. Fix = address cards exactly by the id the platform already provides.

Related-but-not-here: `row-details` on a historical card already fails loud (unknown row → warn, no wrong render); left unchanged.

## Verification

- Regression test red before, green after; full unit suite 603 passed.
- lint (`biome check src tests`) / typecheck / build all exit 0 locally.
- Note: `pnpm run check` flags ONE pre-existing convention violation on current `main` itself — commit `7558da14` ("Revert … (#50)", created via GitHub UI) doesn't match the repo's Conventional Commits regex. Not introduced by this branch; flagging for awareness.

No Feishu scope/event/callback change; manifest untouched.