### PR TITLE
chore: release v0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsh-feishu/dsh-feishu",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "The Feishu UI for DeepSeek Harness (dsh) — a dsh-native plugin: live streaming cards, in-card questions & approvals, one-QR setup.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## What

Merge the v0.3.1 version bump back into `main`. `release/v0.3.1` was cut from `main @ ac9ab4cf` and, after the release gates ran green, carried `chore: release v0.3.1` (package.json 0.3.0 → 0.3.1). Merging it keeps `main`'s version in lockstep with the published npm release.

## Why

- `v0.3.1` is already published to npm (latest) and tagged (`v0.3.1`).
- `main` still shows `0.3.0`; a subsequent `patch` release from main would collide.
- This preserves the repo rule that a release is cut from a frozen `release/*` branch, and the bump is folded back so `main` always reflects the latest shipped version.

## Verification

- Release gates: lint, typecheck, build, and the full test suite (incl. integration under `FEISHU_INT_REQUIRED=1`) — 714 tests, all green.
- The Release workflow published `0.3.1` to npm and created GitHub Release `v0.3.1`.
- Only `package.json` (version) differs from `main`; no behavior change.
