### PR TITLE
chore: release v0.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The Feishu UI for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-har
 > - the `main` branch (installed from git) tracks **dsh `@next`** — currently
 >   **`0.1.2-rc.1`**;
 > - the npm `@latest` release tracks **dsh `@latest`** — currently
->   **`0.1.1-rc.2`**.
+>   **`0.1.2-rc.1`**.
 
 https://github.com/user-attachments/assets/e9163793-52f2-4e2c-a08a-22b27372be61
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 > 目前仍是预发布版本（`0.1.0-rc.x`），版本之间可能有破坏性变更。dsh-feishu
 > 跟踪**两个** dsh 版本：
 > - `main` 分支（git 安装）跟踪 **dsh `@next`**——当前为 **`0.1.2-rc.1`**；
-> - npm `@latest` release 跟踪 **dsh `@latest`**——当前为 **`0.1.1-rc.2`**。
+> - npm `@latest` release 跟踪 **dsh `@latest`**——当前为 **`0.1.2-rc.1`**。
 
 https://github.com/user-attachments/assets/e9163793-52f2-4e2c-a08a-22b27372be61
 

--- a/dsh-version.json
+++ b/dsh-version.json
@@ -5,7 +5,7 @@
     "next": "0.1.2-rc.1"
   },
   "dshFeishu": {
-    "npmLatest": "0.3.1"
+    "npmLatest": "0.3.2"
   },
   "lastAdapted": {
     "track": "stable",

--- a/dsh-version.json
+++ b/dsh-version.json
@@ -1,15 +1,15 @@
 {
   "schema": "dsh-feishu-version-track/v1",
   "dsh": {
-    "stable": "0.1.1-rc.2",
+    "stable": "0.1.2-rc.1",
     "next": "0.1.2-rc.1"
   },
   "dshFeishu": {
     "npmLatest": "0.3.1"
   },
   "lastAdapted": {
-    "track": "bundle",
-    "by": "dsh-version-track (0.1.2-rc.1 adaptation)",
-    "at": "2026-09-05T20:45:00Z"
+    "track": "stable",
+    "by": "dsh-version-track (0.1.2-rc.1 stable release)",
+    "at": "2026-09-05T22:40:00Z"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsh-feishu/dsh-feishu",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "The Feishu UI for DeepSeek Harness (dsh) — a dsh-native plugin: live streaming cards, in-card questions & approvals, one-QR setup.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## What

Merge the v0.3.2 release back to `main`: the `chore: release v0.3.2` version bump plus the version-track refresh (`dsh.stable` → `0.1.2-rc.1`, the stable track now ships verified against it; generated README Notes follow).

## Why

Release branches are cut from frozen `release/*` states; `main` must carry the released version and the refreshed A label so the version-track source of truth stays honest.

## Verification

- Release workflow on tag `v0.3.2`: green (lint / typecheck / build / test with `FEISHU_INT_REQUIRED=1` / npm publish).
- npm `@dsh-feishu/dsh-feishu@0.3.2` published; GitHub Release created (What's Changed curated to the v0.3.1…v0.3.2 range).
- On-device testing of the adapted surface completed before the release.