### PR TITLE
fix(transport): read the bot open id from bot.open_id, not data.open_id

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -168,6 +168,17 @@ The harness sandbox (and this checkout's environment) has specific rules:
   (always/never/ambient/topic). In 1-person-1-bot solo groups the `@`
   requirement is relaxed (`isSoloGroup`).
 - `allowedChats` is an allowlist; chats outside it are ignored entirely.
+- **`bot/v3/info` nests the bot's own open id under `bot.open_id`, not
+  `data.open_id`.** The mention gate compares each inbound group message's
+  mention list against `transport.getBotOpenId()`; if that id is never
+  resolved, `mentioned` is always false and every group message (even a
+  real `@`) reads as "not mentioned" under `always`/`topic` — the bot
+  silently ignores all group traffic. Symptom: "ignoring group message: bot
+  not mentioned" while the user did `@` the bot, with no error anywhere.
+  Fix: parse both shapes (`parseBotOpenId`), and warn loudly at boot when
+  the response carries no open id instead of failing silently. Verify the
+  live shape with the real app — the SDK's `request` returns the raw body
+  with `bot` at the top level.
 
 ## Git discovery vs. scan roots
 

--- a/docs/pitfalls.zh.md
+++ b/docs/pitfalls.zh.md
@@ -149,6 +149,15 @@ harness 沙箱（以及本 checkout 的环境）有一些特定规则：
   兼容（always/never/ambient/topic）。在 1 人 1 bot 的私人群中，`@`
   要求被放宽（`isSoloGroup`）。
 - `allowedChats` 是一个 allowlist；其外的聊天会被完全忽略。
+- **`bot/v3/info` 把 bot 自己的 open_id 放在 `bot.open_id` 下，而不是
+  `data.open_id`。** 提及门禁把每条入站群消息的提及列表与
+  `transport.getBotOpenId()` 比对；如果该 id 从未被解析出来，`mentioned`
+  恒为 false，于是 `always`/`topic` 模式下每条群消息（哪怕真的 `@` 了）
+  都被判为"未提及"——bot 静默忽略所有群消息。症状：日志里出现
+  "ignoring group message: bot not mentioned"，但用户确实 `@` 了 bot，
+  且全程没有任何报错。修复：同时解析两种结构（`parseBotOpenId`），并且
+  当响应不带 open_id 时在启动时大声告警，而不是静默失败。请用真实应用
+  验证线上结构——SDK 的 `request` 返回的是原始 body，`bot` 在顶层。
 
 ## Git 发现 vs 扫描根目录
 

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -227,6 +227,21 @@ export function normalizeMessageEvent(data: RawMessageEvent): FeishuMessage | un
 }
 
 /**
+ * Parse the bot's own open id out of a `bot/v3/info` response. The current
+ * API nests it under `bot.open_id`; the legacy shape put it under
+ * `data.open_id`. Reading only one of the two silently disables the group
+ * mention gate (every @-mention looks like a plain message). Pure function —
+ * unit-testable without any SDK connection.
+ * @param response - the parsed `bot/v3/info` body (code must already be 0).
+ * @returns the bot's open id, or `undefined` when the body carries none.
+ */
+export function parseBotOpenId(response: unknown): string | undefined {
+  const body = response as { bot?: { open_id?: string }; data?: { open_id?: string } };
+  const openId = body.bot?.open_id ?? body.data?.open_id;
+  return openId !== undefined && openId !== '' ? openId : undefined;
+}
+
+/**
  * Normalize a raw `card.action.trigger` payload into a surface action, or
  * `undefined` when no actionable payload is present. Message/chat ids may be
  * nested under `context` (current v2 shape) or at the root (fallback).
@@ -374,17 +389,31 @@ export class LarkTransport implements FeishuTransport {
 
   /** Fetch and cache the bot's own open id (`bot/v3/info`). */
   private async resolveBotOpenId(): Promise<void> {
-    const response = await this.client.request<{
-      code?: number;
-      msg?: string;
-      data?: { open_id?: string };
-    }>({ method: 'GET', url: '/open-apis/bot/v3/info' });
-    const code = response?.code ?? -1;
+    const response = await this.client.request<unknown>({
+      method: 'GET',
+      url: '/open-apis/bot/v3/info',
+    });
+    const code = (response as { code?: number })?.code ?? -1;
     if (code !== 0) {
-      throw new FeishuApiError('bot.v3.info', code, response?.msg ?? 'unknown error');
+      throw new FeishuApiError(
+        'bot.v3.info',
+        code,
+        (response as { msg?: string })?.msg ?? 'unknown error',
+      );
     }
-    const openId = response.data?.open_id;
-    if (openId !== undefined && openId !== '') this.botOpenIdValue = openId;
+    const openId = parseBotOpenId(response);
+    if (openId !== undefined) {
+      this.botOpenIdValue = openId;
+      this.logger?.debug(`bot open id resolved: ${openId}`);
+    } else {
+      // Fail loud: the group mention gate needs the bot's own open id to tell
+      // "the bot was mentioned" apart from "someone else was mentioned". A
+      // bot whose id cannot be resolved leaves every group @-mention looking
+      // like a plain message under `always`/`topic` modes.
+      this.logger?.warn(
+        'bot/v3/info succeeded but carried no bot open id — group mention detection is disabled',
+      );
+    }
   }
 
   /** The bot's own open id, or `undefined` until resolved. */

--- a/tests/transport.spec.ts
+++ b/tests/transport.spec.ts
@@ -13,6 +13,7 @@ import {
   LarkTransport,
   normalizeCardAction,
   normalizeMessageEvent,
+  parseBotOpenId,
 } from '../src/transport.js';
 
 /** A minimal raw event with the fields the normalizer reads. */
@@ -422,6 +423,61 @@ describe('LarkTransport message-resource downloads', () => {
     await expect(transport.downloadFile('om_msg1', 'empty')).rejects.toThrow(
       /response carried no resource bytes/,
     );
+  });
+});
+
+describe('parseBotOpenId', () => {
+  it('parses the current bot/v3/info shape (bot.open_id)', () => {
+    expect(parseBotOpenId({ code: 0, bot: { open_id: 'ou_bot' }, msg: 'ok' })).toBe('ou_bot');
+  });
+
+  it('falls back to the legacy shape (data.open_id)', () => {
+    expect(parseBotOpenId({ code: 0, data: { open_id: 'ou_bot' } })).toBe('ou_bot');
+  });
+
+  it('returns undefined when the body carries no open id', () => {
+    expect(parseBotOpenId({ code: 0, bot: { activate_status: 2 } })).toBeUndefined();
+    expect(parseBotOpenId({ code: 0 })).toBeUndefined();
+    expect(parseBotOpenId({ code: 0, bot: { open_id: '' } })).toBeUndefined();
+  });
+});
+
+describe('LarkTransport.resolveBotOpenId', () => {
+  it('caches the bot open id from the current bot.open_id shape', async () => {
+    const transport = new LarkTransport({
+      credentials: { appId: 'cli_test', appSecret: 'secret' },
+    });
+    const request = vi.fn().mockResolvedValue({
+      code: 0,
+      msg: 'ok',
+      bot: { activate_status: 2, open_id: 'ou_bot', app_name: 'dsh-feishu-test' },
+    });
+    (transport as unknown as { client: { request: unknown } }).client = { request } as never;
+
+    await (transport as unknown as { resolveBotOpenId(): Promise<void> }).resolveBotOpenId();
+
+    expect(request).toHaveBeenCalledWith({ method: 'GET', url: '/open-apis/bot/v3/info' });
+    expect(transport.getBotOpenId()).toBe('ou_bot');
+  });
+
+  it('warns loudly and stays unresolved when the response carries no open id', async () => {
+    const warns: string[] = [];
+    const transport = new LarkTransport({
+      credentials: { appId: 'cli_test', appSecret: 'secret' },
+      logger: {
+        info: () => {},
+        warn: (message: string) => warns.push(message),
+        error: () => {},
+        debug: () => {},
+      },
+    });
+    const request = vi.fn().mockResolvedValue({ code: 0, msg: 'ok' });
+    (transport as unknown as { client: { request: unknown } }).client = { request } as never;
+
+    await (transport as unknown as { resolveBotOpenId(): Promise<void> }).resolveBotOpenId();
+
+    expect(transport.getBotOpenId()).toBeUndefined();
+    expect(warns.join(' ')).toContain('group mention detection is disabled');
   });
 });
 


### PR DESCRIPTION
## What

Fixes the group mention gate being permanently blind. `resolveBotOpenId` parsed the `bot/v3/info` response as `data.open_id`, but the live API nests the bot's own open id under **`bot.open_id`** — so the id was never captured, `getBotOpenId()` always returned `undefined`, and under `groupMentionMode: always`/`topic` every group message (even a real `@`-mention) read as "bot not mentioned" and was silently ignored.

## Why

Reported by the maintainer: in a multi-person group with `always` mode, `@`-mentioning the bot still logged "ignoring group message: bot not mentioned". Root cause verified against the real app — `bot/v3/info` returns `{ bot: { open_id: "...", ... }, code: 0 }`, no `data` object at all. The gate's `mentioned` check (`botOpenId !== undefined && mentions.includes(botOpenId)`) is then always false, so the bot ignores all group traffic under `always`/`topic` with no error anywhere (a silent failure).

## Changes

- **`src/transport.ts`**: new pure `parseBotOpenId()` accepting the current `bot.open_id` shape with a `data.open_id` (legacy) fallback; `resolveBotOpenId()` uses it and **warns loudly at boot** when the response carries no open id (per "fail loud" — a bot whose id can't be resolved leaves mention detection silently disabled).
- **`tests/transport.spec.ts`**: regression tests — parser (current shape / legacy shape / absent) + `resolveBotOpenId` end-to-end against the live `bot.open_id` shape via a fake client, plus the loud-warn path. The end-to-end test fails against the old code.
- **`docs/pitfalls.md` + `docs/pitfalls.zh.md`**: symptom / root-cause / fix entry under "Mention gate".

## Verification

- `pnpm run gates` — lint, typecheck, build, and the full test suite (incl. integration under `FEISHU_INT_REQUIRED=1`): **706 tests, 40 files, all green**.
- `pnpm run check` — all convention checks pass.
- Live API check: `bot/v3/info` returns `{ bot: { open_id: "ou_…" }, code: 0 }` for the test app — confirming the shape and that the id now resolves to the same id carried in group `@`-mentions.
- No new Feishu scope needed (`bot/v3/info` succeeds for the test app without `bot:read`).
