### PR TITLE
chore(release): publish from a tag on merged main after the release PR

### DIFF
--- a/.dsh/skills/dsh-version-track/SKILL.md
+++ b/.dsh/skills/dsh-version-track/SKILL.md
@@ -84,8 +84,9 @@ For the **B / `main`** track:
 
 For the **A / stable** track: cut a `release/*` branch from a commit adapted to the new dsh
 `@latest`, apply the same adaptation, bump the version, and open a "ready to release" PR.
-The actual `scripts/release.mjs` run (which pushes the branch and the `v*` tag → npm publish)
-is a **human-gated** action — do not trigger it; just prepare the branch and PR.
+The publish itself is a **human-gated** two-step action — do not trigger it: the release PR
+must be reviewed and squash-merged first, and only then is `node scripts/release.mjs tag`
+run on merged `main` to cut the `v*` tag → npm publish (see docs/development.md → "Releasing").
 
 ### 4. Refresh a label (green run, no code change)
 Update only `dsh-version.json`, e.g. set `dsh.next` to the current dsh `@next` / `dsh.stable`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,11 @@
 name: Release
 
 # Publish @dsh-feishu/dsh-feishu to npm and create a GitHub Release.
-# Triggered by a `v*` tag (e.g. v0.1.0). The tag must match the version in
-# package.json (see scripts/release.mjs which bumps, builds, gates, tags).
-# npm publish uses the NPM_TOKEN secret (registry-url + token auth — the
-# same pattern the DeepSeek Harness release workflow uses).
+# Triggered by a `v*` tag (e.g. v0.1.0). The tag must point at a commit on
+# merged `main` and match the version in package.json (see the two-phase
+# scripts/release.mjs: `prepare` opens the release PR, `tag` cuts the tag on
+# merged main). npm publish uses the NPM_TOKEN secret (registry-url + token
+# auth — the same pattern the DeepSeek Harness release workflow uses).
 on:
   push:
     tags: ['v*']
@@ -22,7 +23,19 @@ jobs:
     name: Publish to npm + GitHub Release
     runs-on: ubuntu-latest
     steps:
+      # Full history: the main-ancestry guard below needs both the tag commit
+      # and main to resolve their merge-base.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Guard — the tag must point at merged main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "${{ github.sha }}" origin/main; then
+            echo "::error::Tag ${{ github.ref_name }} does not point at merged main. Releases publish from tags cut on merged main (scripts/release.mjs tag) — see docs/development.md → Publishing."
+            exit 1
+          fi
 
       - uses: pnpm/action-setup@v4
         with:

--- a/docs/development.md
+++ b/docs/development.md
@@ -435,10 +435,22 @@ workflow" for the end-to-end practice.
 
 ## Publishing
 
-Releases are **tag-driven from a frozen `release/*` branch**, never from
-`main` — main is a development branch and may carry unreleased work (e.g.
-the next dsh compat pass), so a release must be cut from the exact commit
-that should ship.
+A release is a **reviewed release PR that merges first, then a tag cut on
+merged `main`** — never a direct tag push from a side branch. The version
+bump itself is always prepared on a frozen `release/vX.Y.Z` branch cut from
+the exact commit that should ship (main is a development branch and may
+carry unreleased work, e.g. the next dsh compat pass), but it lands through
+the same PR review as everything else, and the publish is triggered only
+after that PR has merged.
+
+The ordering is not cosmetic. GitHub's generated release notes
+(`--generate-notes`) resolve their "What's Changed" baseline from the
+PREVIOUS tag reachable in the new tag's history. A tag cut on a release
+branch that is later squash-merged never becomes an ancestor of later
+commits, so the next release silently falls back to an ancient tag and lists
+months of unrelated PRs. Tags cut on merged `main` keep every tag an
+ancestor of the next, and the Release workflow refuses tags that are not on
+main (`release.yml` → "Guard").
 
 ### Version tracks
 
@@ -472,16 +484,50 @@ publish stay human-gated).
 
 ### Releasing
 
+The release driver (`scripts/release.mjs`) has two phases — run them in
+order:
+
+**Phase 1 — prepare the release PR** (on a fresh `release/vX.Y.Z` branch):
+
 ```sh
-git checkout -b release/vX.Y.Z <commit>   # cut from the exact commit to ship
-node scripts/release.mjs <major|minor|patch>
+git checkout -b release/vX.Y.Z <commit>      # cut from the exact commit to ship
+node scripts/release.mjs prepare <major|minor|patch>
 ```
 
-`scripts/release.mjs` refuses to run outside a `release/*` branch, bumps
-`package.json`, runs the CI gates (through `scripts/run-gates.mjs` — direct
-binaries, no pnpm store dependency), commits `chore: release vX.Y.Z`, then
-pushes **the release branch and the `v*` tag** to origin. The
-[Release workflow](../.github/workflows/release.yml) then publishes to npm
-(`NODE_AUTH_TOKEN` — the same registry-token pattern the DeepSeek Harness
-release workflow uses) and creates a GitHub Release. Before the first
-public release, rotate the Feishu app secret (see `SECURITY.md`).
+`prepare` bumps `package.json`, runs the CI gates (through
+`scripts/run-gates.mjs` — direct binaries, no pnpm store dependency) and the
+real-client E2E acceptance (`--skip-e2e` exists as an explicit escape hatch
+for when the E2E environment cannot be provisioned — never the default),
+commits `chore: release vX.Y.Z`, pushes the branch, and opens the release PR
+against `main` (`gh pr create` when `gh` is installed, else it prints the
+compare URL). **No tag, no publish happens in this phase.**
+
+**Phase 2 — review, merge, tag** (after the release PR merges):
+
+```sh
+git checkout main && git pull
+node scripts/release.mjs tag
+```
+
+`tag` verifies main is clean and up to date with `origin/main`, refuses a
+tag that already exists, cuts `vX.Y.Z` at merged main's HEAD (the version
+comes from `package.json`), and pushes it. The
+[Release workflow](../.github/workflows/release.yml) then re-runs the gates,
+publishes to npm (`NODE_AUTH_TOKEN` — the same registry-token pattern the
+DeepSeek Harness release workflow uses) and creates the GitHub Release with
+generated notes. The workflow's "Guard" step fails any tag that does not
+point at merged main, so an accidental side-branch tag cannot ship.
+
+After the workflow goes green:
+
+1. verify the Actions run and the npm dist-tag;
+2. bump `dshFeishu.npmLatest` in `dsh-version.json` on main (a one-line
+   `chore:` commit) — it records a published fact, so it follows the publish;
+3. skim the release's What's Changed — with the ancestry intact it lists
+   exactly the PRs since the previous tag; if you ever must tag off main
+   for a hotfix from a release branch instead, regenerate the notes with an
+   explicit baseline (`POST /repos/…/releases/generate-notes` with
+   `previous_tag_name`) and patch the release body.
+
+Before the first public release, rotate the Feishu app secret (see
+`SECURITY.md`).

--- a/docs/development.zh.md
+++ b/docs/development.zh.md
@@ -297,9 +297,18 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
 
 ## 发布
 
-发布由 **冻结的 `release/*` 分支上的 tag** 驱动，**绝不在 `main` 上发**——
-main 是开发分支，可能带着未发布的工作（如下一轮 dsh 适配），所以发布必须
-从"恰好要发布的那个 commit"切出分支进行。
+一次发布 = **先合并一个经过 review 的 release PR，然后在合并后的 `main` 上
+打 tag**——绝不从侧分支直接推 tag。版本号的更新本身仍然在从"恰好要发布的
+那个 commit"切出的冻结 `release/vX.Y.Z` 分支上准备（main 是开发分支，可能
+带着未发布的工作，如下一轮 dsh 适配），但它和其它改动一样走 PR review 落
+到 main；发布只在 PR 合并之后由 tag 触发。
+
+这个顺序不是形式主义。GitHub 生成的 release notes（`--generate-notes`）以
+"新 tag 历史中可达的上一个 tag"为基线。如果 tag 打在稍后被 squash merge 的
+release 分支上，它永远不会成为后续提交的祖先，于是下一次发布就会静默回退到
+很老的 tag，列出几个月无关的 PR。打在合并后 main 上的 tag 保证相邻 tag 的
+祖先链完整；Release workflow 还会拒绝不在 main 上的 tag（`release.yml` 的
+"Guard" 步骤）。
 
 ### 版本轨道
 
@@ -321,16 +330,43 @@ latest release → dsh `@latest`），两条轨道分别验证：
 
 ### 发版步骤
 
+发版驱动脚本（`scripts/release.mjs`)分两个阶段，按顺序执行：
+
+**阶段 1 —— 准备 release PR**（在新的 `release/vX.Y.Z` 分支上）：
+
 ```sh
 git checkout -b release/vX.Y.Z <commit>   # 从要发布的那个 commit 切出
-node scripts/release.mjs <major|minor|patch>
+node scripts/release.mjs prepare <major|minor|patch>
 ```
 
-`scripts/release.mjs` 拒绝在非 `release/*` 分支上运行；它会更新
-`package.json`、运行 CI 门禁（通过 `scripts/run-gates.mjs`——直接调二进制，
-不依赖 pnpm store）、提交 `chore: release vX.Y.Z`，然后**把 release 分支和
-`v*` tag 一起推**到 origin。随后
-[Release workflow](../.github/workflows/release.yml) 发布到 npm
-（`NODE_AUTH_TOKEN`，沿用 DeepSeek Harness 发布 workflow 的 registry-token
-认证）并创建 GitHub Release。首次公开发布前，轮换飞书 app secret（见
-`SECURITY.md`）。
+`prepare` 会更新 `package.json`、运行 CI 门禁（通过
+`scripts/run-gates.mjs`——直接调二进制，不依赖 pnpm store）和真机 E2E
+验收（`--skip-e2e` 是给 E2E 环境确实无法准备时用的显式逃生门——绝非默认），
+提交 `chore: release vX.Y.Z`，推送分支，并向 `main` 发起 release PR（装了
+`gh` 就直接创建，否则打印 compare URL）。**本阶段不打 tag、不发布。**
+
+**阶段 2 —— review、合并、打 tag**（release PR 合并之后）：
+
+```sh
+git checkout main && git pull
+node scripts/release.mjs tag
+```
+
+`tag` 校验 main 干净且与 `origin/main` 一致、拒绝已存在的 tag，在合并后
+main 的 HEAD 上打 `vX.Y.Z`（版本号取自 `package.json`）并推送。
+[Release workflow](../.github/workflows/release.yml) 随之重跑门禁、发布到
+npm（`NODE_AUTH_TOKEN`，沿用 DeepSeek Harness 发布 workflow 的
+registry-token 认证）并创建带生成 notes 的 GitHub Release。workflow 的
+"Guard" 步骤会拒绝不指向合并后 main 的 tag，误推的侧分支 tag 无法发布。
+
+workflow 变绿之后：
+
+1. 核对 Actions 运行与 npm dist-tag；
+2. 在 main 上把 `dsh-version.json` 的 `dshFeishu.npmLatest` 更新为该版本
+   （一行 `chore:` 提交）——它记录的是已发布的事实，跟着发布走；
+3. 过一眼 release 的 What's Changed——祖先链完整时它恰好列出上一个 tag
+   以来的 PR；万一必须从 release 分支打热修 tag，用显式基线重新生成 notes
+   （`POST /repos/…/releases/generate-notes` 带 `previous_tag_name`）并修正
+   release body。
+
+首次公开发布前，轮换飞书 app secret（见 `SECURITY.md`）。

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -166,10 +166,11 @@ FEISHU_DEBUG=1           # the plugin's own debug tracing (visible now that
 No chat name is needed: every case creates its own group chat
 (`<caseId>-<runId>`) through the backend and opens it.
 
-The suite doubles as the **release acceptance gate**: `scripts/release.mjs`
-runs `e2e:ui` before tagging and refuses to release when the environment is
-not prepared (run `e2e:setup` once per machine first) or the run fails —
-see `docs/development.md` → "Releasing".
+The suite doubles as the **release acceptance gate**: the `prepare` phase of
+`scripts/release.mjs` runs `e2e:ui` before the release PR opens and refuses
+to prepare the release when the environment is not prepared (run
+`e2e:setup` once per machine first) or the run fails — see
+`docs/development.md` → "Releasing".
 
 ## Report
 

--- a/docs/e2e-testing.zh.md
+++ b/docs/e2e-testing.zh.md
@@ -106,9 +106,10 @@ FEISHU_DEBUG=1           # 插件自身 debug 追踪（dsh 子进程日志现在
 
 不需要聊天名：每个用例自己通过后台创建群聊（`<caseId>-<runId>`）并打开它。
 
-这套套件同时充当**发版验收门禁**：`scripts/release.mjs` 会在打 tag 前运行
-`e2e:ui`，环境未准备（先在本机跑一次 `e2e:setup`）或运行失败时拒绝发版——见
-`docs/development.md` → "发版步骤"。
+这套套件同时充当**发版验收门禁**：`scripts/release.mjs` 的 `prepare` 阶段
+会在 release PR 发起前运行 `e2e:ui`，环境未准备（先在本机跑一次
+`e2e:setup`）或运行失败时拒绝准备发版——见 `docs/development.zh.md` →
+"发版步骤"。
 
 ## 报告
 

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,121 +1,217 @@
 #!/usr/bin/env node
 /**
- * Release driver for dsh-feishu: bump the version, verify the gates, tag,
- * and push BOTH the release branch and the tag so the Release workflow
- * publishes.
+ * Release driver for dsh-feishu, in two phases:
  *
- * Usage:
- *   node scripts/release.mjs <major|minor|patch>   # e.g. node scripts/release.mjs patch
- *   node scripts/release.mjs --dry-run <bump>      # print what would happen
- *   node scripts/release.mjs --skip-e2e <bump>     # skip the E2E acceptance
- *                                                  # (explicit escape hatch only)
+ *   1. `node scripts/release.mjs prepare <major|minor|patch>`
+ *      Run on a freshly cut `release/vX.Y.Z` branch: bump `package.json`,
+ *      run the gates, commit `chore: release vX.Y.Z`, push the branch, and
+ *      open the release PR against `main` (via `gh` when available, else
+ *      print the compare URL). NO tag, NO publish — the release content is
+ *      reviewed like any other change.
  *
- * Releases happen ONLY from a `release/*` branch (e.g. release/v0.2.1):
- * main is a development branch and may carry unreleased work, so a release
- * must be cut from a frozen release branch cut off the intended commit.
- * The script refuses to run on main or a feature branch. It pushes the
- * release branch AND the `v*` tag to origin — the actual npm publish +
- * GitHub Release run from the tag via .github/workflows/release.yml
- * (NPM_TOKEN secret).
+ *   2. `node scripts/release.mjs tag`
+ *      Run on an up-to-date, clean `main` AFTER the release PR is
+ *      squash-merged: create the `v<version>` tag at HEAD (the version comes
+ *      from `package.json` on merged main) and push it. The tag push
+ *      triggers the Release workflow, which re-runs the gates, publishes to
+ *      npm and creates the GitHub Release.
+ *
+ * WHY tag on `main` instead of the release branch: GitHub's generated
+ * release notes (`--generate-notes`) resolve their "What's Changed" baseline
+ * from the PREVIOUS tag reachable in the new tag's history. A tag cut on a
+ * release branch that is later squash-merged never becomes an ancestor of
+ * later commits, so every subsequent release silently falls back to an
+ * ancient tag and lists months of unrelated PRs (the v0.2.x–v0.3.1 defect).
+ * Tags cut on merged main keep the ancestry chain intact; the Release
+ * workflow additionally refuses tags that are not on main.
+ *
+ * Releases are PREPARED only from a `release/*` branch — main is a
+ * development branch and may carry unreleased work (e.g. the next dsh compat
+ * pass), so the version bump must be cut from the exact commit that should
+ * ship. Phase 2 runs on `main` because the tag must point at the merged,
+ * reviewed state.
  *
  * Gates run through the local binaries (node scripts/run-gates.mjs) rather
  * than `pnpm run` so the script works in constrained shells where pnpm's
- * store check cannot open its SQLite database. After the gates, the
- * real-client E2E suite runs as a release acceptance step (see
+ * store check cannot open its SQLite database. Phase 1 also runs the
+ * real-client E2E suite as a release acceptance step (see
  * docs/e2e-testing.md); the environment must be prepared once with
  * `pnpm run e2e:setup`.
+ *
+ * Usage:
+ *   node scripts/release.mjs prepare <major|minor|patch>   # phase 1
+ *   node scripts/release.mjs prepare --dry-run <bump>      # print what would happen
+ *   node scripts/release.mjs prepare --skip-e2e <bump>     # skip the E2E acceptance
+ *                                                          # (explicit escape hatch only)
+ *   node scripts/release.mjs tag                           # phase 2 (after the PR merges)
+ *   node scripts/release.mjs tag --dry-run
  */
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const [, , ...args] = process.argv;
-const dryRun = args.includes('--dry-run');
-const bump = args.find((arg) => arg === 'major' || arg === 'minor' || arg === 'patch');
+const [, , phase, ...rest] = process.argv;
+const dryRun = rest.includes('--dry-run');
+const skipE2E = rest.includes('--skip-e2e');
+const bump = rest.find((arg) => arg === 'major' || arg === 'minor' || arg === 'patch');
 
-if (bump === undefined) {
-  console.error('usage: node scripts/release.mjs [--dry-run] <major|minor|patch>');
+if (phase !== 'prepare' && phase !== 'tag') {
+  console.error(
+    'usage: node scripts/release.mjs prepare <major|minor|patch>\n' +
+      '       node scripts/release.mjs tag',
+  );
+  process.exit(1);
+}
+if (phase === 'prepare' && bump === undefined) {
+  console.error('usage: node scripts/release.mjs prepare <major|minor|patch>');
   process.exit(1);
 }
 
 const repoRoot = fileURLToPath(new URL('..', import.meta.url));
 
-function run(command, extra) {
+function run(command) {
   if (dryRun) {
     console.log(`[dry-run] would run: ${command}`);
     return;
   }
-  execFileSync(command, extra ?? [], { cwd: repoRoot, stdio: 'inherit', shell: true });
+  execFileSync(command, { cwd: repoRoot, stdio: 'inherit', shell: true });
 }
 
-// Releases are cut from a frozen `release/*` branch, never from main (which
-// is a development branch and may hold unreleased work).
-const branch = execFileSync('git', ['branch', '--show-current'], { encoding: 'utf8' }).trim();
-if (!branch.startsWith('release/')) {
-  console.error(
-    `refusing to release from branch "${branch}" — cut a release branch first:\n` +
-      `  git checkout -b release/vX.Y.Z <commit>`,
-  );
-  process.exit(1);
-}
-console.log(`releasing from branch ${branch}`);
-
-const pkgPath = 'package.json';
-const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
-const [major, minor, patch] = pkg.version.split('.').map(Number);
-const next =
-  bump === 'major'
-    ? `${major + 1}.0.0`
-    : bump === 'minor'
-      ? `${major}.${minor + 1}.0`
-      : `${major}.${minor}.${patch + 1}`;
-
-console.log(`dsh-feishu ${pkg.version} -> ${next}`);
-if (!dryRun) {
-  pkg.version = next;
-  writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+function git(args) {
+  return execFileSync('git', args, { cwd: repoRoot, encoding: 'utf8' }).trim();
 }
 
-// Gates exactly as CI runs them, via the local gate runner (direct binaries,
-// no pnpm store dependency — see the header comment).
-run('node scripts/run-gates.mjs');
+const branch = git(['branch', '--show-current']);
+const version = JSON.parse(readFileSync('package.json', 'utf8')).version;
 
-// Real-client E2E acceptance before every release: the unit/integration
-// gates mock the Feishu wire, so the release must also verify the real
-// long connection + browser client locally (see docs/e2e-testing.md).
-// The environment is prepared once with `pnpm run e2e:setup` (QR scans);
-// afterwards `e2e:ui` is hands-free and idempotent. Failing the E2E run
-// aborts the release. `--skip-e2e` is an explicit escape hatch for cases
-// where the E2E environment cannot be provisioned (e.g. no test account
-// access) — never the default.
-const skipE2E = args.includes('--skip-e2e');
-if (!skipE2E) {
-  const { existsSync } = await import('node:fs');
-  const stateDir = join(repoRoot, 'e2e', '.state');
-  const e2eReady =
-    existsSync(join(stateDir, 'creds.json')) &&
-    existsSync(join(stateDir, 'web-session.json')) &&
-    existsSync(join(stateDir, 'user.json'));
-  if (!e2eReady) {
+if (phase === 'prepare') {
+  // ── Phase 1: bump, gate, commit, push, open the release PR ──────────────
+  if (!branch.startsWith('release/')) {
     console.error(
-      '\n✗ E2E environment is not ready (missing creds.json / web-session.json / user.json in e2e/.state/).\n' +
-        '  Run `pnpm run e2e:setup` once (QR scans with the test account), then re-run the release.\n' +
-        '  Use `--skip-e2e` only if the E2E environment cannot be provisioned.',
+      `refusing to prepare a release from branch "${branch}" — cut a release branch first:\n` +
+        `  git checkout -b release/v${version} main`,
     );
     process.exit(1);
   }
-  console.log('\n── E2E acceptance (real feishu.cn web client) ──');
-  run('pnpm run e2e:ui');
+  console.log(`preparing the release on branch ${branch}`);
+
+  const pkgPath = 'package.json';
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+  const [major, minor, patch] = pkg.version.split('.').map(Number);
+  const next =
+    bump === 'major'
+      ? `${major + 1}.0.0`
+      : bump === 'minor'
+        ? `${major}.${minor + 1}.0`
+        : `${major}.${minor}.${patch + 1}`;
+
+  console.log(`dsh-feishu ${pkg.version} -> ${next}`);
+  if (!dryRun) {
+    pkg.version = next;
+    writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+  }
+
+  // Gates exactly as CI runs them, via the local gate runner (direct binaries,
+  // no pnpm store dependency — see the header comment).
+  run('node scripts/run-gates.mjs');
+
+  // Real-client E2E acceptance before every release: the unit/integration
+  // gates mock the Feishu wire, so the release must also verify the real
+  // long connection + browser client locally (see docs/e2e-testing.md).
+  // Failing the E2E run aborts the release. `--skip-e2e` is an explicit
+  // escape hatch for cases where the E2E environment cannot be provisioned
+  // (e.g. no test account access) — never the default.
+  if (!skipE2E) {
+    const { existsSync } = await import('node:fs');
+    const { join } = await import('node:path');
+    const stateDir = join(repoRoot, 'e2e', '.state');
+    const e2eReady =
+      existsSync(join(stateDir, 'creds.json')) &&
+      existsSync(join(stateDir, 'web-session.json')) &&
+      existsSync(join(stateDir, 'user.json'));
+    if (!e2eReady) {
+      console.error(
+        '\n✗ E2E environment is not ready (missing creds.json / web-session.json / user.json in e2e/.state/).\n' +
+          '  Run `pnpm run e2e:setup` once (QR scans with the test account), then re-run the release.\n' +
+          '  Use `--skip-e2e` only if the E2E environment cannot be provisioned.',
+      );
+      process.exit(1);
+    }
+    console.log('\n── E2E acceptance (real feishu.cn web client) ──');
+    run('pnpm run e2e:ui');
+  }
+
+  run(`git add package.json pnpm-lock.yaml`);
+  run(`git commit -m "chore: release v${next}"`);
+  run(`git push -u origin ${branch}`);
+
+  const title = `chore: release v${next}`;
+  const body =
+    '## What\n' +
+    `Bump the package version to \`${next}\` for the \`v${next}\` release.\n\n` +
+    '## Why\n' +
+    'Version bumps land on `main` through a reviewed release PR; the `v' +
+    next +
+    '` tag is cut on merged `main` afterwards (see docs/development.md → Publishing).\n\n' +
+    '## Verification\n' +
+    '- `node scripts/release.mjs prepare ' + bump + '` ran the full gate matrix locally.';
+  if (dryRun) {
+    console.log(`[dry-run] would open the release PR "${title}" against main`);
+  } else if (execFileSync('bash', ['-lc', 'command -v gh || true'], { encoding: 'utf8' }).trim()) {
+    run(
+      `gh pr create --base main --head ${branch} --title "${title}" --body ${JSON.stringify(body)}`,
+    );
+  } else {
+    console.log(
+      `\n` +
+        '`gh` is not installed — open the release PR manually:\n' +
+        `  https://github.com/PGZXB/dsh-feishu/compare/main...${branch}`,
+    );
+  }
+  console.log(
+    `\nnext: review and squash-merge the release PR, then run\n` +
+      `  node scripts/release.mjs tag\n` +
+      `on updated main to cut the v${next} tag and trigger the publish.`,
+  );
+} else {
+  // ── Phase 2: tag merged main, triggering the publish ────────────────────
+  if (branch !== 'main') {
+    console.error(
+      `refusing to tag from branch "${branch}" — phase 2 runs on main, after the release PR merges.`,
+    );
+    process.exit(1);
+  }
+  if (!dryRun && git(['status', '--porcelain']) !== '') {
+    console.error('main has uncommitted changes — commit or stash them first.');
+    process.exit(1);
+  }
+  run('git fetch origin --tags');
+  const remoteMain = git(['rev-parse', 'origin/main']);
+  const head = git(['rev-parse', 'HEAD']);
+  if (head !== remoteMain) {
+    console.error(
+      `local main (${head.slice(0, 8)}) is behind/ahead of origin/main (${remoteMain.slice(0, 8)}) — pull first.`,
+    );
+    process.exit(1);
+  }
+  const tag = `v${version}`;
+  const existing = execFileSync('git', ['ls-remote', '--tags', 'origin', `refs/tags/${tag}`], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  }).trim();
+  if (existing) {
+    console.error(`tag ${tag} already exists on origin — bump the version with a new release PR.`);
+    process.exit(1);
+  }
+  console.log(`tagging ${head.slice(0, 8)} (merged main) as ${tag} and pushing the tag`);
+  run(`git tag ${tag}`);
+  run(`git push origin ${tag}`);
+  console.log(
+    `\ntag ${tag} pushed — the Release workflow publishes to npm and creates the GitHub Release.\n` +
+      `after the workflow goes green:\n` +
+      `  1. verify https://github.com/PGZXB/dsh-feishu/actions and the npm dist-tag;\n` +
+      `  2. bump \`dshFeishu.npmLatest\` to ${version} in dsh-version.json on main (one-line commit);\n` +
+      `  3. skim the release's What's Changed — it must list exactly the PRs since the previous tag.`,
+  );
 }
-
-// Tag and push BOTH the release branch and the tag; the release workflow
-// publishes from the tag.
-run(`git add package.json pnpm-lock.yaml`);
-run(`git commit -m "chore: release v${next}"`);
-run(`git tag v${next}`);
-run(`git push -u origin ${branch}`);
-run(`git push origin v${next}`);
-
-console.log(`\npushed branch ${branch} and tag v${next} — the Release workflow (NPM_TOKEN) publishes to npm and creates the GitHub Release.`);


### PR DESCRIPTION
## What

Two changes to the release process:

1. **`scripts/release.mjs` becomes two-phase.**
   - `prepare <major|minor|patch>` (on a `release/vX.Y.Z` branch): bump version, run the gates + E2E acceptance, commit `chore: release vX.Y.Z`, push the branch, open the release PR against `main`. **No tag, no publish.**
   - `tag` (on merged, up-to-date `main`): cut the `v<version>` tag at HEAD and push it — this is what triggers the Release workflow.
2. **`release.yml` gains a Guard step**: it fails any tag that does not point at a commit on merged `main` (with `fetch-depth: 0` so the merge-base resolves).

Plus the release runbook rewritten in `docs/development.md` / `docs/development.zh.md`, the e2e acceptance wording, and the version-track skill.

## Why

The old one-shot driver pushed the release branch **and** the `v*` tag from a side branch. Since the release branch is later squash-merged, the tag commit never becomes an ancestor of later commits — so GitHub's `--generate-notes` fell back to an ancient baseline and most release pages (v0.2.x–v0.3.1) listed months of unrelated PRs. A direct tag push also published to npm without any PR review of the release content.

Cutting the tag on merged `main` keeps every tag an ancestor of the next (notes baselines stay correct forever), puts the release content through PR review like every other change, and makes the publish a deliberate second step instead of a side effect of a push.

All 8 existing releases' notes have been regenerated with explicit correct baselines via the `releases/generate-notes` API (separate one-off API operation, no repo change needed).

## Verification

- `node --check scripts/release.mjs`; dry-runs: `tag` refuses non-main branches (exit 1), `prepare` runs bump → gates → E2E check → commit → push → PR.
- `release.yml` parses (yaml.safe_load) and the Guard logic is plain `git merge-base --is-ancestor`.
- `node scripts/check-conventions.mjs`: all green on the committed tree.
- Docs updated in both languages (development / e2e-testing pairs) + the version-track skill's release step.
