### PR TITLE
fix: resolve agent options lazily so fresh sessions run the saved default model

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,7 +67,7 @@ Feishu user ──message──> Feishu platform ──WS long connection──>
 | `src/panel/views/` | Panel view **Strategy objects**: one `PanelViewState` per view (declaring its own `asyncData`) + `PanelViewRegistry`; the pickers are separate states (`picker:repo` / `picker:model` / `picker:permission`). |
 | `src/commands/surface.ts` | The surface command set: full registration of the plugin-owned slash commands (and their panel buttons) + `runHarnessCommand`, behind the `SurfaceCommandHost` seam. |
 | `src/bridge.ts` | **Facade + orchestration**: message routing (dedup, mention gate, slash dispatch), agent resolution ladder (live → resume mapped session → create → rebind fresh id on collision), the working-state and working-directory gates, the session lifecycle (`/sessions /resume /clear`), proactive mentions, and the four host seams (`StreamingCardHost` / `PanelHost` / `InteractionCardHost` / `SurfaceCommandHost`). All card surfaces live in the modules above. |
-| `src/index.ts` | Plugin entry: config, credential resolution, agent options (config or `agentDefaultModel`), wiring, `feishu-status` command. |
+| `src/index.ts` | Plugin entry: config, credential resolution, agent options (config or `agentDefaultModel`, resolved **lazily at each create/resume** — never snapshotted once at activation, see `docs/pitfalls.md` → "Activation-time snapshots of host services"), wiring, `feishu-status` command. |
 
 ## Key behaviors
 

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -58,7 +58,7 @@ Feishu user ──message──> Feishu platform ──WS long connection──>
 | `src/panel/views/` | 作为 **Strategy 对象**的面板视图：每个视图一个 `PanelViewState`（自声明 `asyncData`）+ `PanelViewRegistry`；选择器是独立状态（`picker:repo` / `picker:model` / `picker:permission`）。 |
 | `src/commands/surface.ts` | surface 命令集：插件自有斜杠命令（及其面板按钮）的完整注册 + `runHarnessCommand`，依赖 `SurfaceCommandHost` seam。 |
 | `src/bridge.ts` | **门面 + 编排**：消息路由（去重、提及 gate、斜杠分发）、agent 解析阶梯（live → 恢复已映射 session → 新建 → 冲突时重绑新 id）、工作状态与工作目录 gate、session 生命周期（`/sessions /resume /clear`）、主动提及，以及四个宿主 seam（`StreamingCardHost` / `PanelHost` / `InteractionCardHost` / `SurfaceCommandHost`）。所有卡片表面都位于上述模块。 |
-| `src/index.ts` | 插件入口：配置、凭据解析、agent 选项（配置或 `agentDefaultModel`）、接线、`feishu-status` 命令。 |
+| `src/index.ts` | 插件入口：配置、凭据解析、agent 选项（配置或 `agentDefaultModel`，在**每次 create/resume 时惰性解析**——绝不在激活时快照一次，见 `docs/pitfalls.md` → “宿主服务的激活期快照”）、接线、`feishu-status` 命令。 |
 
 ## 关键行为
 

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -258,6 +258,28 @@ The harness sandbox (and this checkout's environment) has specific rules:
   resumed chat
   is stuck behind the gate.
 
+## Activation-time snapshots of host services
+
+- Never read a host service's live value once at plugin activation and
+  cache it. `@deepseek-ai/dsh-base/cordis.patch.yml` mounts
+  `agent-default-model` with a hardcoded composition entry, and its
+  settings-backed user layer is wired in **after** the plugin may already
+  have run (mount-order race). The surface used to snapshot
+  `agentDefaultModel.currentSelection()` at activation and pass it as
+  static `agentOptions` on every create/resume — so after a restart the
+  FIRST turn of every fresh session ran the composition entry default
+  (`deepseek-official/deepseek-v4-flash`) while the `/model` panel showed
+  the saved default from `settings.yaml`: displayed model ≠ served model,
+  and only a `/model` in that chat fixed it. The same staleness also meant
+  a later `/model` `saveSelection` never reached agents created afterwards
+  until a restart. Fix: resolve agent options **lazily at each create/resume**
+  (by then every service is mounted and the live selection is read). The
+  dsh-base comment says it outright: "Settings may supply a saved selection;
+  consumers read it at creation time." Regression tests:
+  `tests/index.spec.ts` (lazy create + later-saveSelection cases) and
+  `tests/integration/real-composition.spec.ts` →
+  "fresh sessions run the saved default model, not the dsh-base entry (#62)".
+
 ## Integration-test traps
 
 - The integration suite shares the real profile (`_dev/dsh-home`). A test

--- a/docs/pitfalls.zh.md
+++ b/docs/pitfalls.zh.md
@@ -229,6 +229,25 @@ harness 沙箱（以及本 checkout 的环境）有一些特定规则：
   中携带它；键入的 `/resume` 从会话列表中查找它），否则被恢复的聊天会
   卡在门禁后面。
 
+## 宿主服务的激活期快照
+
+- 绝不要在插件激活时读取宿主服务的实时值并缓存它。
+  `@deepseek-ai/dsh-base/cordis.patch.yml` 以硬编码的组合入口挂载
+  `agent-default-model`，而 settings 支撑的用户层是在插件可能已经运行
+  **之后**才接入的（挂载顺序竞态）。该表面曾在激活时快照
+  `agentDefaultModel.currentSelection()`，并把它作为静态 `agentOptions`
+  传给每次 create/resume——于是重启后每个新会话的首回合都运行组合入口
+  的兜底模型（`deepseek-official/deepseek-v4-flash`），而 `/model` 面板
+  显示的是 `settings.yaml` 中保存的默认模型：**显示的模型 ≠ 实际服务的
+  模型**，只有在该会话里执行一次 `/model` 才会恢复一致。同样的陈旧性还
+  意味着：之后某个会话 `/model` 触发的 `saveSelection` 在重启前永远到不了
+  后续新建的 agent。修复：在**每次 create/resume 时惰性解析** agent 选项
+  （彼时所有服务均已挂载，读取的是实时选择）。dsh-base 的注释直言：
+  "Settings may supply a saved selection; consumers read it at creation
+  time." 回归测试：`tests/index.spec.ts`（惰性 create + 后续 saveSelection
+  两个用例）与 `tests/integration/real-composition.spec.ts` →
+  "fresh sessions run the saved default model, not the dsh-base entry (#62)"。
+
 ## 集成测试陷阱
 
 - 集成测试套件共享真实 profile（`_dev/dsh-home`）。通过表面写入状态的

--- a/src/index.ts
+++ b/src/index.ts
@@ -476,7 +476,11 @@ export function apply(ctx: Context, config: Config, deps: ApplyDeps = {}): void 
   });
   // Agents need an explicit provider/model; config overrides win, otherwise
   // the deployment default selection applies (the headless-runner pattern).
-  const resolvedAgentOptions = resolveAgentOptions(ctx, config);
+  // Resolved LAZILY per create/resume, never snapshotted once at activation:
+  // at activation the agentDefaultModel settings layer may not be wired into
+  // the service yet (mount-order race → the composition entry default would
+  // leak into every first turn), and a later /model saveSelection must reach
+  // agents created afterwards (both defects reported in #62).
   const agentStore: AgentStore = {
     get: (sessionId) => ctx.get('agents')?.get(sessionId as unknown as SessionId),
     resume: async (sessionId) => {
@@ -484,9 +488,14 @@ export function apply(ctx: Context, config: Config, deps: ApplyDeps = {}): void 
       if (agents === undefined) {
         throw new Error('agents service unavailable; cannot resume a session');
       }
+      const resolved = resolveAgentOptions(ctx, config);
+      logger.debug(
+        `[feishu] agent options resume session=${String(sessionId)} ` +
+          `provider=${resolved?.provider ?? '(none)'} model=${resolved?.model ?? '(none)'}`,
+      );
       const { agent } = await agents.resume({
         resumeSessionId: sessionId as unknown as SessionId,
-        ...(resolvedAgentOptions !== undefined ? { agentOptions: resolvedAgentOptions } : {}),
+        ...(resolved !== undefined ? { agentOptions: resolved } : {}),
       });
       return agent;
     },
@@ -495,10 +504,15 @@ export function apply(ctx: Context, config: Config, deps: ApplyDeps = {}): void 
       if (agents === undefined) {
         throw new Error('agents service unavailable; cannot create a session');
       }
+      const resolved = resolveAgentOptions(ctx, config);
+      logger.debug(
+        `[feishu] agent options create session=${String(sessionId)} ` +
+          `provider=${resolved?.provider ?? '(none)'} model=${resolved?.model ?? '(none)'}`,
+      );
       const { agent } = await agents.create({
         sessionId: sessionId as unknown as SessionId,
         meta: { cwd },
-        ...(resolvedAgentOptions !== undefined ? { agentOptions: resolvedAgentOptions } : {}),
+        ...(resolved !== undefined ? { agentOptions: resolved } : {}),
       });
       // Attach the new session to the workspace owning `cwd` (dsh web parity),
       // creating the workspace record when the directory is not yet
@@ -704,6 +718,14 @@ function promoteAmbientApiKey(ctx: Context, config: Config): void {
  * requests without both, so the resolved options carry whichever of the two
  * is known (a partial config with no default service fails loud at turn
  * time).
+ *
+ * MUST be called lazily at each agent create/resume, never once at plugin
+ * activation: the caller's activation may run before the
+ * `agentDefaultModel` settings user layer is wired (mount-order race), so an
+ * early snapshot captures the composition entry instead of the saved
+ * selection — the first turn of every fresh session runs the wrong model
+ * (#62). Lazy resolution also means a later `/model` `saveSelection` reaches
+ * agents created afterwards without a restart.
  * @param ctx - plugin context.
  * @param config - validated plugin config.
  * @returns agent options to pass on create/resume, or `undefined` when

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -97,6 +97,9 @@ function makeFakeContext(
     credentials?: { resolve: () => Promise<unknown>; set: () => unknown };
     agents?: unknown;
     workspaceRegistry?: unknown;
+    agentDefaultModel?: {
+      currentSelection: () => { provider: string; model: string } | undefined;
+    };
   } = {},
 ): {
   ctx: Context;
@@ -123,6 +126,7 @@ function makeFakeContext(
     if (service === 'credentials') return options.credentials;
     if (service === 'agents') return options.agents;
     if (service === 'workspaceRegistry') return options.workspaceRegistry;
+    if (service === 'agentDefaultModel') return options.agentDefaultModel;
     return undefined;
   };
   const on = vi.fn(() => () => {});
@@ -314,9 +318,16 @@ describe('apply', () => {
     const attachSession = vi.fn(async () => {});
     const workspaceCreate = vi.fn(async () => ({ attachSession }));
     const followup = vi.fn();
-    const create = vi.fn(async ({ sessionId }: { sessionId: string }) => ({
-      agent: { id: sessionId, followup },
-    }));
+    const create = vi.fn(
+      async ({
+        sessionId,
+      }: {
+        sessionId: string;
+        agentOptions?: { provider?: string; model?: string };
+      }) => ({
+        agent: { id: sessionId, followup },
+      }),
+    );
     const agents = {
       get: () => undefined,
       resume: vi.fn(async () => {
@@ -354,6 +365,154 @@ describe('apply', () => {
     expect(workspaceCreate).toHaveBeenCalledWith(process.cwd(), expect.any(String));
     // And the freshly minted `feishu-…` session id was attached to it.
     expect(attachSession).toHaveBeenCalledWith(expect.stringMatching(/^feishu-/));
+  });
+
+  it('resolves agent options lazily at create — a post-activation default is used (#62)', async () => {
+    process.env.FEISHU_APP_ID = 'env_app';
+    process.env.FEISHU_APP_SECRET = 'env_secret';
+    process.env.DSH_HOME = mkdtempSync(`${tmpdir()}/dsh-feishu-`);
+    // The agentDefaultModel service starts on the dsh-base composition entry
+    // (deepseek) and only rewires to the settings-backed selection AFTER the
+    // plugin activates (mount-order race). A lazy create-time resolve must read
+    // the saved default; the old activation-time snapshot captured the entry.
+    const currentSelection = vi.fn(() => ({
+      provider: 'deepseek-official',
+      model: 'deepseek-v4-flash',
+    }));
+    const create = vi.fn(
+      async ({
+        sessionId,
+      }: {
+        sessionId: string;
+        agentOptions?: { provider?: string; model?: string };
+      }) => ({
+        agent: { id: sessionId, followup: vi.fn() },
+      }),
+    );
+    const agents = {
+      get: () => undefined,
+      resume: vi.fn(async () => {
+        throw new Error('not found');
+      }),
+      create,
+    };
+    const { ctx } = makeFakeContext({ agents, agentDefaultModel: { currentSelection } });
+    const transport = new FakeTransport();
+    apply(ctx, { requireWorkingDir: false }, { createTransport: () => transport });
+    // The settings layer lands after activation: the saved default is live now.
+    currentSelection.mockReturnValue({ provider: 'zai-coding-cn', model: 'glm-5.3' });
+    transport.emitMessage({
+      messageId: 'om_race_1',
+      chatId: 'oc_race_1',
+      chatType: 'p2p',
+      senderOpenId: 'ou_1',
+      text: 'hi',
+      mentions: [],
+      attachments: [],
+      createdAt: 1_700_000_000_000,
+    });
+    await vi.waitFor(() => expect(create).toHaveBeenCalled());
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentOptions: { provider: 'zai-coding-cn', model: 'glm-5.3' },
+      }),
+    );
+  });
+
+  it('picks up a later default-model change for subsequently created sessions (#62)', async () => {
+    process.env.FEISHU_APP_ID = 'env_app';
+    process.env.FEISHU_APP_SECRET = 'env_secret';
+    process.env.DSH_HOME = mkdtempSync(`${tmpdir()}/dsh-feishu-`);
+    const currentSelection = vi.fn(() => ({ provider: 'p-a', model: 'm-a' }));
+    const create = vi.fn(
+      async ({
+        sessionId,
+      }: {
+        sessionId: string;
+        agentOptions?: { provider?: string; model?: string };
+      }) => ({
+        agent: { id: sessionId, followup: vi.fn() },
+      }),
+    );
+    const agents = {
+      get: () => undefined,
+      resume: vi.fn(async () => {
+        throw new Error('not found');
+      }),
+      create,
+    };
+    const { ctx } = makeFakeContext({ agents, agentDefaultModel: { currentSelection } });
+    const transport = new FakeTransport();
+    apply(ctx, { requireWorkingDir: false }, { createTransport: () => transport });
+    const emit = (messageId: string, chatId: string) =>
+      transport.emitMessage({
+        messageId,
+        chatId,
+        chatType: 'p2p',
+        senderOpenId: 'ou_1',
+        text: 'hi',
+        mentions: [],
+        attachments: [],
+        createdAt: 1_700_000_000_000,
+      });
+    emit('om_a_1', 'oc_a_1');
+    await vi.waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+    // A /model in any chat saves a new default (saveSelection rewires the
+    // service's source): the next created session must see it without a
+    // restart, not a stale activation-time snapshot.
+    currentSelection.mockReturnValue({ provider: 'p-b', model: 'm-b' });
+    emit('om_b_1', 'oc_b_1');
+    await vi.waitFor(() => expect(create).toHaveBeenCalledTimes(2));
+    const calls = create.mock.calls.map(([opts]) => opts.agentOptions);
+    expect(calls[0]).toEqual({ provider: 'p-a', model: 'm-a' });
+    expect(calls[1]).toEqual({ provider: 'p-b', model: 'm-b' });
+  });
+
+  it('prefers config provider/model over the deployment default', async () => {
+    process.env.FEISHU_APP_ID = 'env_app';
+    process.env.FEISHU_APP_SECRET = 'env_secret';
+    process.env.DSH_HOME = mkdtempSync(`${tmpdir()}/dsh-feishu-`);
+    const currentSelection = vi.fn(() => ({ provider: 'saved-p', model: 'saved-m' }));
+    const create = vi.fn(
+      async ({
+        sessionId,
+      }: {
+        sessionId: string;
+        agentOptions?: { provider?: string; model?: string };
+      }) => ({
+        agent: { id: sessionId, followup: vi.fn() },
+      }),
+    );
+    const agents = {
+      get: () => undefined,
+      resume: vi.fn(async () => {
+        throw new Error('not found');
+      }),
+      create,
+    };
+    const { ctx } = makeFakeContext({ agents, agentDefaultModel: { currentSelection } });
+    const transport = new FakeTransport();
+    apply(
+      ctx,
+      { requireWorkingDir: false, provider: 'cfg-p', model: 'cfg-m' },
+      { createTransport: () => transport },
+    );
+    transport.emitMessage({
+      messageId: 'om_cfg_1',
+      chatId: 'oc_cfg_1',
+      chatType: 'p2p',
+      senderOpenId: 'ou_1',
+      text: 'hi',
+      mentions: [],
+      attachments: [],
+      createdAt: 1_700_000_000_000,
+    });
+    await vi.waitFor(() => expect(create).toHaveBeenCalled());
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentOptions: { provider: 'cfg-p', model: 'cfg-m' },
+      }),
+    );
   });
 
   it('registers the feishu-status command when the commands service exists', () => {

--- a/tests/integration/mock-llm-server.ts
+++ b/tests/integration/mock-llm-server.ts
@@ -47,6 +47,13 @@ export interface MockLlmServer {
    */
   lastRequestBody(): unknown;
   /**
+   * Every parsed /chat/completions request body, in arrival order. Lets a
+   * test assert that ANY request matched a shape (e.g. that the agent's
+   * requests carried the saved default model, not just the last one — a
+   * title-generation completion can interleave with the turn's requests).
+   */
+  requestBodies(): unknown[];
+  /**
    * Serve one scripted response per completion request, in order. The agent
    * loop issues a new completion request after each tool result, so a
    * tool-calling turn needs two entries (tool call, then final answer).
@@ -100,6 +107,7 @@ function sseToolCallDelta(index: number, id: string, name: string, argumentsDelt
 export async function startMockLlmServer(): Promise<MockLlmServer> {
   let completions = 0;
   let lastBody: unknown;
+  const bodies: unknown[] = [];
   let scripts: readonly (readonly MockScriptChunk[])[] | undefined;
   let hold = false;
   let releaseHold: (() => void) | undefined;
@@ -167,7 +175,9 @@ export async function startMockLlmServer(): Promise<MockLlmServer> {
       req.on('data', (chunk: Buffer) => bodyChunks.push(chunk));
       req.on('end', () => {
         try {
-          lastBody = JSON.parse(Buffer.concat(bodyChunks).toString('utf8'));
+          const body = JSON.parse(Buffer.concat(bodyChunks).toString('utf8'));
+          lastBody = body;
+          bodies.push(body);
         } catch {
           lastBody = undefined;
         }
@@ -232,6 +242,7 @@ export async function startMockLlmServer(): Promise<MockLlmServer> {
       }),
     completionRequests: () => completions,
     lastRequestBody: () => lastBody,
+    requestBodies: () => bodies.slice(),
     setScripts: (next) => {
       scripts = next;
     },

--- a/tests/integration/real-composition.spec.ts
+++ b/tests/integration/real-composition.spec.ts
@@ -20,6 +20,7 @@ import { spawn, spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { dump, load } from 'js-yaml';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { MemoryOutboxRecord } from '../../src/memory-transport.js';
 import { type MockLlmServer, startMockLlmServer } from './mock-llm-server.js';
@@ -214,6 +215,29 @@ function sendMessage(chatId: string, text: string): void {
     }),
     'utf8',
   );
+}
+
+/** The shared test home's `settings.yaml` (the dsh-base settings document). */
+const SETTINGS_PATH = join(DSH_HOME, 'settings.yaml');
+
+/** Write the `agent-default-model` section into the shared settings file
+ *  BEFORE a dsh process boots, preserving any other sections. Returns the
+ *  exact prior file content (or `undefined` when the file did not exist) so
+ *  the caller can restore it in `finally` — the integration suites share the
+ *  real profile (AGENTS.md: "Test-side state is part of the test"). */
+function writeSavedDefaultModel(provider: string, model: string): string | undefined {
+  const previous = existsSync(SETTINGS_PATH) ? readFileSync(SETTINGS_PATH, 'utf8') : undefined;
+  const doc = previous === undefined ? {} : (load(previous) as Record<string, unknown>);
+  doc['agent-default-model'] = { provider, model };
+  writeFileSync(SETTINGS_PATH, dump(doc), 'utf8');
+  return previous;
+}
+
+/** Restore the shared settings file to its exact prior content (or remove it
+ *  when it did not exist before the test). */
+function restoreSettings(previous: string | undefined): void {
+  if (previous === undefined) rmSync(SETTINGS_PATH, { force: true });
+  else writeFileSync(SETTINGS_PATH, previous, 'utf8');
 }
 
 describe.skipIf(!integrationReady)('real-composition integration', () => {
@@ -1863,6 +1887,74 @@ describe.skipIf(!integrationReady)('real-composition integration', () => {
       );
     }
   }, 120_000);
+
+  /** Issue #62: after a process restart, a NEW session's first turn must run
+   *  the SAVED `agent-default-model` from settings.yaml — the same model the
+   *  /model panel displays — never the dsh-base composition entry. The plugin
+   *  used to snapshot `agentDefaultModel.currentSelection()` once at
+   *  activation (before the settings user layer is wired), so every fresh
+   *  session's first request carried the entry default until a /model ran. */
+  it('fresh sessions run the saved default model, not the dsh-base entry (#62)', async () => {
+    const bin = dshBin;
+    const server = mock;
+    if (bin === undefined) throw new Error('dsh CLI unavailable');
+    if (server === undefined) throw new Error('mock LLM server unavailable');
+    // A saved default that differs from the composition entry
+    // (`deepseek-v4-flash`); deepseek-official keeps the adapter routing to
+    // the mock, only the model id differs.
+    const previous = writeSavedDefaultModel('deepseek-official', 'deepseek-v4-pro');
+    try {
+      child = spawn(bin, ['--profile', 'feishu-dev'], {
+        env: {
+          ...process.env,
+          DSH_HOME,
+          FEISHU_APP_ID: 'cli_mock_app',
+          FEISHU_APP_SECRET: 'mock_secret',
+          FEISHU_TRANSPORT: 'memory',
+          FEISHU_MEMORY_DIR: MEMORY_DIR,
+          DEEPSEEK_API_KEY: 'mock_key',
+          DEEPSEEK_BASE_URL: server.url,
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      child.stdout?.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString();
+        if (stdout.includes('[feishu] bridge ready')) bridgeReady = true;
+      });
+      child.stderr?.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+      await waitFor('the bridge to report ready', () => bridgeReady, 30_000);
+
+      const chatId = `oc_default_${Date.now()}`;
+      await pinWorkingDir(chatId);
+      sendMessage(chatId, 'run with the saved default model');
+      await waitFor(
+        'the green final card patch',
+        () => readOutbox().some((r) => r.kind === 'patch' && r.card?.header?.template === 'green'),
+        90_000,
+      );
+      // Every completion this agent issues — the turn's request(s) and the
+      // new-session title generation — must carry the SAVED model, never the
+      // dsh-base entry default. Assert on ANY request, not just the last:
+      // request ordering vs the title-generation completion is not stable.
+      expect(server.completionRequests()).toBeGreaterThanOrEqual(1);
+      const models = server
+        .requestBodies()
+        .map((body) => (body as { model?: unknown }).model)
+        .filter((model): model is string => typeof model === 'string');
+      expect(models.length).toBeGreaterThanOrEqual(1);
+      expect(models.every((model) => model === 'deepseek-v4-pro')).toBe(true);
+    } catch (error) {
+      throw new Error(
+        `${String(error)}\n--- dsh stderr ---\n${stderr}\n--- dsh stdout ---\n${stdout}`,
+      );
+    } finally {
+      // Restore the shared test home's settings (AGENTS.md: test-side state
+      // is part of the test).
+      restoreSettings(previous);
+    }
+  }, 150_000);
 
   /** The working-directory gate on the real process: a fresh chat refuses
    *  turns with guidance until /cd pins a directory (user requirement: DSH


### PR DESCRIPTION
Fixes #62

## What

- `src/index.ts`: resolve agent `provider`/`model` options **lazily at each create/resume** instead of snapshotting `agentDefaultModel.currentSelection()` once at plugin activation; add a `FEISHU_DEBUG` trace line per create/resume carrying the resolved provider/model and the session id.
- `tests/index.spec.ts`: three new unit tests — a post-activation default is used at create (the mount-order race), a later `/model` `saveSelection` reaches subsequently created sessions, and config overrides still win.
- `tests/integration/real-composition.spec.ts` + `tests/integration/mock-llm-server.ts`: regression test that writes a non-entry saved default into the profile's `settings.yaml` before boot and asserts the fresh session's first requests carry it (the mock server now records every request body).

## Why

Issue #62: after a process restart, the first turn of every new session ran the dsh-base composition-entry default (`deepseek-official/deepseek-v4-flash`) while the `/model` panel showed the saved default from `settings.yaml` — displayed model ≠ served model, and only a `/model` in that chat fixed it. Root cause: the plugin read `agentDefaultModel.currentSelection()` once at activation, before the service's settings user layer is wired in (mount-order race), and passed that static snapshot as `agentOptions` on every create/resume. Secondary defect: a later `/model` `saveSelection` never reached agents created afterwards until a restart. dsh-base's own comment states the intended contract: "Settings may supply a saved selection; consumers read it at creation time."

## Docs

- `docs/architecture.md` / `.zh.md`: the `src/index.ts` row now notes lazy per-create/resume resolution.
- `docs/pitfalls.md` / `.zh.md`: new section "Activation-time snapshots of host services" documenting the race, the fix, and the regression tests.
- No README changes (maintainer-gated).

## Verification

- `pnpm run verify` passes locally (convention checks + lint + typecheck + build + test with `FEISHU_INT_REQUIRED=1`, exit codes checked): 41 files / 718 tests green.
- The two new unit tests fail against the pre-fix code (verified via stash-revert) and pass with the fix.
- The new integration test fails against the pre-fix build (the request carries `deepseek-v4-flash` instead of the saved `deepseek-v4-pro`) and passes with the fix.
- Full real-composition suite (38 tests) plus every other integration suite pass with `FEISHU_INT_REQUIRED=1`.
