### PR TITLE
feat(build): self-contained portable deployment package

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -345,6 +345,7 @@ they land.
 | `docs/features.md` (+ `.zh.md`) | feature list / TODO tracker — every shipped or planned feature updates its row |
 | `src/i18n/en-US.ts` + `src/i18n/zh-CN.ts` | any user-facing string change: add the key(s) to BOTH catalogs in the same PR |
 | `docs/pitfalls.md` (+ `.zh.md`) | field-proven failure modes; every entry ships with its regression test |
+| `docs/portable-deployment.md` (+ `.zh.md`) | the self-contained/green deployment package: how to build it, its multi-instance model, and per-instance deployment |
 | `AGENTS.md` | agent guidance, conventions, workflow (this file) |
 | `CONTRIBUTING.md` / `SECURITY.md` | contribution guidance / security posture (rare, deliberate) |
 

--- a/docs/development.zh.md
+++ b/docs/development.zh.md
@@ -227,6 +227,7 @@ source _dev/bot-env.sh        # 设置 DSH_HOME=_dev/dsh-home 并 source _dev/se
 | `src/i18n/en-US.ts` + `src/i18n/zh-CN.ts` | 任何用户可见文案变更：在同一个 PR 中同时向两个目录添加键 |
 | `docs/e2e-testing.md`（+ `.zh.md`） | E2E UI 套件：场景、运行手册、约束、捕获到的网页选择器 |
 | `docs/pitfalls.md`（+ `.zh.md`） | 实战踩坑；每条都伴随回归测试 |
+| `docs/portable-deployment.md`（+ `.zh.md`） | 绿色/便携部署包：构建方式、多实例模型、每实例部署 |
 | `AGENTS.md` | agent 指南、约定、流程（本文件） |
 | `CONTRIBUTING.md` / `SECURITY.md` | 贡献指南 / 安全姿态（低频、刻意为之） |
 

--- a/docs/portable-deployment.md
+++ b/docs/portable-deployment.md
@@ -1,0 +1,137 @@
+# Portable deployment (green package)
+
+`scripts/package-portable.mjs` builds a self-contained, "green" deployment
+directory for dsh-feishu on Linux **x86_64 (glibc)**: a bundled Node runtime,
+the DSH CLI + harness family, the dsh-feishu bundle built from `main`, a
+credential-free profile-home template, and per-instance launchers. Deploying
+is copying the directory to a host and running `bin/start` — no system Node,
+no network, no pnpm.
+
+The use case is **many instances on one server**: each deployed copy is its
+own isolated dsh-feishu instance (own home, own Feishu app, own API key,
+own model), so a single host can serve several users without the instances
+touching one another's state.
+
+## Build
+
+```sh
+pnpm install                      # once, in the repo
+pnpm run build                    # produces lib/ (the bundle is built below)
+node scripts/package-portable.mjs
+```
+
+The script runs a real `npm install @deepseek-ai/dsh@<pin>` into a staging
+app prefix (the `INSTALL_ANCHOR`) and supplements it with every
+`@deepseek-ai/*` package a Feishu profile needs (the `cordis.patch.yml`
+bundle-layer names plus the plugin's peer dependencies), so bundle
+resolution is fully offline. It then builds the dsh-feishu bundle from the
+checkout, vendors a Node LTS runtime, writes a profile-home template, and
+emits:
+
+```
+_dev/portable/dsh-feishu-portable-linux-x64-v<version>-<sha>/   # the package
+_dev/portable/dsh-feishu-portable-linux-x64-v<version>-<sha>.tar.gz
+```
+
+Output is git-ignored (`_dev/`), never committed. The precedence checks are:
+
+- **Host must be Linux x86_64 glibc** — the vendored native prebuilds
+  (sharp, node-pty, rollup, koffi, …) are platform-selected. musl/Alpine is
+  out of scope (a musl Node build would be needed).
+- Build machine needs outbound network (nodejs.org + the npm registry); the
+  *deployed* package never does.
+
+### Environment overrides
+
+| Variable | Meaning |
+| --- | --- |
+| `PORTABLE_NODE_CACHE` | persistent dir caching the downloaded Node tarball (default `_dev/portable/.cache`) |
+| `PORTABLE_NODE_VERSION` | pin a Node version (defaults to the latest LTS patch of the major below) |
+| `PORTABLE_NODE_MAJOR` | Node major to auto-pick (default `22`) |
+| `PORTABLE_NODE_TARBALL` | path to a pre-downloaded `.tar.xz` for offline builds |
+| `PORTABLE_DSH_VERSION` | pin the DSH version (defaults to the repo's `devDependencies["@deepseek-ai/dsh"]`) |
+| `PORTABLE_OUT_DIR` | output dir (default `_dev/portable`) |
+| `PORTABLE_PACKAGE_NAME` | override the package dir name |
+
+### Layout
+
+```
+runtime/node/         bundled Node (bin/node + npm-cli)
+runtime/app/          DSH CLI install anchor: node_modules/@deepseek-ai/{dsh,dsh-base,…}
+bundle/dsh-feishu/    the bundle built from main (lib/, cordis.patch.yml, package.json, + its runtime deps)
+home/                 credential-free DSH_HOME template (profiles/feishu/**)
+bin/dsh-feishu        launcher: sets PATH, sources instance.env, DSH_HOME, execs dsh
+bin/start             convenience wrapper around bin/dsh-feishu
+bin/setup             one QR scan: create + configure the Feishu app (the bundle's quick-setup wizard)
+bin/init-instance     copy this package into a fresh isolated instance
+instance.env.example  per-instance credentials & options
+README-PORTABLE.md    per-instance deployment instructions (also shipped in the package)
+portable.json         provenance: versions, source sha, libc
+```
+
+## First deploy and per-instance app setup
+
+```sh
+cp -r dsh-feishu-portable-linux-x64-* yourinstance
+cd yourinstance
+cp instance.env.example instance.env          # FEISHU_APP_ID/SECRET, DEEPSEEK_API_KEY, …
+./bin/setup                                    # one QR scan: create + configure the Feishu app
+./bin/start
+```
+
+`bin/setup` runs the bundle's quick-setup wizard with `--dsh-home <instance
+home> --profile feishu`, writing app credentials into the instance's
+`home/profiles/feishu/cordis.patch.yml`. Re-run with `--app-id cli_xxx` to
+reconfigure an existing app.
+
+## How the harness resolves offline
+
+Boot loads bundle layers from `INSTALL_ANCHOR` (the vendored dsh app
+install) first, then the profile's own `node_modules`. The profile's
+`dsh.profile.bundles` lists `@deepseek-ai/dsh-base`, the bundle-layer
+packages referenced by the dsh-feishu patch, and the dsh-feishu bundle. The
+harness family lives **once** (in the anchor); the profile layer ships only
+the dsh-feishu bundle plus its non-harness runtime deps, with harness peers
+symlinked from the anchor — never a second copy (a duplicate would break
+module-identity state, the double-install bug family).
+
+## Multi-instance model
+
+- **One copy = one instance.** Deploy N users by copying the package N
+  times; each copy has its own `home/` (its DSH_HOME and `dataDir`), its own
+  `instance.env` (Feishu app, API key, model), so there is no cross-instance
+  session, log, or model state.
+- Per-instance identity is pinned to **its own Feishu app** (separate
+  appId/appSecret/bot/team). A single Feishu chat maps to one agent session;
+  instances should not share one app if you need isolation.
+- No ports are bound (the surface uses the Feishu long connection, a
+  WebSocket, not HTTP), so multiple instances on one host do not conflict.
+- `bin/start` sources `instance.env`; keys in the instance's
+  `home/profiles/feishu/cordis.patch.yml` win over the environment.
+
+### Serve a second user on the same server
+
+```sh
+cd path/to/firstinstance
+./bin/init-instance second          # fresh isolated copy at ./second
+cd second
+#  edit instance.env with the second user's appId/appSecret/api key
+./bin/start
+```
+
+## Verification
+
+- `bin/start --dump-config` composes the dsh-feishu row (no credentials
+  needed to compose; booting needs a real app + API key).
+- With credentials set, `bin/start` logs `[feishu] bridge ready`.
+- The end-to-end bot path (a real turn in a group) must be verified by the
+  operator against a real Feishu app — CI does not drive a real bot.
+
+## Notes / limits
+
+- Target is **glibc x86_64 Linux**; musl/Alpine needs a musl Node build.
+- Each instance needs its own Feishu app (separate appId/appSecret/bot/team).
+- The chat must have a working directory pinned (choose via `/repo` or
+  `/cd`); `defaultCwd` is a fallback, never an implicit choice.
+- The package builds the bundle from the current working tree; build from a
+  clean `main` checkout so shipped code matches the release.

--- a/docs/portable-deployment.zh.md
+++ b/docs/portable-deployment.zh.md
@@ -1,0 +1,125 @@
+# 便携部署（绿色安装包）
+
+`scripts/package-portable.mjs` 面向 Linux **x86_64（glibc）** 构建一个自包含、
+可直接复制的 dsh-feishu 部署目录：内置 Node 运行时、DSH CLI + harness 家族、
+从 `main` 构建的 dsh-feishu bundle、不含密钥的 profile-home 模板、以及每实例
+启动脚本。部署就是把目录拷贝到服务器运行 `bin/start` —— 无需系统 Node、无需
+网络、无需 pnpm。
+
+使用场景是**单服务器多实例**：每份拷贝都是独立隔离的 dsh-feishu 实例
+（各自的 home、飞书应用、API key、模型），一台服务器可同时服务多个用户而互不
+串状态。
+
+## 构建
+
+```sh
+pnpm install                      # repo 内执行一次
+pnpm run build                    # 产生 lib/（bundle 在下面一并构建）
+node scripts/package-portable.mjs
+```
+
+脚本会真正执行一次 `npm install @deepseek-ai/dsh@<pin>` 到临时 app 前缀
+（即 `INSTALL_ANCHOR`），并补装一个 Feishu profile 所需的全部 `@deepseek-ai/*`
+包（`cordis.patch.yml` 引用的 bundle 层 + 插件的 peer 依赖），从而完全离线解析
+bundle。接着从当前 checkout 构建 dsh-feishu bundle、内置 Node LTS 运行时、写入
+profile-home 模板，产出：
+
+```
+_dev/portable/dsh-feishu-portable-linux-x64-v<version>-<sha>/   # 包目录
+_dev/portable/dsh-feishu-portable-linux-x64-v<version>-<sha>.tar.gz
+```
+
+产物在 git-ignored 的 `_dev/` 下，不提交。前置校验：
+
+- **构建机必须是 Linux x86_64 glibc** —— vendored 的原生预编译（sharp、
+  node-pty、rollup、koffi 等）按平台选择。musl/Alpine 不在支持范围（需要
+  musl 版 Node）。
+- 构建机需出站网络（nodejs.org + npm registry）；**部署后的包**永不联网。
+
+### 环境变量
+
+| 变量 | 含义 |
+| --- | --- |
+| `PORTABLE_NODE_CACHE` | 缓存已下载 Node tarball 的持久目录（默认 `_dev/portable/.cache`） |
+| `PORTABLE_NODE_VERSION` | 固定 Node 版本（默认取下列 major 的最新 LTS patch） |
+| `PORTABLE_NODE_MAJOR` | 自动挑选的 Node major（默认 `22`） |
+| `PORTABLE_NODE_TARBALL` | 预下载 `.tar.xz` 路径（离线构建用） |
+| `PORTABLE_DSH_VERSION` | 固定 DSH 版本（默认取仓库 `devDependencies["@deepseek-ai/dsh"]`） |
+| `PORTABLE_OUT_DIR` | 输出目录（默认 `_dev/portable`） |
+| `PORTABLE_PACKAGE_NAME` | 覆盖包目录名 |
+
+### 目录结构
+
+```
+runtime/node/        内置 Node（bin/node + npm-cli）
+runtime/app/         DSH CLI 安装锚点：node_modules/@deepseek-ai/{dsh,dsh-base,…}
+bundle/dsh-feishu/   从 main 构建的 bundle（lib/、cordis.patch.yml、package.json、+ 其运行时依赖）
+home/                不含密钥的 DSH_HOME 模板（profiles/feishu/**）
+bin/dsh-feishu       启动器：设 PATH、source instance.env、DSH_HOME、exec dsh
+bin/start            bin/dsh-feishu 的便捷封装
+bin/setup            一次扫码：创建并配置飞书应用（bundle 的快速配置向导）
+bin/init-instance    把本包复制成一个新的隔离实例
+instance.env.example 每实例凭据与选项
+README-PORTABLE.md   每实例部署说明（随包附送）
+portable.json        溯源信息：版本、源码 sha、libc
+```
+
+## 首次部署与每实例应用配置
+
+```sh
+cp -r dsh-feishu-portable-linux-x64-* yourinstance
+cd yourinstance
+cp instance.env.example instance.env          # FEISHU_APP_ID/SECRET、DEEPSEEK_API_KEY、…
+./bin/setup                                    # 一次扫码：创建并配置飞书应用
+./bin/start
+```
+
+`bin/setup` 以 `--dsh-home <实例 home> --profile feishu` 运行 bundle 的快速
+配置向导，把应用凭据写入实例的 `home/profiles/feishu/cordis.patch.yml`。
+用 `--app-id cli_xxx` 重跑可重配置已有应用。
+
+## harness 如何离线解析
+
+boot 先按 `INSTALL_ANCHOR`（vendored 的 dsh 安装）解析 bundle 层，再查 profile
+自身的 `node_modules`。profile 的 `dsh.profile.bundles` 列出 `@deepseek-ai/dsh-base`、
+dsh-feishu 补丁引用的 bundle 层包、以及 dsh-feishu 自身。harness 家族**只存在
+一份**（在锚点里）；profile 层只带 dsh-feishu bundle 与其非 harness 运行时依赖，
+harness peer 从锚点 symlink 过来——绝不放第二份（重复会导致模块身份状态错乱，
+即 double-install 这一类 bug）。
+
+## 多实例模型
+
+- **一份拷贝 = 一个实例。** 服务 N 个用户就复制 N 份；每份有自己的 `home/`
+  （即 DSH_HOME 与 `dataDir`）、自己的 `instance.env`（飞书应用、API key、模型），
+  因此不存在跨实例的会话、日志或模型状态。
+- 每实例身份绑定**各自的飞书应用**（独立 appId/appSecret/bot/团队）。一个飞书群
+  对应一个 agent 会话；若需要隔离，实例不应共享同一个应用。
+- 不占用端口（surface 走飞书长连接 WebSocket，而非 HTTP），同机多实例不会冲突。
+- `bin/start` 会 source `instance.env`；实例
+  `home/profiles/feishu/cordis.patch.yml` 里的键优先生效。
+
+### 在同机服务第二个用户
+
+```sh
+cd path/to/firstinstance
+./bin/init-instance second          # 在 ./second 生成全新隔离副本
+cd second
+#  编辑 instance.env，填入第二个用户的 appId/appSecret/api key
+./bin/start
+```
+
+## 验证
+
+- `bin/start --dump-config` 能拼出 dsh-feishu 行（拼装无需凭据；真正启动需要
+  真实 app + API key）。
+- 设置凭据后 `bin/start` 输出 `[feishu] bridge ready`。
+- 端到端 bot 路径（群内一次真实 turn）需由操作者针对真实飞书应用验证 —— CI
+  不驱动真实 bot。
+
+## 说明 / 限制
+
+- 目标为 **glibc x86_64 Linux**；musl/Alpine 需要 musl 版 Node。
+- 每个实例需要自己的飞书应用（独立 appId/appSecret/bot/团队）。
+- 群必须已固定工作目录（通过 `/repo` 或 `/cd` 选择）；`defaultCwd` 只是回退，
+  绝不是隐式选择。
+- 包从当前工作树构建；请基于干净的 `main` checkout 构建，使产物与发布一致。

--- a/scripts/package-portable.d.mts
+++ b/scripts/package-portable.d.mts
@@ -1,0 +1,40 @@
+/** Type declarations for the portable-deployment packager (`package-portable.mjs`). */
+
+export interface PackResult {
+  readonly dir: string;
+  readonly tarPath?: string;
+  readonly packageName: string;
+  readonly nodeVersion: string;
+  readonly sourceSha: string;
+}
+
+export function resolveNodeVersion(major?: string): Promise<string>;
+export function provideNode(dest: string, version: string): Promise<string>;
+export function buildBundle(bundleDir: string): Promise<void>;
+export function installDshAnchor(
+  anchorDir: string,
+  nodeBin: string,
+  dshVersion: string,
+  bundleDir: string,
+  opts?: { readonly cache?: string },
+): Promise<string>;
+export function installBundleRuntimeDeps(
+  bundleDir: string,
+  nodeBin: string,
+  opts?: { readonly cache?: string },
+): Promise<void>;
+export function writeTemplateHome(
+  homeDir: string,
+  bundleDir: string,
+  anchorDir: string,
+): Promise<void>;
+export function bootstrapFiles(): Record<string, string>;
+export function buildPortablePackage(opts?: {
+  readonly outDir?: string;
+  readonly nodeMajor?: string;
+  readonly nodeVersion?: string;
+  readonly dshVersion?: string;
+  readonly packageName?: string;
+  readonly skipTarball?: boolean;
+}): Promise<PackResult>;
+export function main(argv?: readonly string[]): Promise<void>;

--- a/scripts/package-portable.mjs
+++ b/scripts/package-portable.mjs
@@ -1,0 +1,542 @@
+#!/usr/bin/env node
+/**
+ * package-portable.mjs
+ *
+ * Build a self-contained, "green" deployment directory for dsh-feishu on
+ * Linux (x86_64, glibc): a bundled Node runtime, a real DSH CLI install
+ * (the harness family it ships plus every bundle/service a Feishu profile
+ * needs), the dsh-feishu bundle built from `main`, a credential-free
+ * profile-home template, and per-instance launchers. Deploying = copying
+ * the produced directory to a host and running `bin/start` (or
+ * `bin/init-instance` for a fresh instance) — no system Node, no network.
+ *
+ * Model (see docs/portable-deployment.md):
+ *  - One instance = one copy of the produced directory, with its own
+ *    DSH_HOME (`home/`), its own Feishu app (appId/appSecret from
+ *    `instance.env`), own dataDir, API key, and model.
+ *  - dsh resolves bundle layers from INSTALL_ANCHOR (the vendored dsh app
+ *    install) first, then the profile's own node_modules. We vendor a REAL
+ *    `npm install @deepseek-ai/dsh@<pin>` tree as the anchor and supplement
+ *    it with every bundle/service a Feishu profile requires, so boot is
+ *    fully offline (no pnpm, no registry). The harness family lives ONCE
+ *    (in the anchor); the profile layer only ships the dsh-feishu bundle
+ *    plus its non-harness runtime deps, with harness peers symlinked from
+ *    the anchor — never a second copy (double-install breaks module state).
+ *  - The build host must be Linux x86_64 glibc (vendored native prebuilds
+ *    — sharp, node-pty, rollup, koffi, … — are platform-selected).
+ */
+
+import { spawn } from 'node:child_process';
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+const DEFAULT_OUT_DIR = join(REPO_ROOT, '_dev', 'portable');
+const NAME_BASE = 'dsh-feishu-portable-linux-x64';
+
+/* ── helpers ────────────────────────────────────────────────────────────── */
+
+/** Spawn a command, resolve on exit 0, reject with captured stderr otherwise. */
+function run(cmd, args, opts = {}) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'], ...opts });
+    let out = '';
+    let err = '';
+    child.stdout.on('data', (d) => (out += d.toString()));
+    child.stderr.on('data', (d) => (err += d.toString()));
+    child.on('error', (e) => rejectPromise(e));
+    child.on('close', (code) =>
+      code === 0
+        ? resolvePromise({ out, err })
+        : rejectPromise(new Error(`${basename(cmd)} ${args.join(' ')} exited ${code}\n${err}`)),
+    );
+  });
+}
+
+/** The npm CLI shipped inside the bundled node, invoked via that node. */
+function npmArgs(nodeBin, args) {
+  const nodeDir = dirname(nodeBin); // <runtime>/node/bin
+  const npmCli = join(nodeDir, '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js');
+  return [npmCli, ...args];
+}
+
+/** Read the package.json of a package dir. */
+function readPkg(dir) {
+  return JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'));
+}
+
+/** dsh family version (from dsh's dep spec on dsh-base), as a caret range. */
+function familyVersion(dshDir) {
+  return readPkg(dshDir).dependencies?.['@deepseek-ai/dsh-base'] ?? '^0.1.1-rc.2';
+}
+
+/** The `@deepseek-ai/*` package names referenced by the dsh-feishu bundle
+ *  patch (its `cordis.patch.yml`), extracted from the `name:` fields. A regex
+ *  is used because the patch carries `!!js` expressions (a dsh home-path
+ *  tag) that a plain YAML parse rejects; we only ever need the names. */
+function patchPackages(bundleDir) {
+  const text = readFileSync(join(bundleDir, 'cordis.patch.yml'), 'utf8');
+  const names = new Set();
+  for (const match of text.matchAll(/\bname:\s*['"]?@deepseek-ai\/([a-z0-9-]+)['"]?/g)) {
+    names.add(`@deepseek-ai/${match[1]}`);
+  }
+  return [...names];
+}
+
+/** Every `@deepseek-ai/*` name a Feishu profile must resolve at boot: the
+ *  bundle-layer packages referenced by `cordis.patch.yml` plus the plugin's
+ *  peer dependencies (the harness services/libraries it imports). */
+function requiredHostPackages(bundleDir) {
+  const names = new Set(['@deepseek-ai/dsh-base', ...patchPackages(bundleDir)]);
+  for (const peer of Object.keys(readPkg(bundleDir).peerDependencies ?? {})) {
+    if (peer.startsWith('@deepseek-ai/')) names.add(peer);
+  }
+  return [...names];
+}
+
+/** The profile `dsh.profile.bundles` layer list: ONLY the packages that are
+ *  actual bundles (export a `dsh.bundle.patch`). For the Feishu surface that
+ *  is dsh-base and the dsh-feishu plugin; the patch's other referenced
+ *  service packages (storage-family, workspace, schedule, tool-ask-user) are
+ *  resolved from the anchor, not bundle layers. Listing a non-bundle here
+ *  fails loud in loadProfile ("declares no dsh.bundle"). */
+function profileLayers(bundleDir) {
+  return ['@deepseek-ai/dsh-base', readPkg(bundleDir).name];
+}
+
+/** The dsh-feishu plugin's non-harness runtime dependencies (installed into
+ *  the bundle's own node_modules so the bundle resolves its libs offline —
+ *  both when booted in dsh and when run standalone via `bin/setup`). */
+function pluginRuntimeDeps(bundleDir) {
+  return Object.entries(readPkg(bundleDir).dependencies ?? {})
+    .filter(([name]) => !name.startsWith('@deepseek-ai/'))
+    .map(([name, spec]) => `${name}@${spec}`);
+}
+
+/** Install the plugin's non-harness runtime deps into the bundle directory. */
+export async function installBundleRuntimeDeps(bundleDir, nodeBin, opts = {}) {
+  const deps = pluginRuntimeDeps(bundleDir);
+  if (deps.length === 0) return;
+  await npmInstall(nodeBin, bundleDir, deps, { ...opts, extra: ['--legacy-peer-deps'] });
+}
+
+/* ── build steps ────────────────────────────────────────────────────────── */
+
+/** Latest LTS patch within a major, from the official nodejs dist index. */
+export async function resolveNodeVersion(major = '22') {
+  const { out } = await run('curl', ['-sL', '-m', '40', 'https://nodejs.org/dist/index.json']);
+  const versions = JSON.parse(out);
+  const hit = versions.find((v) => v.version.startsWith(`v${major}.`) && v.lts !== false);
+  if (hit === undefined) throw new Error(`no LTS release for node major ${major}`);
+  return hit.version;
+}
+
+/** Download (or reuse) a node tarball and extract `bin/node` into `dest`.
+ *  The tarball is cached in the checkout's `_dev/portable/.cache` (writable
+ *  and reused on a rebuild of the same checkout). Set PORTABLE_NODE_CACHE /
+ *  PORTABLE_NODE_TARBALL to a shared path to reuse one download across
+ *  worktrees/hosts — the ~30 MB archive is the slow part; extraction is cheap. */
+export async function provideNode(dest, version) {
+  mkdirSync(dest, { recursive: true });
+  if (!existsSync(join(dest, 'bin', 'node'))) {
+    const cache = process.env.PORTABLE_NODE_CACHE ?? join(DEFAULT_OUT_DIR, '.cache');
+    mkdirSync(cache, { recursive: true });
+    const tarball =
+      process.env.PORTABLE_NODE_TARBALL ?? join(cache, `node-${version}-linux-x64.tar.xz`);
+    if (!existsSync(tarball)) {
+      const url = `https://nodejs.org/dist/${version}/node-${version}-linux-x64.tar.xz`;
+      process.stderr.write(`[portable] downloading ${url}\n`);
+      await run('curl', ['-sL', '-m', '600', '-o', tarball, url], {
+        maxBuffer: 1024 * 1024 * 1024,
+      });
+    } else {
+      process.stderr.write(`[portable] using cached node tarball ${tarball}\n`);
+    }
+    await run('tar', ['-xJf', tarball, '-C', dest, '--strip-components=1'], {
+      maxBuffer: 1024 * 1024 * 1024,
+    });
+  }
+  return (await run(join(dest, 'bin', 'node'), ['--version'])).out.trim();
+}
+
+/** npm install (via the bundled node's npm) a spec list into a prefix. The
+ *  official registry + a writable per-build cache are forced (the harness
+ *  family is not fully mirrored on npmmirror, and `~/.npm` may be read-only). */
+async function npmInstall(nodeBin, prefix, specs, opts = {}) {
+  const cache = opts.cache ?? join(tmpdir(), 'dsh-portable-npm-cache');
+  await run(
+    nodeBin,
+    npmArgs(nodeBin, [
+      'install',
+      '--prefix',
+      prefix,
+      '--no-audit',
+      '--no-fund',
+      '--loglevel',
+      'error',
+      '--registry',
+      'https://registry.npmjs.org/',
+      '--cache',
+      cache,
+      '--userconfig',
+      '/dev/null',
+      '--fetch-retries',
+      '5',
+      ...(opts.extra ?? []),
+      ...specs,
+    ]),
+    { maxBuffer: 512 * 1024 * 1024 },
+  );
+}
+
+/** Build the dsh-feishu bundle from the current checkout into `bundleDir`. */
+export async function buildBundle(bundleDir) {
+  const tsc = join(REPO_ROOT, 'node_modules', '.bin', 'tsc');
+  await run(tsc, ['-p', join(REPO_ROOT, 'tsconfig.build.json')]);
+  // Copy the npm `files` whitelist plus the manifest (npm ships package.json
+  // automatically, but we copy the bundle by hand). LICENSE too.
+  const entries = new Set(readPkg(REPO_ROOT).files ?? []);
+  for (const must of ['package.json', 'LICENSE']) entries.add(must);
+  for (const entry of entries) {
+    const src = join(REPO_ROOT, entry);
+    if (existsSync(src)) cpSync(src, join(bundleDir, entry), { recursive: true });
+  }
+  for (const must of ['lib', 'cordis.patch.yml', 'package.json', 'README.md']) {
+    if (!existsSync(join(bundleDir, must))) {
+      throw new Error(`bundle build did not produce required part: ${must}`);
+    }
+  }
+}
+
+/** Vendor the DSH CLI plus every service/bundle a Feishu profile needs into
+ *  an app prefix (the INSTALL_ANCHOR), so bundle resolution is offline. */
+export async function installDshAnchor(anchorDir, nodeBin, dshVersion, bundleDir, opts = {}) {
+  await npmInstall(nodeBin, anchorDir, [`@deepseek-ai/dsh@${dshVersion}`], opts);
+  const dshDir = join(anchorDir, 'node_modules', '@deepseek-ai', 'dsh');
+  if (!existsSync(dshDir)) throw new Error(`@deepseek-ai/dsh@${dshVersion} did not install`);
+  const family = familyVersion(dshDir);
+  const need = requiredHostPackages(bundleDir);
+  const missing = need.filter((n) => !existsSync(join(anchorDir, 'node_modules', n)));
+  if (missing.length > 0) {
+    process.stderr.write(
+      `[portable] supplementing anchor with ${missing.length} package(s): ${missing.join(', ')}\n`,
+    );
+    await npmInstall(
+      nodeBin,
+      anchorDir,
+      missing.map((n) => `${n}@${family}`),
+      opts,
+    );
+  }
+  const still = need.filter((n) => !existsSync(join(anchorDir, 'node_modules', n)));
+  if (still.length > 0) {
+    throw new Error(
+      `cannot resolve Feishu host packages: ${still.join(', ')} — install \`` +
+        'npm i <pkg>@<family>` into the anchor and rebuild',
+    );
+  }
+  return dshDir;
+}
+
+/** Write the credential-free DSH-HOME template used by deployed instances. */
+export async function writeTemplateHome(homeDir, bundleDir, anchorDir) {
+  const profileDir = join(homeDir, 'profiles', 'feishu');
+  mkdirSync(profileDir, { recursive: true });
+  const pluginName = readPkg(bundleDir).name;
+  writeFileSync(
+    join(profileDir, 'package.json'),
+    JSON.stringify(
+      { private: true, dsh: { profile: { bundles: profileLayers(bundleDir) } } },
+      null,
+      2,
+    ) + '\n',
+  );
+
+  const nm = join(profileDir, 'node_modules');
+  mkdirSync(nm, { recursive: true });
+  // Every @deepseek-ai peer must resolve from the ANCHOR (one copy only) —
+  // never a real duplicate in the profile (double-install breaks cordis
+  // module identity). npm may have planted a real cordis/dsh-* during the
+  // runtime-deps install; clear the subtree and RE-LINK from the anchor with
+  // package-relative symlinks, so the assembled tree stays relocatable (no
+  // absolute temp paths survive the build).
+  rmSync(join(nm, '@deepseek-ai'), { recursive: true, force: true });
+  const linkRelative = (linkPath, target) => {
+    rmSync(linkPath, { recursive: true, force: true });
+    mkdirSync(dirname(linkPath), { recursive: true });
+    try {
+      symlinkSync(relative(dirname(linkPath), target), linkPath);
+    } catch {
+      cpSync(target, linkPath, { recursive: true });
+    }
+  };
+  // The bundle itself, then every harness peer, both as package-relative
+  // links into their real location (bundle/ + runtime/app/node_modules).
+  linkRelative(join(nm, '@dsh-feishu', pluginName.split('/').pop() ?? pluginName), bundleDir);
+  for (const peer of Object.keys(readPkg(bundleDir).peerDependencies ?? {})) {
+    if (!peer.startsWith('@deepseek-ai/')) continue;
+    const anchorPkg = join(anchorDir, 'node_modules', peer);
+    if (existsSync(anchorPkg)) linkRelative(join(nm, peer), anchorPkg);
+  }
+  // The user-layer patch: feishu row with no credentials (env fallback).
+  writeFileSync(
+    join(profileDir, 'cordis.patch.yml'),
+    `# dsh-feishu user layer for this instance.
+# Credentials and surface options come from instance.env by default (config
+# wins over env); set them here instead to pin them in the patch.
+- id: feishu
+  name: '${pluginName}'
+  config: {}
+`,
+  );
+}
+
+/** Static files installed into the package (launchers + per-instance docs). */
+export function bootstrapFiles() {
+  return {
+    'bin/dsh-feishu': `#!/usr/bin/env bash
+# dsh-feishu launcher: run THIS deployed instance. Each copy of the package
+# is its own instance (own home, app, api key, model).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+export PATH="$ROOT/runtime/node/bin:$PATH"
+if [ -f "$ROOT/instance.env" ]; then
+  set -a; . "$ROOT/instance.env"; set +a
+fi
+export DSH_HOME="\${DSH_HOME:-$ROOT/home}"
+export DSH_FEISHU_SESSION="\${DSH_FEISHU_SESSION:-$DSH_HOME/feishu-session.json}"
+export NODE="$ROOT/runtime/node/bin/node"
+exec "$NODE" "$ROOT/runtime/app/node_modules/@deepseek-ai/dsh/lib/bin.js" --profile feishu "$@"
+`,
+    'bin/start': `#!/usr/bin/env bash
+# Start this deployed dsh-feishu instance.
+set -euo pipefail
+exec "$(cd "$(dirname "$0")" && pwd)/dsh-feishu" "$@"
+`,
+    'bin/setup': `#!/usr/bin/env bash
+# One QR scan: create + configure the Feishu app for THIS instance and write
+# appId/appSecret into its home/profiles/feishu/cordis.patch.yml. Re-run
+# against an existing app with --app-id <cli_...> to reconfigure it.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+export PATH="$ROOT/runtime/node/bin:$PATH"
+if [ -f "$ROOT/instance.env" ]; then
+  set -a; . "$ROOT/instance.env"; set +a
+fi
+export DSH_HOME="\${DSH_HOME:-$ROOT/home}"
+export DSH_FEISHU_SESSION="\${DSH_FEISHU_SESSION:-$DSH_HOME/feishu-session.json}"
+exec "$ROOT/runtime/node/bin/node" "$ROOT/bundle/dsh-feishu/lib/setup/cli.js" \
+  --dsh-home "$DSH_HOME" --profile feishu "$@"
+`,
+    'bin/init-instance': `#!/usr/bin/env bash
+# Create a NEW isolated instance as a full copy of this package, with a fresh
+# instance.env to fill in.  Usage:  bin/init-instance <name> [dest-dir]
+set -euo pipefail
+NAME="\${1:?usage: bin/init-instance <name> [dest-dir]}"
+SRC="$(cd "$(dirname "$0")/.." && pwd)"
+DEST="\${2:-"$(dirname "$SRC")/$NAME"}"
+if [ -e "$DEST" ]; then echo "error: $DEST already exists" >&2; exit 1; fi
+echo "copying $SRC -> $DEST"
+cp -a "$SRC" "$DEST"
+cp "$DEST/instance.env.example" "$DEST/instance.env"
+echo "instance created at $DEST"
+echo "1) edit $DEST/instance.env (FEISHU_APP_ID/SECRET, DEEPSEEK_API_KEY, …)"
+echo "2) run:  $DEST/bin/start"
+`,
+    'instance.env.example': `# Per-instance credentials & options. Config in the profile patch wins over these.
+FEISHU_APP_ID=cli_xxxxxxxxxxxxxxxx
+FEISHU_APP_SECRET=yyyyyyyyyyyyyyyyyyyyyyyy
+DEEPSEEK_API_KEY=sk-xxxxxxxxxxxxxxxx
+# Comma-separated Feishu user open ids allowed to use this bot (empty = all).
+# FEISHU_ALLOWED_USERS=
+# The chat must have a working directory pinned (via /repo or /cd).
+# defaultCwd=/path/to/workspace
+# model=deepseek-v4-flash
+# Unset the ambient proxy so the Feishu long connection is not sandboxed.
+unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
+`,
+    'README-PORTABLE.md': `# dsh-feishu portable deployment (Linux x64)
+
+A self-contained dsh-feishu deployment: bundled Node, DSH CLI + harness, the
+dsh-feishu bundle, a credential-free profile home, and per-instance launchers.
+Copy the directory to a Linux x86_64 (glibc) host and run it — no system Node,
+no network, no pnpm.
+
+**One copy = one instance.** Each copy has its own home, Feishu app
+(appId/appSecret), API key, and model. Run separate copies (or
+\`bin/init-instance\`) to serve multiple users on one server with isolation.
+
+## First deployment
+\`\`\`sh
+cp dsh-feishu-portable-linux-x64-* yourinstance
+cd yourinstance
+cp instance.env.example instance.env
+#  edit instance.env: FEISHU_APP_ID/SECRET, DEEPSEEK_API_KEY, …
+./bin/start
+\`\`\`
+
+## Create + configure the Feishu app (one QR scan)
+\`\`\`sh
+cd yourinstance
+./bin/setup            # one QR scan creates + configures the app, writes
+                       # appId/appSecret into home/profiles/feishu/cordis.patch.yml
+\`\`\`
+Re-run \`./bin/setup --app-id cli_xxx\` to reconfigure an existing app.
+
+## Another instance on the same server
+\`\`\`sh
+cd path/to/yourfirstinstance
+./bin/init-instance second   # creates ./second as a fresh isolated copy
+cd second
+#  edit instance.env with the second instance's own app + key
+./bin/setup                  # create + configure the second instance's app
+./bin/start
+\`\`\`
+
+## Verify
+- \`./bin/start --dump-config\` prints the composed dsh-feishu row (no
+  credentials needed to compose; booting needs a real app + api key).
+- With credentials set, \`./bin/start\` logs \`[feishu] bridge ready\`.
+
+## Notes
+- Target is glibc x86_64 Linux; musl/Alpine needs a musl Node build.
+- Each instance needs its own Feishu app (separate appId/appSecret/bot/team).
+- The chat must have a working directory pinned (choose via /repo or /cd).
+- \`bin/start\` sources \`instance.env\`; config in
+  \`<instance>/home/profiles/feishu/cordis.patch.yml\` wins over env.
+`,
+  };
+}
+
+/* ── orchestration ──────────────────────────────────────────────────────── */
+
+/** Assemble the package directory (and, unless `skipTarball`, a .tar.gz). */
+export async function buildPortablePackage(opts = {}) {
+  const outRoot = resolve(opts.outDir ?? process.env.PORTABLE_OUT_DIR ?? DEFAULT_OUT_DIR);
+  const nodeMajor = opts.nodeMajor ?? process.env.PORTABLE_NODE_MAJOR ?? '22';
+  const dshVersion =
+    opts.dshVersion ??
+    process.env.PORTABLE_DSH_VERSION ??
+    readPkg(REPO_ROOT).devDependencies['@deepseek-ai/dsh'];
+  if (process.platform !== 'linux' || process.arch !== 'x64') {
+    throw new Error(
+      `portable package requires linux x64 (glibc); got ${process.platform}/${process.arch}`,
+    );
+  }
+  const nodeVersion = opts.nodeVersion ?? (await resolveNodeVersion(nodeMajor));
+  const pluginVersion = readPkg(REPO_ROOT).version;
+  let sourceSha = 'unknown';
+  try {
+    sourceSha = (await run('git', ['-C', REPO_ROOT, 'rev-parse', '--short', 'HEAD'])).out.trim();
+  } catch {}
+
+  const packageName = opts.packageName ?? `${NAME_BASE}-v${pluginVersion}-${sourceSha}`;
+  const outDir = join(outRoot, packageName);
+  // Build into a sibling `.part` dir on the SAME filesystem, then rename —
+  // atomic and, crucially, preserves the package-relative symlinks (a
+  // cross-device cpSync could dereference them or leave dangling temp links).
+  const partDir = join(outRoot, `.${packageName}.part`);
+  rmSync(partDir, { recursive: true, force: true });
+  mkdirSync(partDir, { recursive: true });
+  const npmOpts = { cache: process.env.PORTABLE_NPM_CACHE ?? join(outRoot, '.npm-cache') };
+
+  // 1) Build the bundle from the checkout.
+  const bundleDir = join(partDir, 'bundle', 'dsh-feishu');
+  await buildBundle(bundleDir);
+
+  // 2) Bundled Node runtime.
+  const nodeDir = join(partDir, 'runtime', 'node');
+  const nodeBin = join(nodeDir, 'bin', 'node');
+  const actualNode = await provideNode(nodeDir, nodeVersion);
+
+  // 3) DSH CLI install anchor (+ supplements).
+  const appDir = join(partDir, 'runtime', 'app');
+  await installDshAnchor(appDir, nodeBin, dshVersion, bundleDir, npmOpts);
+
+  // 4) Credential-free profile-home template.
+  await writeTemplateHome(join(partDir, 'home'), bundleDir, appDir);
+
+  // 5) Bundle self-contained runtime deps (for dsh boot AND `bin/setup`).
+  await installBundleRuntimeDeps(bundleDir, nodeBin, npmOpts);
+
+  // 6) Launchers + docs.
+  for (const [rel, content] of Object.entries(bootstrapFiles())) {
+    const p = join(partDir, rel);
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, content, 'utf8');
+    if (rel.startsWith('bin/')) chmodSync(p, 0o755);
+  }
+
+  // 7) Provenance manifest.
+  writeFileSync(
+    join(partDir, 'portable.json'),
+    JSON.stringify(
+      {
+        product: 'dsh-feishu',
+        pluginVersion,
+        dsh: dshVersion,
+        node: actualNode,
+        platform: 'linux-x64',
+        libc: 'glibc',
+        source: { branch: 'main', sha: sourceSha },
+        builtAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    ) + '\n',
+  );
+
+  // Atomic publish: rename the finished part dir into place.
+  mkdirSync(outRoot, { recursive: true });
+  rmSync(outDir, { recursive: true, force: true });
+  renameSync(partDir, outDir);
+
+  let tarPath;
+  if (!opts.skipTarball) {
+    tarPath = join(outRoot, `${packageName}.tar.gz`);
+    rmSync(tarPath, { force: true });
+    await run('tar', ['-czf', tarPath, '-C', outRoot, packageName]);
+  }
+
+  return { dir: outDir, tarPath, packageName, nodeVersion: actualNode, sourceSha };
+}
+
+/** CLI entry. */
+export async function main(argv = process.argv.slice(2)) {
+  const args = new Set(argv);
+  try {
+    const result = await buildPortablePackage({
+      skipTarball: args.has('--no-tarball'),
+      nodeVersion: process.env.PORTABLE_NODE_VERSION,
+      nodeMajor: process.env.PORTABLE_NODE_MAJOR,
+      dshVersion: process.env.PORTABLE_DSH_VERSION,
+      outDir: process.env.PORTABLE_OUT_DIR,
+      packageName: process.env.PORTABLE_PACKAGE_NAME,
+    });
+    process.stdout.write(
+      `[portable] built ${result.packageName} (node ${result.nodeVersion}, source ${result.sourceSha})\n` +
+        `  dir:   ${result.dir}\n` +
+        (result.tarPath ? `  tarball: ${result.tarPath}\n` : ''),
+    );
+  } catch (error) {
+    process.stderr.write(`[portable] ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+// Direct execution (the bin entry runs main); imported modules just export.
+if (import.meta.main) {
+  void main();
+}

--- a/tests/portable.spec.ts
+++ b/tests/portable.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for the portable-deployment packager (`scripts/package-portable.mjs`).
+ * The heavy, network-bound path (node download + `npm install` of the DSH
+ * anchor) is verified end-to-end by `buildPortablePackage` / the `--dump-config`
+ * smoke test in the PR body; here we cover the deterministic, offline parts
+ * (the shipped launcher/doc files and the module surface).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  bootstrapFiles,
+  buildBundle,
+  buildPortablePackage,
+  installBundleRuntimeDeps,
+  installDshAnchor,
+  main,
+  provideNode,
+  resolveNodeVersion,
+  writeTemplateHome,
+} from '../scripts/package-portable.mjs';
+
+describe('package-portable', () => {
+  it('exposes the expected build/verify surface', () => {
+    expect(typeof main).toBe('function');
+    expect(typeof buildPortablePackage).toBe('function');
+    expect(typeof buildBundle).toBe('function');
+    expect(typeof provideNode).toBe('function');
+    expect(typeof installDshAnchor).toBe('function');
+    expect(typeof installBundleRuntimeDeps).toBe('function');
+    expect(typeof writeTemplateHome).toBe('function');
+    expect(typeof resolveNodeVersion).toBe('function');
+  });
+
+  it('ships every per-instance launcher and the deployment readme', () => {
+    const files = bootstrapFiles();
+    for (const rel of [
+      'bin/dsh-feishu',
+      'bin/start',
+      'bin/setup',
+      'bin/init-instance',
+      'instance.env.example',
+      'README-PORTABLE.md',
+    ]) {
+      expect(Object.hasOwn(files, rel)).toBe(true);
+      expect((files[rel] ?? '').length).toBeGreaterThan(0);
+    }
+  });
+
+  it('setup launcher runs the bundle quick-setup wizard against the instance home', () => {
+    const setup = bootstrapFiles()['bin/setup'];
+    expect(setup).toContain('--profile feishu');
+    expect(setup).toContain('--dsh-home "$DSH_HOME"');
+    expect(setup).toContain('bundle/dsh-feishu/lib/setup/cli.js');
+    expect(setup).toContain('DSH_FEISHU_SESSION');
+  });
+
+  it('launcher boots the bundled dsh entry and binds the instance home', () => {
+    const launcher = bootstrapFiles()['bin/dsh-feishu'];
+    expect(launcher).toContain('--profile feishu');
+    expect(launcher).toContain('export DSH_HOME="${DSH_HOME:-$ROOT/home}"');
+    expect(launcher).toContain('instance.env');
+    expect(launcher).toContain('runtime/node/bin');
+    expect(launcher).toContain('runtime/app/node_modules/@deepseek-ai/dsh/lib/bin.js');
+  });
+
+  it('instance.env example carries the per-instance credentials and unsets the proxy', () => {
+    const env = bootstrapFiles()['instance.env.example'];
+    for (const key of ['FEISHU_APP_ID', 'FEISHU_APP_SECRET', 'DEEPSEEK_API_KEY']) {
+      expect(env).toContain(key);
+    }
+    expect(env).toContain('unset http_proxy https_proxy');
+  });
+});


### PR DESCRIPTION
## What

Add `scripts/package-portable.mjs`, which builds a **self-contained "green" deployment package** for dsh-feishu on Linux x86_64 (glibc): bundled Node 22 LTS, the DSH CLI + harness (a real `npm install @deepseek-ai/dsh@<pin>` tree used as the bundle-install anchor, supplemented with every `@deepseek-ai/*` a Feishu profile needs), the dsh-feishu bundle built from `main`, a credential-free profile-home template, and per-instance launchers. Deploying = copy the directory to a host and run `bin/start` — no system Node, no network, no pnpm.

One copy = one instance: each copy has its own `DSH_HOME`, Feishu app (appId/appSecret), API key, and model, so one server serves many isolated users.

## Why

Running multiple dsh+dsh-feishu instances on a single server previously required a system Node, a network install at deploy time, and manual home-dir/per-instance separation. This packages a green directory embeddable on a fresh Linux x64 host, with per-instance isolation by construction.

## Design (see docs/portable-deployment.md)

- **Offline bundle resolution** mirrors dsh's rule: resolve bundle layers from `INSTALL_ANCHOR` (the vendored dsh install) first, then the profile's `node_modules`. The harness family lives ONCE (in the anchor); the profile layer ships only the dsh-feishu bundle (with its own non-harness runtime deps), and harness peers are package-relative **symlinks** into the anchor — never a duplicate (a second copy would break cordis module identity, the double-install bug class).
- **`dsh.profile.bundles`** lists only real bundles: `@deepseek-ai/dsh-base` + the dsh-feishu plugin. The patch's other referenced packages (storage-family, workspace, schedule, tool-ask-user) are services resolved from the anchor, not layers — listed as a layer they'd fail loadProfile ("declares no dsh.bundle").
- **`bin/setup`** runs the bundle's quick-setup wizard (`--dsh-home <instance> --profile feishu`): one QR scan creates + configures the Feishu app and writes credentials into the instance's `cordis.patch.yml`. The bundle ships its own runtime deps so the wizard resolves offline.
- **Node tarball caching**: the downloaded `node-v22-…-linux-x64.tar.xz` is cached in the checkout's `_dev/portable/.cache` (reused on rebuild; `PORTABLE_NODE_CACHE`/`PORTABLE_NODE_TARBALL` to share across worktrees) — the ~30 MB download is the slow part and is not repeated.
- Strict build preconditions: Linux x64 required; platform-selected native prebuilds (sharp/node-pty/rollup/koffi/lzma) make musl/Alpine out of scope (documented).

## Files

- `scripts/package-portable.mjs` (+ `.d.mts`) — the builder (importable functions + `main()`).
- `tests/portable.spec.ts` — unit tests for the shipped launcher/doc files and module surface (the heavy network path is verified end-to-end in the PR body).
- `docs/portable-deployment.md` / `.zh.md` — build, layout, multi-instance model, first-deploy + `bin/setup`, notes/limits.
- `docs/development.md` / `.zh.md` — documentation-map entry.

## Verification

- `node scripts/package-portable.mjs` exits 0, emitting
  `_dev/portable/dsh-feishu-portable-linux-x64-v<version>-<sha>/` + `.tar.gz` (git-ignored).
- **Clean-env proof**: `env -i PATH=/usr/bin:/bin HOME=/tmp <pkg>/bin/start --dump-config` composes the dsh-feishu row **without system Node on PATH and offline** — node runtime, dsh CLI, bundle, and profile all resolve from the package. Output shows the `@dsh-feishu/dsh-feishu` section (feishu + tool-ask-user + schedule + storage-json + workspace rows).
- Profile harness peers are all package-relative symlinks into the anchor (no duplicate cordis/harness).
- `pnpm run check` passes; lint/typecheck green locally. Full unit suite runs in CI (this adds `tests/portable.spec.ts`; no `src/` behavior change).
- **End-to-end bot path** (a real turn in a group) must be verified by the operator against a real Feishu app via `bin/setup` + `bin/start` — CI cannot drive a real bot.

## Docs

`## Docs`: `docs/portable-deployment.md` + `.zh.md` (new), `docs/development.md` + `.zh.md` (map row). README unchanged (maintainer-gated).

## Wait for review

This PR is intentionally left for maintainer review before merge. The built package is git-ignored and not committed; only the builder script + docs ship.